### PR TITLE
Lark image support: memory-only, turn-scoped, vision-aware

### DIFF
--- a/src/agent/compaction.ts
+++ b/src/agent/compaction.ts
@@ -833,7 +833,25 @@ function serializeMessageForSummary(message: Message): string {
 
 function serializeUserMessage(message: Message): string {
   const payload = parsePayload<AgentUserPayload>(message.payloadJson);
-  return typeof payload.content === "string" ? `[User]: ${payload.content}` : "";
+  if (typeof payload.content !== "string") {
+    return "";
+  }
+
+  const imageCount = Array.isArray(payload.images) ? payload.images.length : 0;
+  if (imageCount > 0) {
+    logger.debug("serializing user message with image placeholders for compaction", {
+      storageMessageId: message.id,
+      imageCount,
+      images: payload.images?.map((image) => ({
+        id: image.id,
+        messageId: image.messageId,
+        mimeType: image.mimeType,
+      })),
+    });
+  }
+  return imageCount > 0
+    ? `[User]: ${payload.content}\n[Attached images: ${imageCount}]`
+    : `[User]: ${payload.content}`;
 }
 
 function serializeAssistantMessage(message: Message): string {

--- a/src/agent/llm/messages.ts
+++ b/src/agent/llm/messages.ts
@@ -11,6 +11,7 @@ import type {
   Usage,
   UserMessage,
 } from "@mariozechner/pi-ai";
+import { createSubsystemLogger } from "@/src/shared/logger.js";
 import type { Message } from "@/src/storage/schema/types.js";
 
 export type AgentAssistantContentBlock =
@@ -55,18 +56,40 @@ export interface AgentToolResultPayload {
   details?: unknown;
 }
 
+const logger = createSubsystemLogger("llm-messages");
+
+export interface AgentUserImagePayload {
+  type: "image";
+  id: string;
+  messageId: string;
+  mimeType: string;
+}
+
+export interface AgentUserRuntimeImagePayload extends AgentUserImagePayload {
+  data: string;
+}
+
 export interface AgentUserPayload {
   content: string;
+  images?: AgentUserImagePayload[];
 }
 
-export function buildPiMessages(messages: Message[]): PiMessage[] {
-  return messages.map((message) => buildPiMessage(message));
+export interface BuildPiMessageOptions {
+  supportsVision?: boolean;
+  resolveRuntimeImages?: (
+    message: Message,
+    images: AgentUserImagePayload[],
+  ) => AgentUserRuntimeImagePayload[];
 }
 
-export function buildPiMessage(message: Message): PiMessage {
+export function buildPiMessages(messages: Message[], options?: BuildPiMessageOptions): PiMessage[] {
+  return messages.map((message) => buildPiMessage(message, options));
+}
+
+export function buildPiMessage(message: Message, options?: BuildPiMessageOptions): PiMessage {
   switch (message.role) {
     case "user":
-      return buildPiUserMessage(message);
+      return buildPiUserMessage(message, options);
     case "assistant":
       return buildPiAssistantMessage(message);
     case "tool":
@@ -76,17 +99,148 @@ export function buildPiMessage(message: Message): PiMessage {
   }
 }
 
-function buildPiUserMessage(message: Message): UserMessage {
+function buildPiUserMessage(message: Message, options?: BuildPiMessageOptions): UserMessage {
   const payload = parsePayload<AgentUserPayload>(message.payloadJson, message.id);
   if (typeof payload.content !== "string") {
     throw new Error(`Stored user message ${message.id} is missing string payload.content`);
   }
 
+  const parsedImages = parseUserImages(payload.images);
+  const supportsVision = options?.supportsVision ?? true;
+  const runtimeImages =
+    options?.resolveRuntimeImages?.(message, parsedImages.images) ??
+    parsedImages.inlineRuntimeImages;
+
+  logger.debug("building pi user message", {
+    storageMessageId: message.id,
+    persistedImageCount: parsedImages.images.length,
+    persistedImageIds: parsedImages.images.map((image) => image.id),
+    inlineRuntimeImageCount: parsedImages.inlineRuntimeImages.length,
+    resolvedRuntimeImageCount: runtimeImages.length,
+    resolvedRuntimeImages: runtimeImages.map((image) => ({
+      id: image.id,
+      messageId: image.messageId,
+      mimeType: image.mimeType,
+      base64Length: image.data.length,
+    })),
+    supportsVision,
+  });
+
   return {
     role: "user",
-    content: payload.content,
+    content: buildPiUserContent({
+      content: payload.content,
+      images: parsedImages.images,
+      runtimeImages,
+      supportsVision,
+    }),
     timestamp: parseMessageTimestamp(message),
   };
+}
+
+function parseUserImages(images: unknown): {
+  images: AgentUserImagePayload[];
+  inlineRuntimeImages: AgentUserRuntimeImagePayload[];
+} {
+  if (!Array.isArray(images)) {
+    return { images: [], inlineRuntimeImages: [] };
+  }
+
+  const parsedImages: AgentUserImagePayload[] = [];
+  const inlineRuntimeImages: AgentUserRuntimeImagePayload[] = [];
+  for (const image of images) {
+    if (image?.type !== "image" || typeof image.id !== "string" || image.id.length === 0) {
+      continue;
+    }
+    const messageId =
+      typeof image.messageId === "string" && image.messageId.length > 0
+        ? image.messageId
+        : image.id;
+    if (typeof image.mimeType !== "string" || image.mimeType.length === 0) {
+      continue;
+    }
+    parsedImages.push({
+      type: "image",
+      id: image.id,
+      messageId,
+      mimeType: image.mimeType,
+    });
+    if (typeof image.data === "string" && image.data.length > 0) {
+      inlineRuntimeImages.push({
+        type: "image",
+        id: image.id,
+        messageId,
+        data: image.data,
+        mimeType: image.mimeType,
+      });
+    }
+  }
+
+  return {
+    images: parsedImages,
+    inlineRuntimeImages,
+  };
+}
+
+function buildPiUserContent(input: {
+  content: string;
+  images: AgentUserImagePayload[];
+  runtimeImages: AgentUserRuntimeImagePayload[];
+  supportsVision: boolean;
+}): UserMessage["content"] {
+  if (input.images.length === 0) {
+    logger.debug("building pi user content without images", {
+      supportsVision: input.supportsVision,
+    });
+    return input.content;
+  }
+
+  if (input.supportsVision && input.runtimeImages.length > 0) {
+    logger.info("building pi user content with vision image blocks", {
+      supportsVision: input.supportsVision,
+      persistedImageCount: input.images.length,
+      runtimeImageCount: input.runtimeImages.length,
+      imageIds: input.images.map((image) => image.id),
+    });
+    return [
+      { type: "text", text: input.content },
+      ...input.runtimeImages.map((image) => ({
+        type: "image" as const,
+        data: image.data,
+        mimeType: image.mimeType,
+      })),
+    ];
+  }
+
+  if (!input.supportsVision) {
+    logger.debug("building pi user content with unsupported-vision notice", {
+      supportsVision: input.supportsVision,
+      persistedImageCount: input.images.length,
+      runtimeImageCount: input.runtimeImages.length,
+      imageIds: input.images.map((image) => image.id),
+    });
+    return appendUnsupportedVisionNotice(input.content, input.images);
+  }
+
+  logger.debug("building pi user content with image metadata only", {
+    supportsVision: input.supportsVision,
+    persistedImageCount: input.images.length,
+    runtimeImageCount: input.runtimeImages.length,
+    imageIds: input.images.map((image) => image.id),
+  });
+  return input.content;
+}
+
+function appendUnsupportedVisionNotice(content: string, images: AgentUserImagePayload[]): string {
+  const lines = [content.trimEnd()];
+  lines.push(
+    `[Note: The user attached ${images.length} image${images.length === 1 ? "" : "s"} (image IDs: ${images
+      .map((image) => image.id)
+      .join(
+        ", ",
+      )}), but the current model is not configured for vision, so the image content is not available to you.]`,
+  );
+  return lines.filter((line) => line.length > 0).join("\n");
 }
 
 function buildPiAssistantMessage(message: Message): AssistantMessage {

--- a/src/agent/llm/messages.ts
+++ b/src/agent/llm/messages.ts
@@ -74,6 +74,10 @@ export interface AgentUserPayload {
   images?: AgentUserImagePayload[];
 }
 
+export function normalizeAgentUserImageMessageId(imageId: string, messageId: unknown): string {
+  return typeof messageId === "string" && messageId.length > 0 ? messageId : imageId;
+}
+
 export interface BuildPiMessageOptions {
   supportsVision?: boolean;
   resolveRuntimeImages?: (
@@ -121,7 +125,7 @@ function buildPiUserMessage(message: Message, options?: BuildPiMessageOptions): 
       id: image.id,
       messageId: image.messageId,
       mimeType: image.mimeType,
-      base64Length: image.data.length,
+      byteLength: Buffer.from(image.data, "base64").length,
     })),
     supportsVision,
   });
@@ -152,10 +156,7 @@ function parseUserImages(images: unknown): {
     if (image?.type !== "image" || typeof image.id !== "string" || image.id.length === 0) {
       continue;
     }
-    const messageId =
-      typeof image.messageId === "string" && image.messageId.length > 0
-        ? image.messageId
-        : image.id;
+    const messageId = normalizeAgentUserImageMessageId(image.id, image.messageId);
     if (typeof image.mimeType !== "string" || image.mimeType.length === 0) {
       continue;
     }

--- a/src/agent/llm/pi-bridge.ts
+++ b/src/agent/llm/pi-bridge.ts
@@ -57,6 +57,7 @@ export interface PiBridgeRunTurnInput {
   systemPrompt?: string;
   compactSummary: string | null;
   messages: Message[];
+  resolveRuntimeImages?: AgentModelTurnInput["resolveRuntimeImages"];
   tools: ToolRegistry;
   sessionPurpose?: string;
   agentKind?: string | null;
@@ -92,7 +93,12 @@ export class PiBridge {
       : null;
     const context = {
       ...(input.systemPrompt == null ? {} : { systemPrompt: input.systemPrompt }),
-      messages: buildPiContextMessages(input.compactSummary, input.messages),
+      messages: buildPiContextMessages(
+        input.compactSummary,
+        input.messages,
+        input.model.supportsVision,
+        input.resolveRuntimeImages,
+      ),
     };
     if (tools != null) {
       Object.assign(context, { tools });
@@ -104,6 +110,8 @@ export class PiBridge {
       messageCount: input.messages.length,
       tools: tools?.length ?? 0,
       hasCompactSummary: input.compactSummary != null && input.compactSummary.trim().length > 0,
+      hasResolveRuntimeImages: input.resolveRuntimeImages != null,
+      supportsVision: input.model.supportsVision,
     });
 
     try {
@@ -162,7 +170,12 @@ export class PiBridge {
       : null;
     const context = {
       ...(input.systemPrompt == null ? {} : { systemPrompt: input.systemPrompt }),
-      messages: buildPiContextMessages(input.compactSummary, input.messages),
+      messages: buildPiContextMessages(
+        input.compactSummary,
+        input.messages,
+        input.model.supportsVision,
+        input.resolveRuntimeImages,
+      ),
     };
     if (tools != null) {
       Object.assign(context, { tools });
@@ -272,6 +285,9 @@ export class PiAgentModelRunner implements AgentModelRunner, CompactionModelRunn
       ...(input.systemPrompt == null ? {} : { systemPrompt: input.systemPrompt }),
       compactSummary: input.compactSummary,
       messages: input.messages,
+      ...(input.resolveRuntimeImages == null
+        ? {}
+        : { resolveRuntimeImages: input.resolveRuntimeImages }),
       ...(input.sessionPurpose == null ? {} : { sessionPurpose: input.sessionPurpose }),
       ...(input.agentKind === undefined ? {} : { agentKind: input.agentKind }),
       tools: this.tools,
@@ -286,8 +302,31 @@ export class PiAgentModelRunner implements AgentModelRunner, CompactionModelRunn
   }
 }
 
-function buildPiContextMessages(compactSummary: string | null, messages: Message[]) {
-  const piMessages = buildPiMessages(messages);
+function buildPiContextMessages(
+  compactSummary: string | null,
+  messages: Message[],
+  supportsVision: boolean,
+  resolveRuntimeImages?: AgentModelTurnInput["resolveRuntimeImages"],
+) {
+  logger.debug("building pi context messages", {
+    storedMessageCount: messages.length,
+    supportsVision,
+    hasCompactSummary: compactSummary != null && compactSummary.trim().length > 0,
+    hasResolveRuntimeImagesCallback: resolveRuntimeImages != null,
+  });
+  const piMessages = buildPiMessages(messages, {
+    supportsVision,
+    ...(resolveRuntimeImages == null
+      ? {}
+      : { resolveRuntimeImages: (message, _images) => resolveRuntimeImages(message) }),
+  });
+  logger.debug("built pi context messages", {
+    storedMessageCount: messages.length,
+    piMessageCount: piMessages.length,
+    supportsVision,
+    hasCompactSummary: compactSummary != null && compactSummary.trim().length > 0,
+    hasResolveRuntimeImagesCallback: resolveRuntimeImages != null,
+  });
   if (compactSummary == null || compactSummary.trim().length === 0) {
     return piMessages;
   }

--- a/src/agent/llm/pi-bridge.ts
+++ b/src/agent/llm/pi-bridge.ts
@@ -308,12 +308,6 @@ function buildPiContextMessages(
   supportsVision: boolean,
   resolveRuntimeImages?: AgentModelTurnInput["resolveRuntimeImages"],
 ) {
-  logger.debug("building pi context messages", {
-    storedMessageCount: messages.length,
-    supportsVision,
-    hasCompactSummary: compactSummary != null && compactSummary.trim().length > 0,
-    hasResolveRuntimeImagesCallback: resolveRuntimeImages != null,
-  });
   const piMessages = buildPiMessages(messages, {
     supportsVision,
     ...(resolveRuntimeImages == null

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -28,6 +28,7 @@ import type {
   AgentAssistantPayload,
   AgentToolResultPayload,
   AgentUserPayload,
+  AgentUserRuntimeImagePayload,
 } from "@/src/agent/llm/messages.js";
 import type { ModelScenario, ResolvedModel } from "@/src/agent/llm/models.js";
 import type { ProviderRegistry } from "@/src/agent/llm/provider-registry.js";
@@ -123,6 +124,7 @@ export interface AgentModelTurnInput {
   systemPrompt?: string;
   compactSummary: string | null;
   messages: Message[];
+  resolveRuntimeImages?: (message: Message) => AgentUserRuntimeImagePayload[];
   signal: AbortSignal;
   onTextDelta?: (delta: { delta: string; accumulatedText: string }) => void;
   onThinkingDelta?: (delta: { delta: string }) => void;
@@ -135,6 +137,7 @@ export interface AgentModelRunner {
 export interface RunAgentLoopInput {
   sessionId: string;
   scenario: ModelScenario;
+  initialRuntimeImagesByMessageId?: Record<string, AgentUserRuntimeImagePayload[]>;
   maxTurns?: number;
   afterToolResultHook?: AgentLoopAfterToolResultHook;
 }
@@ -312,6 +315,8 @@ export class AgentLoop {
   enqueueSteerInput(input: {
     sessionId: string;
     content: string;
+    userPayload?: AgentUserPayload;
+    runtimeImages?: AgentUserRuntimeImagePayload[];
     messageType?: string;
     visibility?: string;
     channelMessageId?: string | null;
@@ -372,6 +377,29 @@ export class AgentLoop {
     const handle = this.deps.cancel.begin(input.sessionId);
     const maxTurns = input.maxTurns ?? this.defaultMaxTurns;
     let context = this.deps.sessions.getContext(input.sessionId);
+    const runtimeImagesByMessageId = new Map<string, AgentUserRuntimeImagePayload[]>(
+      Object.entries(input.initialRuntimeImagesByMessageId ?? {}),
+    );
+    const activeTurnImageMessageIds = new Set(
+      Object.keys(input.initialRuntimeImagesByMessageId ?? {}),
+    );
+    logger.debug("initialized run runtime image state", {
+      sessionId: input.sessionId,
+      initialImageMessageIds: [...activeTurnImageMessageIds],
+      initialRuntimeImageCount: [...runtimeImagesByMessageId.values()].reduce(
+        (sum, images) => sum + images.length,
+        0,
+      ),
+      initialRuntimeImages: [...runtimeImagesByMessageId.entries()].flatMap(([messageId, images]) =>
+        images.map((image) => ({
+          storageMessageId: messageId,
+          id: image.id,
+          messageId: image.messageId,
+          mimeType: image.mimeType,
+          base64Length: image.data.length,
+        })),
+      ),
+    });
     const model = this.deps.models.getRequiredScenarioModel(input.scenario);
     assertSessionModelSupportsTools({
       sessionPurpose: context.session.purpose,
@@ -525,6 +553,26 @@ export class AgentLoop {
               systemPrompt,
               compactSummary: context.compactSummary,
               messages,
+              resolveRuntimeImages: (message) => {
+                const mapped = runtimeImagesByMessageId.get(message.id) ?? [];
+                logger.debug("resolved runtime images for model turn message", {
+                  sessionId: input.sessionId,
+                  runId,
+                  storageMessageId: message.id,
+                  activeTurnHasMessageId: activeTurnImageMessageIds.has(message.id),
+                  runtimeImageMapHasMessageId: runtimeImagesByMessageId.has(message.id),
+                  resolvedImageCount: mapped.length,
+                  activeTurnImageMessageIds: [...activeTurnImageMessageIds],
+                  availableRuntimeImageMessageIds: [...runtimeImagesByMessageId.keys()],
+                  images: mapped.map((image) => ({
+                    id: image.id,
+                    messageId: image.messageId,
+                    mimeType: image.mimeType,
+                    base64Length: image.data.length,
+                  })),
+                });
+                return mapped;
+              },
               signal: handle.signal,
               onTextDelta: (event) => {
                 sawStreamedText = true;
@@ -802,12 +850,19 @@ export class AgentLoop {
               count: queuedSteer.length,
               latest: truncateLogText(queuedSteer.at(-1)?.content ?? "", 48),
             });
-            nextSeq = this.appendQueuedSteerMessages({
+            const queuedMessages = this.appendQueuedSteerMessages({
               queuedSteer,
               sessionId: input.sessionId,
               nextSeq,
               messages,
               appendedMessageIds,
+              runtimeImagesByMessageId,
+            });
+            nextSeq = queuedMessages.nextSeq;
+            replaceActiveTurnRuntimeImages({
+              activeTurnImageMessageIds,
+              runtimeImagesByMessageId,
+              nextMessageIds: queuedMessages.messageIds,
             });
           }
 
@@ -1001,12 +1056,19 @@ export class AgentLoop {
             latest: truncateLogText(queuedSteer.at(-1)?.content ?? "", 48),
             tail: summarizeTranscriptTail(messages),
           });
-          nextSeq = this.appendQueuedSteerMessages({
+          const queuedMessages = this.appendQueuedSteerMessages({
             queuedSteer,
             sessionId: input.sessionId,
             nextSeq,
             messages,
             appendedMessageIds,
+            runtimeImagesByMessageId,
+          });
+          nextSeq = queuedMessages.nextSeq;
+          replaceActiveTurnRuntimeImages({
+            activeTurnImageMessageIds,
+            runtimeImagesByMessageId,
+            nextMessageIds: queuedMessages.messageIds,
           });
         }
 
@@ -1519,8 +1581,10 @@ export class AgentLoop {
     nextSeq: number;
     messages: Message[];
     appendedMessageIds: string[];
-  }): number {
+    runtimeImagesByMessageId: Map<string, AgentUserRuntimeImagePayload[]>;
+  }): { nextSeq: number; messageIds: string[] } {
     let nextSeq = input.nextSeq;
+    const messageIds: string[] = [];
 
     for (const queued of input.queuedSteer) {
       const messageId = randomUUID();
@@ -1530,9 +1594,11 @@ export class AgentLoop {
         messageId,
         seq: nextSeq,
         role: "user",
-        payload: {
-          content: queued.content,
-        } satisfies AgentUserPayload,
+        payload:
+          queued.userPayload ??
+          ({
+            content: queued.content,
+          } satisfies AgentUserPayload),
         messageType: queued.messageType ?? "text",
         visibility: queued.visibility ?? "user_visible",
         channelMessageId: queued.channelMessageId ?? null,
@@ -1540,12 +1606,27 @@ export class AgentLoop {
         channelThreadId: queued.channelThreadId ?? null,
         createdAt: queued.createdAt ?? new Date(),
       });
+      if (queued.runtimeImages && queued.runtimeImages.length > 0) {
+        input.runtimeImagesByMessageId.set(messageId, queued.runtimeImages);
+        logger.debug("attached runtime images to queued steer message", {
+          sessionId: input.sessionId,
+          storageMessageId: messageId,
+          runtimeImageCount: queued.runtimeImages.length,
+          images: queued.runtimeImages.map((image) => ({
+            id: image.id,
+            messageId: image.messageId,
+            mimeType: image.mimeType,
+            base64Length: image.data.length,
+          })),
+        });
+      }
       nextSeq += 1;
+      messageIds.push(messageId);
       input.messages.push(message);
       input.appendedMessageIds.push(messageId);
     }
 
-    return nextSeq;
+    return { nextSeq, messageIds };
   }
 
   private recordEvent(events: AgentRuntimeEvent[], event: AgentRuntimeEventInput): void {
@@ -1558,6 +1639,30 @@ export class AgentLoop {
     events.push(hydrated);
     this.deps.emitEvent?.(hydrated);
   }
+}
+
+function replaceActiveTurnRuntimeImages(input: {
+  activeTurnImageMessageIds: Set<string>;
+  runtimeImagesByMessageId: Map<string, AgentUserRuntimeImagePayload[]>;
+  nextMessageIds: string[];
+}): void {
+  const previousActiveMessageIds = [...input.activeTurnImageMessageIds];
+  for (const messageId of input.activeTurnImageMessageIds) {
+    input.runtimeImagesByMessageId.delete(messageId);
+  }
+  input.activeTurnImageMessageIds.clear();
+  for (const messageId of input.nextMessageIds) {
+    if (!input.runtimeImagesByMessageId.has(messageId)) {
+      continue;
+    }
+    input.activeTurnImageMessageIds.add(messageId);
+  }
+  logger.debug("replaced active turn runtime images", {
+    previousActiveMessageIds,
+    nextMessageIds: input.nextMessageIds,
+    newActiveMessageIds: [...input.activeTurnImageMessageIds],
+    remainingRuntimeImageMessageIds: [...input.runtimeImagesByMessageId.keys()],
+  });
 }
 
 function appendMessageAndHydrate(input: {

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -396,7 +396,7 @@ export class AgentLoop {
           id: image.id,
           messageId: image.messageId,
           mimeType: image.mimeType,
-          base64Length: image.data.length,
+          byteLength: Buffer.from(image.data, "base64").length,
         })),
       ),
     });
@@ -568,7 +568,7 @@ export class AgentLoop {
                     id: image.id,
                     messageId: image.messageId,
                     mimeType: image.mimeType,
-                    base64Length: image.data.length,
+                    byteLength: Buffer.from(image.data, "base64").length,
                   })),
                 });
                 return mapped;
@@ -1616,7 +1616,7 @@ export class AgentLoop {
             id: image.id,
             messageId: image.messageId,
             mimeType: image.mimeType,
-            base64Length: image.data.length,
+            byteLength: Buffer.from(image.data, "base64").length,
           })),
         });
       }

--- a/src/channels/lark/inbound.ts
+++ b/src/channels/lark/inbound.ts
@@ -9,10 +9,11 @@
 import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 import * as Lark from "@larksuiteoapi/node-sdk";
-import type {
-  AgentUserImagePayload,
-  AgentUserPayload,
-  AgentUserRuntimeImagePayload,
+import {
+  type AgentUserImagePayload,
+  type AgentUserPayload,
+  type AgentUserRuntimeImagePayload,
+  normalizeAgentUserImageMessageId,
 } from "@/src/agent/llm/messages.js";
 import type { LarkSdkClient } from "@/src/channels/lark/client.js";
 import type { ConfiguredLarkInstallation } from "@/src/channels/lark/types.js";
@@ -460,7 +461,7 @@ export function createLarkMessageReceiveHandler(input: {
           id: image.id,
           messageId: image.messageId,
           mimeType: image.mimeType,
-          base64Length: image.data.length,
+          byteLength: Buffer.from(image.data, "base64").length,
         })),
         userPayloadImageCount: userPayload?.images?.length ?? 0,
         runtimeImageCount: runtimeImages.length,
@@ -2228,7 +2229,7 @@ function buildLarkInboundUserPayload(input: {
       (image): AgentUserImagePayload => ({
         type: "image",
         id: image.id,
-        messageId: image.messageId,
+        messageId: normalizeAgentUserImageMessageId(image.id, image.messageId),
         mimeType: image.mimeType,
       }),
     ),
@@ -2242,7 +2243,7 @@ function buildLarkInboundRuntimeImages(
     (image): AgentUserRuntimeImagePayload => ({
       type: "image",
       id: image.id,
-      messageId: image.messageId,
+      messageId: normalizeAgentUserImageMessageId(image.id, image.messageId),
       data: image.data,
       mimeType: image.mimeType,
     }),
@@ -2254,7 +2255,7 @@ function buildLarkInboundRuntimeImages(
         id: image.id,
         messageId: image.messageId,
         mimeType: image.mimeType,
-        base64Length: image.data.length,
+        byteLength: Buffer.from(image.data, "base64").length,
       })),
     });
   }
@@ -2303,6 +2304,9 @@ async function fetchLarkInboundImageAssets(input: {
         },
       });
       const buffer = await readLarkResourceBuffer(response.getReadableStream());
+      if (buffer.length === 0) {
+        throw new Error("empty lark inbound image resource");
+      }
       const mimeType = normalizeLarkImageMimeType(response.headers?.["content-type"]);
       const data = buffer.toString("base64");
       assets.push({
@@ -2317,7 +2321,6 @@ async function fetchLarkInboundImageAssets(input: {
         imageKey,
         mimeType,
         byteLength: buffer.length,
-        base64Length: data.length,
       });
     } catch (error) {
       logger.warn("failed to fetch lark inbound image resource", {
@@ -2353,12 +2356,16 @@ function normalizeLarkImageMimeType(value: unknown): string {
     if (normalized?.startsWith("image/")) {
       return normalized;
     }
+    return "image/png";
   }
 
   if (Array.isArray(value)) {
     for (const item of value) {
-      const normalized = normalizeLarkImageMimeType(item);
-      if (normalized !== "image/png") {
+      if (typeof item !== "string") {
+        continue;
+      }
+      const normalized = item.split(";")[0]?.trim().toLowerCase();
+      if (normalized?.startsWith("image/")) {
         return normalized;
       }
     }

--- a/src/channels/lark/inbound.ts
+++ b/src/channels/lark/inbound.ts
@@ -5,8 +5,15 @@
  * translates user actions into runtime ingress/control commands (`submitMessage`,
  * `/status`, `/stop`, approval decisions).
  */
+
+import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 import * as Lark from "@larksuiteoapi/node-sdk";
+import type {
+  AgentUserImagePayload,
+  AgentUserPayload,
+  AgentUserRuntimeImagePayload,
+} from "@/src/agent/llm/messages.js";
 import type { LarkSdkClient } from "@/src/channels/lark/client.js";
 import type { ConfiguredLarkInstallation } from "@/src/channels/lark/types.js";
 import type { ResolveSubagentCreationRequestResult } from "@/src/orchestration/agent-manager.js";
@@ -42,6 +49,8 @@ export interface LarkInboundIngress {
     sessionId: string;
     scenario: "chat" | "cron" | "subagent";
     content: string;
+    userPayload?: AgentUserPayload;
+    runtimeImages?: AgentUserRuntimeImagePayload[];
     channelMessageId?: string | null;
     channelParentMessageId?: string | null;
     channelThreadId?: string | null;
@@ -92,6 +101,8 @@ export interface LarkMessageReceiveEvent {
     sender_id?: {
       open_id?: string;
     };
+    id?: string;
+    id_type?: string;
     sender_type?: string;
   };
   message?: {
@@ -102,6 +113,16 @@ export interface LarkMessageReceiveEvent {
     parent_id?: string;
     message_type?: string;
     create_time?: string;
+    content?: string;
+  };
+  message_id?: string;
+  chat_id?: string;
+  chat_type?: string;
+  thread_id?: string;
+  parent_id?: string;
+  msg_type?: string;
+  create_time?: string;
+  body?: {
     content?: string;
   };
 }
@@ -116,7 +137,15 @@ export interface NormalizedLarkTextMessage {
   senderType: string | null;
   chatType: string | null;
   text: string;
+  imageKeys?: string[];
   createdAt?: Date;
+}
+
+interface LarkInboundImageAsset {
+  id: string;
+  messageId: string;
+  data: string;
+  mimeType: string;
 }
 
 interface LarkQuotedMessage {
@@ -165,53 +194,70 @@ export function normalizeLarkTextMessage(
     return { skipReason: "event payload is not an object" };
   }
 
-  const message = isRecord(data.message) ? data.message : null;
+  const nestedMessage = isRecord(data.message) ? data.message : null;
+  const flatMessage = nestedMessage == null ? data : null;
+  const message = nestedMessage ?? flatMessage;
   if (message == null) {
     return { skipReason: "event payload is missing message" };
   }
 
-  const messageType =
-    typeof message.message_type === "string" && message.message_type.trim().length > 0
-      ? message.message_type.trim()
-      : null;
+  const messageType = readString(nestedMessage?.message_type) ?? readString(flatMessage?.msg_type);
   if (messageType == null) {
     return { skipReason: "message is missing message_type" };
   }
 
-  const chatId = typeof message.chat_id === "string" ? message.chat_id.trim() : "";
+  const chatId = readString(message.chat_id) ?? "";
   if (chatId.length === 0) {
     return { skipReason: "text message is missing chat_id" };
   }
 
-  const messageId = typeof message.message_id === "string" ? message.message_id.trim() : "";
+  const messageId = readString(message.message_id) ?? "";
   if (messageId.length === 0) {
     return { skipReason: "text message is missing message_id" };
   }
 
-  const contentRaw = typeof message.content === "string" ? message.content : "";
+  const contentRaw =
+    readString(nestedMessage?.content) ??
+    readString(isRecord(flatMessage?.body) ? flatMessage.body.content : null) ??
+    "";
   const text = parseLarkMessageContent(messageType, contentRaw);
   if (text.length === 0) {
+    logger.debug("normalized lark message produced empty text", {
+      messageShape: nestedMessage == null ? "raw" : "event",
+      chatId,
+      messageId,
+      messageType,
+      hasBodyContent: contentRaw.length > 0,
+    });
     return { skipReason: "text message content is empty" };
   }
+  const imageKeys = extractLarkImageKeys(messageType, contentRaw);
 
-  const parentMessageId =
-    typeof message.parent_id === "string" && message.parent_id.trim().length > 0
-      ? message.parent_id.trim()
-      : null;
-  const threadId =
-    typeof message.thread_id === "string" && message.thread_id.trim().length > 0
-      ? message.thread_id.trim()
-      : null;
+  const parentMessageId = readString(message.parent_id);
+  const threadId = readString(message.thread_id);
   const sender = isRecord(data.sender) ? data.sender : null;
   const senderId = sender != null && isRecord(sender.sender_id) ? sender.sender_id : null;
   const senderOpenId =
-    senderId != null && typeof senderId.open_id === "string" && senderId.open_id.length > 0
-      ? senderId.open_id
-      : null;
-  const senderType =
-    sender != null && typeof sender.sender_type === "string" ? sender.sender_type : null;
-  const chatType = typeof message.chat_type === "string" ? message.chat_type : null;
+    readString(senderId?.open_id) ??
+    (readString(sender?.id_type) === "open_id" ? readString(sender?.id) : null);
+  const senderType = readString(sender?.sender_type);
+  const chatType = readString(message.chat_type);
   const createdAt = parseLarkMessageCreatedAt(message.create_time);
+
+  logger.debug("normalized lark inbound message", {
+    messageShape: nestedMessage == null ? "raw" : "event",
+    chatId,
+    messageId,
+    messageType,
+    parentMessageId,
+    threadId,
+    senderOpenId,
+    senderType,
+    chatType,
+    imageKeyCount: imageKeys.length,
+    imageKeys,
+    contentPreview: truncateLogText(text, LARK_INBOUND_LOG_PREVIEW_MAX_LENGTH),
+  });
 
   return {
     chatId,
@@ -223,6 +269,7 @@ export function normalizeLarkTextMessage(
     senderType,
     chatType,
     text,
+    ...(imageKeys.length === 0 ? {} : { imageKeys }),
     ...(createdAt == null ? {} : { createdAt }),
   };
 }
@@ -387,12 +434,46 @@ export function createLarkMessageReceiveHandler(input: {
       route.kind === "ordinary_thread"
         ? hydrated.text
         : await buildInboundMessageContent(hydrated, input);
+    const imageAssets =
+      input.clients == null
+        ? []
+        : await fetchLarkInboundImageAssets({
+            installationId: input.installationId,
+            messageId: hydrated.messageId,
+            imageKeys: hydrated.imageKeys ?? [],
+            clients: input.clients,
+          });
+    const userPayload = buildLarkInboundUserPayload({
+      content,
+      imageAssets,
+    });
+    const runtimeImages = buildLarkInboundRuntimeImages(imageAssets);
+
+    if ((hydrated.imageKeys?.length ?? 0) > 0 || runtimeImages.length > 0) {
+      logger.info("prepared lark inbound image payloads", {
+        installationId: input.installationId,
+        chatId: hydrated.chatId,
+        messageId: hydrated.messageId,
+        imageKeyCount: hydrated.imageKeys?.length ?? 0,
+        fetchedImageAssetCount: imageAssets.length,
+        fetchedImageAssets: imageAssets.map((image) => ({
+          id: image.id,
+          messageId: image.messageId,
+          mimeType: image.mimeType,
+          base64Length: image.data.length,
+        })),
+        userPayloadImageCount: userPayload?.images?.length ?? 0,
+        runtimeImageCount: runtimeImages.length,
+      });
+    }
 
     try {
       await input.ingress.submitMessage({
         sessionId: route.sessionId,
         scenario: route.scenario,
         content,
+        ...(userPayload == null ? {} : { userPayload }),
+        ...(runtimeImages.length === 0 ? {} : { runtimeImages }),
         channelMessageId: hydrated.messageId,
         ...(hydrated.parentMessageId == null
           ? {}
@@ -1560,6 +1641,54 @@ async function buildOrdinaryThreadKickoffContent(input: {
   return lines.join("\n");
 }
 
+function extractLarkImageKeys(messageType: string, content: string): string[] {
+  if (content.length === 0) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(content);
+    if (!isRecord(parsed)) {
+      return [];
+    }
+
+    switch (messageType) {
+      case "image": {
+        const imageKey = readString(parsed.image_key);
+        return imageKey == null ? [] : [imageKey];
+      }
+      case "post": {
+        const body = unwrapLarkPostContent(parsed);
+        if (body == null) {
+          return [];
+        }
+
+        const keys: string[] = [];
+        const content = Array.isArray(body.content) ? body.content : [];
+        for (const paragraph of content) {
+          if (!Array.isArray(paragraph)) {
+            continue;
+          }
+          for (const element of paragraph) {
+            if (!isRecord(element) || readString(element.tag) !== "img") {
+              continue;
+            }
+            const imageKey = readString(element.image_key);
+            if (imageKey != null) {
+              keys.push(imageKey);
+            }
+          }
+        }
+        return keys;
+      }
+      default:
+        return [];
+    }
+  } catch {
+    return [];
+  }
+}
+
 function parseLarkMessageContent(messageType: string, content: string): string {
   if (content.length === 0) {
     return "";
@@ -2083,6 +2212,159 @@ export function createLarkQuoteMessageFetcher(input: {
       return null;
     }
   };
+}
+
+function buildLarkInboundUserPayload(input: {
+  content: string;
+  imageAssets: LarkInboundImageAsset[];
+}): AgentUserPayload | null {
+  if (input.imageAssets.length === 0) {
+    return null;
+  }
+
+  return {
+    content: input.content,
+    images: input.imageAssets.map(
+      (image): AgentUserImagePayload => ({
+        type: "image",
+        id: image.id,
+        messageId: image.messageId,
+        mimeType: image.mimeType,
+      }),
+    ),
+  };
+}
+
+function buildLarkInboundRuntimeImages(
+  imageAssets: LarkInboundImageAsset[],
+): AgentUserRuntimeImagePayload[] {
+  const runtimeImages = imageAssets.map(
+    (image): AgentUserRuntimeImagePayload => ({
+      type: "image",
+      id: image.id,
+      messageId: image.messageId,
+      data: image.data,
+      mimeType: image.mimeType,
+    }),
+  );
+  if (runtimeImages.length > 0) {
+    logger.debug("built lark inbound runtime images", {
+      imageCount: runtimeImages.length,
+      images: runtimeImages.map((image) => ({
+        id: image.id,
+        messageId: image.messageId,
+        mimeType: image.mimeType,
+        base64Length: image.data.length,
+      })),
+    });
+  }
+  return runtimeImages;
+}
+
+async function fetchLarkInboundImageAssets(input: {
+  installationId: string;
+  messageId: string;
+  imageKeys: string[];
+  clients: {
+    getOrCreate(installationId: string): LarkSdkClient;
+  };
+}): Promise<LarkInboundImageAsset[]> {
+  if (input.imageKeys.length === 0) {
+    logger.debug("no lark inbound images to fetch", {
+      installationId: input.installationId,
+      messageId: input.messageId,
+    });
+    return [];
+  }
+
+  logger.debug("fetching lark inbound image assets", {
+    installationId: input.installationId,
+    messageId: input.messageId,
+    imageKeyCount: input.imageKeys.length,
+    imageKeys: input.imageKeys,
+  });
+
+  const client = input.clients.getOrCreate(input.installationId);
+  const assets: LarkInboundImageAsset[] = [];
+  for (const imageKey of input.imageKeys) {
+    try {
+      logger.debug("requesting lark inbound image resource", {
+        installationId: input.installationId,
+        messageId: input.messageId,
+        imageKey,
+      });
+      const response = await client.sdk.im.messageResource.get({
+        path: {
+          message_id: input.messageId,
+          file_key: imageKey,
+        },
+        params: {
+          type: "image",
+        },
+      });
+      const buffer = await readLarkResourceBuffer(response.getReadableStream());
+      const mimeType = normalizeLarkImageMimeType(response.headers?.["content-type"]);
+      const data = buffer.toString("base64");
+      assets.push({
+        id: imageKey,
+        messageId: input.messageId,
+        data,
+        mimeType,
+      });
+      logger.debug("fetched lark inbound image resource", {
+        installationId: input.installationId,
+        messageId: input.messageId,
+        imageKey,
+        mimeType,
+        byteLength: buffer.length,
+        base64Length: data.length,
+      });
+    } catch (error) {
+      logger.warn("failed to fetch lark inbound image resource", {
+        installationId: input.installationId,
+        messageId: input.messageId,
+        imageKey,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  logger.debug("finished fetching lark inbound image assets", {
+    installationId: input.installationId,
+    messageId: input.messageId,
+    requestedImageKeyCount: input.imageKeys.length,
+    fetchedAssetCount: assets.length,
+  });
+
+  return assets;
+}
+
+async function readLarkResourceBuffer(stream: NodeJS.ReadableStream): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+function normalizeLarkImageMimeType(value: unknown): string {
+  if (typeof value === "string") {
+    const normalized = value.split(";")[0]?.trim().toLowerCase();
+    if (normalized?.startsWith("image/")) {
+      return normalized;
+    }
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const normalized = normalizeLarkImageMimeType(item);
+      if (normalized !== "image/png") {
+        return normalized;
+      }
+    }
+  }
+
+  return "image/png";
 }
 
 async function fetchQuotedLarkMessage(input: {

--- a/src/runtime/session-lane.ts
+++ b/src/runtime/session-lane.ts
@@ -6,7 +6,11 @@
  * by external coordination if runtime becomes multi-process.
  */
 import { randomUUID } from "node:crypto";
-import type { AgentUserPayload, AgentUserRuntimeImagePayload } from "@/src/agent/llm/messages.js";
+import {
+  type AgentUserPayload,
+  type AgentUserRuntimeImagePayload,
+  normalizeAgentUserImageMessageId,
+} from "@/src/agent/llm/messages.js";
 import type { ModelScenario } from "@/src/agent/llm/models.js";
 import type {
   AgentLoop,
@@ -78,7 +82,7 @@ export class InMemorySessionLane {
         id: image.id,
         messageId: image.messageId,
         mimeType: image.mimeType,
-        base64Length: image.data.length,
+        byteLength: Buffer.from(image.data, "base64").length,
       })),
       channelMessageId: input.channelMessageId ?? null,
       channelParentMessageId: input.channelParentMessageId ?? null,
@@ -198,10 +202,10 @@ function normalizeSubmittedUserPayload(
       return [];
     }
     const runtimeCandidate = image as AgentUserRuntimeImagePayload;
-    const messageId =
-      typeof runtimeCandidate.messageId === "string" && runtimeCandidate.messageId.length > 0
-        ? runtimeCandidate.messageId
-        : runtimeCandidate.id;
+    const messageId = normalizeAgentUserImageMessageId(
+      runtimeCandidate.id,
+      runtimeCandidate.messageId,
+    );
     if (typeof runtimeCandidate.mimeType !== "string" || runtimeCandidate.mimeType.length === 0) {
       return [];
     }
@@ -241,7 +245,7 @@ function normalizeSubmittedUserPayload(
       id: image.id,
       messageId: image.messageId,
       mimeType: image.mimeType,
-      base64Length: image.data.length,
+      byteLength: Buffer.from(image.data, "base64").length,
     })),
   });
 

--- a/src/runtime/session-lane.ts
+++ b/src/runtime/session-lane.ts
@@ -6,6 +6,7 @@
  * by external coordination if runtime becomes multi-process.
  */
 import { randomUUID } from "node:crypto";
+import type { AgentUserPayload, AgentUserRuntimeImagePayload } from "@/src/agent/llm/messages.js";
 import type { ModelScenario } from "@/src/agent/llm/models.js";
 import type {
   AgentLoop,
@@ -26,6 +27,8 @@ export interface SubmitSessionMessageInput {
   sessionId: string;
   scenario: ModelScenario;
   content: string;
+  userPayload?: AgentUserPayload;
+  runtimeImages?: AgentUserRuntimeImagePayload[];
   messageType?: string;
   visibility?: string;
   channelMessageId?: string | null;
@@ -64,10 +67,29 @@ export class InMemorySessionLane {
   // loop's steer queue. Otherwise we append it as a new user message and start
   // the session run immediately.
   async submitMessage(input: SubmitSessionMessageInput): Promise<SubmitSessionMessageResult> {
+    const normalized = normalizeSubmittedUserPayload(input.userPayload, input.runtimeImages);
+    logger.debug("session lane received message", {
+      sessionId: input.sessionId,
+      scenario: input.scenario,
+      hasUserPayload: normalized.userPayload != null,
+      persistedImageCount: normalized.userPayload?.images?.length ?? 0,
+      runtimeImageCount: normalized.runtimeImages?.length ?? 0,
+      runtimeImages: normalized.runtimeImages?.map((image) => ({
+        id: image.id,
+        messageId: image.messageId,
+        mimeType: image.mimeType,
+        base64Length: image.data.length,
+      })),
+      channelMessageId: input.channelMessageId ?? null,
+      channelParentMessageId: input.channelParentMessageId ?? null,
+      channelThreadId: input.channelThreadId ?? null,
+    });
     if (this.activeRun != null) {
       const steered = this.deps.loop.enqueueSteerInput({
         sessionId: input.sessionId,
         content: input.content,
+        ...(normalized.userPayload == null ? {} : { userPayload: normalized.userPayload }),
+        ...(normalized.runtimeImages == null ? {} : { runtimeImages: normalized.runtimeImages }),
         ...(input.messageType == null ? {} : { messageType: input.messageType }),
         ...(input.visibility == null ? {} : { visibility: input.visibility }),
         ...(input.channelMessageId === undefined
@@ -82,9 +104,11 @@ export class InMemorySessionLane {
         ...(input.createdAt == null ? {} : { createdAt: input.createdAt }),
       });
       if (steered) {
-        logger.info("queued inbound message behind active run", {
+        logger.debug("queued inbound message behind active run", {
           sessionId: input.sessionId,
           content: truncateLogValue(input.content),
+          persistedImageCount: normalized.userPayload?.images?.length ?? 0,
+          runtimeImageCount: normalized.runtimeImages?.length ?? 0,
         });
         return {
           status: "steered",
@@ -98,9 +122,11 @@ export class InMemorySessionLane {
       sessionId: input.sessionId,
       seq: this.deps.messages.getNextSeq(input.sessionId),
       role: "user",
-      payloadJson: JSON.stringify({
-        content: input.content,
-      }),
+      payloadJson: JSON.stringify(
+        normalized.userPayload ?? {
+          content: input.content,
+        },
+      ),
       messageType: input.messageType ?? "text",
       visibility: input.visibility ?? "user_visible",
       channelMessageId: input.channelMessageId ?? null,
@@ -113,6 +139,9 @@ export class InMemorySessionLane {
       .run({
         sessionId: input.sessionId,
         scenario: input.scenario,
+        ...(normalized.runtimeImages == null || normalized.runtimeImages.length === 0
+          ? {}
+          : { initialRuntimeImagesByMessageId: { [messageId]: normalized.runtimeImages } }),
         ...(input.maxTurns == null ? {} : { maxTurns: input.maxTurns }),
         ...(input.afterToolResultHook == null
           ? {}
@@ -126,10 +155,13 @@ export class InMemorySessionLane {
       });
 
     this.activeRun = runPromise;
-    logger.info("starting session run", {
+    logger.debug("starting session run", {
       sessionId: input.sessionId,
       messageId,
       scenario: input.scenario,
+      persistedImageCount: normalized.userPayload?.images?.length ?? 0,
+      runtimeImageCount: normalized.runtimeImages?.length ?? 0,
+      runtimeImageMessageIds: normalized.runtimeImages?.map((image) => image.messageId) ?? [],
     });
 
     return {
@@ -142,6 +174,84 @@ export class InMemorySessionLane {
   submitApprovalDecision(input: ApprovalResponseInput): boolean {
     return this.deps.loop.submitApprovalResponse(input);
   }
+}
+
+function normalizeSubmittedUserPayload(
+  userPayload: AgentUserPayload | undefined,
+  runtimeImages: AgentUserRuntimeImagePayload[] | undefined,
+): {
+  userPayload: AgentUserPayload | undefined;
+  runtimeImages: AgentUserRuntimeImagePayload[] | undefined;
+} {
+  if (userPayload == null || !Array.isArray(userPayload.images)) {
+    logger.debug("normalizeSubmittedUserPayload bypassed image normalization", {
+      hasUserPayload: userPayload != null,
+      runtimeImageCount: runtimeImages?.length ?? 0,
+    });
+    return { userPayload, runtimeImages };
+  }
+
+  const existingRuntimeImages = runtimeImages ?? [];
+  const extractedRuntimeImages: AgentUserRuntimeImagePayload[] = [];
+  const normalizedImages = userPayload.images.flatMap((image) => {
+    if (image?.type !== "image" || typeof image.id !== "string" || image.id.length === 0) {
+      return [];
+    }
+    const runtimeCandidate = image as AgentUserRuntimeImagePayload;
+    const messageId =
+      typeof runtimeCandidate.messageId === "string" && runtimeCandidate.messageId.length > 0
+        ? runtimeCandidate.messageId
+        : runtimeCandidate.id;
+    if (typeof runtimeCandidate.mimeType !== "string" || runtimeCandidate.mimeType.length === 0) {
+      return [];
+    }
+    if (typeof runtimeCandidate.data === "string" && runtimeCandidate.data.length > 0) {
+      extractedRuntimeImages.push({
+        type: "image",
+        id: runtimeCandidate.id,
+        messageId,
+        data: runtimeCandidate.data,
+        mimeType: runtimeCandidate.mimeType,
+      });
+    }
+    return [
+      {
+        type: "image" as const,
+        id: runtimeCandidate.id,
+        messageId,
+        mimeType: runtimeCandidate.mimeType,
+      },
+    ];
+  });
+
+  const resolvedRuntimeImages =
+    existingRuntimeImages.length > 0
+      ? existingRuntimeImages
+      : extractedRuntimeImages.length > 0
+        ? extractedRuntimeImages
+        : undefined;
+
+  logger.debug("normalized submitted user payload images", {
+    persistedImageCountBefore: userPayload.images.length,
+    persistedImageCountAfter: normalizedImages.length,
+    providedRuntimeImageCount: existingRuntimeImages.length,
+    extractedLegacyRuntimeImageCount: extractedRuntimeImages.length,
+    resolvedRuntimeImageCount: resolvedRuntimeImages?.length ?? 0,
+    resolvedRuntimeImages: resolvedRuntimeImages?.map((image) => ({
+      id: image.id,
+      messageId: image.messageId,
+      mimeType: image.mimeType,
+      base64Length: image.data.length,
+    })),
+  });
+
+  return {
+    userPayload: {
+      ...userPayload,
+      images: normalizedImages,
+    },
+    runtimeImages: resolvedRuntimeImages,
+  };
 }
 
 function truncateLogValue(value: string, maxLength: number = 40) {

--- a/src/runtime/steer-queue.ts
+++ b/src/runtime/steer-queue.ts
@@ -4,8 +4,15 @@
  * Stores deferred user steering messages while a run is busy and lets runtime
  * replay them in order once the current execution stage allows it.
  */
+import type { AgentUserPayload, AgentUserRuntimeImagePayload } from "@/src/agent/llm/messages.js";
+import { createSubsystemLogger } from "@/src/shared/logger.js";
+
+const logger = createSubsystemLogger("steer-queue");
+
 export interface SteerInput {
   content: string;
+  userPayload?: AgentUserPayload;
+  runtimeImages?: AgentUserRuntimeImagePayload[];
   messageType?: string;
   visibility?: string;
   channelMessageId?: string | null;
@@ -20,6 +27,8 @@ export class SessionSteerQueueRegistry {
   enqueue(input: {
     sessionId: string;
     content: string;
+    userPayload?: AgentUserPayload;
+    runtimeImages?: AgentUserRuntimeImagePayload[];
     messageType?: string;
     visibility?: string;
     channelMessageId?: string | null;
@@ -30,6 +39,8 @@ export class SessionSteerQueueRegistry {
     const queue = this.queues.get(input.sessionId) ?? [];
     queue.push({
       content: input.content,
+      ...(input.userPayload == null ? {} : { userPayload: input.userPayload }),
+      ...(input.runtimeImages == null ? {} : { runtimeImages: input.runtimeImages }),
       ...(input.messageType == null ? {} : { messageType: input.messageType }),
       ...(input.visibility == null ? {} : { visibility: input.visibility }),
       ...(input.channelMessageId === undefined
@@ -44,6 +55,13 @@ export class SessionSteerQueueRegistry {
       ...(input.createdAt == null ? {} : { createdAt: input.createdAt }),
     });
     this.queues.set(input.sessionId, queue);
+    logger.debug("enqueued steer input", {
+      sessionId: input.sessionId,
+      queueLength: queue.length,
+      persistedImageCount: input.userPayload?.images?.length ?? 0,
+      runtimeImageCount: input.runtimeImages?.length ?? 0,
+      channelMessageId: input.channelMessageId ?? null,
+    });
   }
 
   drain(sessionId: string): SteerInput[] {
@@ -53,6 +71,11 @@ export class SessionSteerQueueRegistry {
     }
 
     this.queues.delete(sessionId);
+    logger.debug("drained steer queue", {
+      sessionId,
+      drainedCount: queue.length,
+      runtimeImageCount: queue.reduce((sum, item) => sum + (item.runtimeImages?.length ?? 0), 0),
+    });
     return [...queue];
   }
 

--- a/tests/agent/loop.test.ts
+++ b/tests/agent/loop.test.ts
@@ -227,6 +227,155 @@ describe("agent loop", () => {
     ]);
   });
 
+  test("keeps image bytes only for the active user turn across multi-request runs", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationFixture(handle);
+
+    const sessionsRepo = new SessionsRepo(handle.storage.db);
+    const messagesRepo = new MessagesRepo(handle.storage.db);
+    sessionsRepo.create({
+      id: "sess_1",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      purpose: "chat",
+      createdAt: new Date("2026-03-22T00:00:00.000Z"),
+    });
+    messagesRepo.append({
+      id: "msg_user",
+      sessionId: "sess_1",
+      seq: 1,
+      role: "user",
+      payloadJson: JSON.stringify({
+        content: "[图片 img_v3_123]",
+        images: [
+          {
+            type: "image",
+            id: "img_v3_123",
+            messageId: "om_msg_1",
+            mimeType: "image/png",
+          },
+        ],
+      }),
+      createdAt: new Date("2026-03-22T00:00:01.000Z"),
+    });
+
+    const seenRuntimeImageCounts: number[] = [];
+    let turns = 0;
+    const runner: AgentModelRunner = {
+      async runTurn(input) {
+        const userMessage = input.messages.find((message) => message.id === "msg_user");
+        seenRuntimeImageCounts.push(
+          userMessage == null ? -1 : (input.resolveRuntimeImages?.(userMessage).length ?? 0),
+        );
+        turns += 1;
+        if (turns === 1) {
+          return makeAssistantResult({
+            stopReason: "toolUse",
+            content: [
+              {
+                type: "toolCall",
+                id: "call_1",
+                name: "ping",
+                arguments: {},
+              },
+            ],
+          });
+        }
+
+        return makeAssistantResult({
+          content: [{ type: "text", text: "done" }],
+        });
+      },
+    };
+
+    const loop = new AgentLoop({
+      sessions: new AgentSessionService(sessionsRepo, messagesRepo),
+      messages: messagesRepo,
+      models: new ProviderRegistry(createModelConfig()),
+      tools: new ToolRegistry([
+        defineTool({
+          name: "ping",
+          description: "no-op",
+          inputSchema: NO_ARGS_TOOL_SCHEMA,
+          execute() {
+            return textToolResult("pong");
+          },
+        }),
+      ]),
+      cancel: new SessionRunAbortRegistry(),
+      modelRunner: runner,
+      storage: handle.storage.db,
+      securityConfig: DEFAULT_CONFIG.security,
+      compaction: DEFAULT_CONFIG.compaction,
+    });
+
+    await loop.run({
+      sessionId: "sess_1",
+      scenario: "chat",
+      initialRuntimeImagesByMessageId: {
+        msg_user: [
+          {
+            type: "image",
+            id: "img_v3_123",
+            messageId: "om_msg_1",
+            data: "ZmFrZS1pbWFnZQ==",
+            mimeType: "image/png",
+          },
+        ],
+      },
+    });
+
+    expect(seenRuntimeImageCounts).toEqual([1, 1]);
+    expect(JSON.parse(messagesRepo.listBySession("sess_1")[0]?.payloadJson ?? "{}")).toEqual({
+      content: "[图片 img_v3_123]",
+      images: [
+        {
+          type: "image",
+          id: "img_v3_123",
+          messageId: "om_msg_1",
+          mimeType: "image/png",
+        },
+      ],
+    });
+
+    messagesRepo.append({
+      id: "msg_user_2",
+      sessionId: "sess_1",
+      seq: messagesRepo.getNextSeq("sess_1"),
+      role: "user",
+      payloadJson: JSON.stringify({ content: "follow-up" }),
+      createdAt: new Date("2026-03-22T00:00:02.000Z"),
+    });
+
+    const secondRunSeenCounts: number[] = [];
+    const secondRunRunner: AgentModelRunner = {
+      async runTurn(input) {
+        for (const message of input.messages.filter((entry) => entry.role === "user")) {
+          secondRunSeenCounts.push(input.resolveRuntimeImages?.(message).length ?? 0);
+        }
+        return makeAssistantResult({
+          content: [{ type: "text", text: "follow-up done" }],
+        });
+      },
+    };
+
+    const secondLoop = new AgentLoop({
+      sessions: new AgentSessionService(sessionsRepo, messagesRepo),
+      messages: messagesRepo,
+      models: new ProviderRegistry(createModelConfig()),
+      tools: new ToolRegistry(),
+      cancel: new SessionRunAbortRegistry(),
+      modelRunner: secondRunRunner,
+      storage: handle.storage.db,
+      securityConfig: DEFAULT_CONFIG.security,
+      compaction: DEFAULT_CONFIG.compaction,
+    });
+
+    await secondLoop.run({ sessionId: "sess_1", scenario: "chat" });
+
+    expect(secondRunSeenCounts).toEqual([0, 0]);
+  });
+
   test("captures runtime date context once per run so multi-turn prompts keep a stable prefix", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-30T05:47:00.000Z"));

--- a/tests/agent/pi-agent-model-runner.test.ts
+++ b/tests/agent/pi-agent-model-runner.test.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage, AssistantMessageEvent } from "@mariozechner/pi-ai";
 import { afterEach, describe, expect, test, vi } from "vitest";
+import type { AgentUserRuntimeImagePayload } from "@/src/agent/llm/messages.js";
 import { PiAgentModelRunner, PiBridge } from "@/src/agent/llm/pi-bridge.js";
 import { ProviderRegistry } from "@/src/agent/llm/provider-registry.js";
 import { AgentLoop } from "@/src/agent/loop.js";
@@ -121,6 +122,84 @@ describe("pi agent model runner", () => {
       await destroyTestDatabase(handle);
       handle = null;
     }
+  });
+
+  test("forwards resolveRuntimeImages into the pi bridge", async () => {
+    const streamTurn = vi.fn(async () => ({
+      provider: "anthropic_main",
+      model: "claude-sonnet-4-5-20250929",
+      modelApi: "anthropic-messages" as const,
+      stopReason: "stop" as const,
+      content: [{ type: "text" as const, text: "ok" }],
+      usage: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 2,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      },
+    }));
+    const runner = new PiAgentModelRunner(
+      { streamTurn, completeText: vi.fn() } as unknown as PiBridge,
+      new ToolRegistry(),
+    );
+    const resolveRuntimeImages = vi.fn((): AgentUserRuntimeImagePayload[] => [
+      {
+        type: "image",
+        id: "img_v3_123",
+        messageId: "om_msg_1",
+        data: "ZmFrZS1pbWFnZQ==",
+        mimeType: "image/png",
+      },
+    ]);
+
+    await runner.runTurn({
+      sessionId: "sess_1",
+      conversationId: "conv_1",
+      scenario: "chat",
+      sessionPurpose: "chat",
+      agentKind: "main",
+      model: {
+        id: "anthropic_main/claude-sonnet-4-5",
+        providerId: "anthropic_main",
+        upstreamId: "claude-sonnet-4-5-20250929",
+        contextWindow: 200_000,
+        maxOutputTokens: 16_384,
+        supportsTools: true,
+        supportsVision: true,
+        reasoning: { enabled: true },
+        provider: {
+          id: "anthropic_main",
+          api: "anthropic-messages",
+          apiKey: "secret",
+        },
+      },
+      systemPrompt: "system prompt",
+      compactSummary: null,
+      messages: [
+        {
+          ...createStoredUserMessage(),
+          sessionId: "sess_1",
+        },
+      ],
+      resolveRuntimeImages,
+      signal: new AbortController().signal,
+    });
+
+    expect(streamTurn).toHaveBeenCalledOnce();
+    const firstArg = ((streamTurn.mock.calls as unknown as unknown[][])[0]?.[0] ?? null) as {
+      resolveRuntimeImages?: typeof resolveRuntimeImages;
+    } | null;
+    expect(firstArg).toMatchObject({
+      resolveRuntimeImages,
+    });
   });
 
   test("drives the loop through pi streaming and persists the final assistant payload", async () => {

--- a/tests/agent/pi-history.test.ts
+++ b/tests/agent/pi-history.test.ts
@@ -149,6 +149,92 @@ describe("pi history", () => {
     });
   });
 
+  test("reconstructs multimodal user messages from legacy inline image data too", () => {
+    const message = makeStoredMessage({
+      payloadJson: JSON.stringify({
+        content: "请看这张图",
+        images: [
+          {
+            type: "image",
+            id: "img_v3_legacy",
+            data: "ZmFrZS1pbWFnZQ==",
+            mimeType: "image/png",
+          },
+        ],
+      }),
+    });
+
+    expect(buildPiMessage(message)).toEqual({
+      role: "user",
+      content: [
+        { type: "text", text: "请看这张图" },
+        { type: "image", data: "ZmFrZS1pbWFnZQ==", mimeType: "image/png" },
+      ],
+      timestamp: Date.parse("2026-03-22T00:00:01.000Z"),
+    });
+  });
+
+  test("reconstructs multimodal user messages with attached runtime images", () => {
+    const message = makeStoredMessage({
+      payloadJson: JSON.stringify({
+        content: "请看这张图",
+        images: [{ type: "image", id: "img_v3_123", messageId: "om_msg_1", mimeType: "image/png" }],
+      }),
+    });
+
+    expect(
+      buildPiMessage(message, {
+        resolveRuntimeImages: () => [
+          {
+            type: "image",
+            id: "img_v3_123",
+            messageId: "om_msg_1",
+            data: "ZmFrZS1pbWFnZQ==",
+            mimeType: "image/png",
+          },
+        ],
+      }),
+    ).toEqual({
+      role: "user",
+      content: [
+        { type: "text", text: "请看这张图" },
+        { type: "image", data: "ZmFrZS1pbWFnZQ==", mimeType: "image/png" },
+      ],
+      timestamp: Date.parse("2026-03-22T00:00:01.000Z"),
+    });
+  });
+
+  test("keeps only placeholder text when runtime image bytes are no longer available", () => {
+    const message = makeStoredMessage({
+      payloadJson: JSON.stringify({
+        content: "[图片 img_v3_123]",
+        images: [{ type: "image", id: "img_v3_123", messageId: "om_msg_1", mimeType: "image/png" }],
+      }),
+    });
+
+    expect(buildPiMessage(message)).toEqual({
+      role: "user",
+      content: "[图片 img_v3_123]",
+      timestamp: Date.parse("2026-03-22T00:00:01.000Z"),
+    });
+  });
+
+  test("falls back to an English note when the current model does not support vision", () => {
+    const message = makeStoredMessage({
+      payloadJson: JSON.stringify({
+        content: "Please review this",
+        images: [{ type: "image", id: "img_v3_123", messageId: "om_msg_1", mimeType: "image/png" }],
+      }),
+    });
+
+    expect(buildPiMessage(message, { supportsVision: false })).toEqual({
+      role: "user",
+      content:
+        "Please review this\n[Note: The user attached 1 image (image IDs: img_v3_123), but the current model is not configured for vision, so the image content is not available to you.]",
+      timestamp: Date.parse("2026-03-22T00:00:01.000Z"),
+    });
+  });
+
   test("fails clearly when stored assistant metadata is incomplete", () => {
     const message = makeStoredMessage({
       role: "assistant",

--- a/tests/channels/lark/inbound.test.ts
+++ b/tests/channels/lark/inbound.test.ts
@@ -182,6 +182,27 @@ describe("lark inbound message handling", () => {
     });
   });
 
+  test("extracts image keys from post messages", () => {
+    expect(
+      normalizeLarkTextMessage(
+        makeMessageEvent("post", {
+          zh_cn: {
+            content: [
+              [
+                { tag: "md", text: "Here are screenshots" },
+                { tag: "img", image_key: "img_v3_post_1" },
+                { tag: "img", image_key: "img_v3_post_2" },
+              ],
+            ],
+          },
+        }),
+      ),
+    ).toMatchObject({
+      text: "Here are screenshots![image](img_v3_post_1)![image](img_v3_post_2)",
+      imageKeys: ["img_v3_post_1", "img_v3_post_2"],
+    });
+  });
+
   test("routes a text message through surface binding into runtime ingress", async () => {
     await withHandle(async (handle) => {
       seedFixture(handle);
@@ -355,6 +376,147 @@ describe("lark inbound message handling", () => {
           },
         ],
         channelMessageId: "om_msg_raw_1",
+        createdAt: new Date("2026-03-27T00:00:00.000Z"),
+      });
+    });
+  });
+
+  test("keeps only successfully fetched post images in payload metadata", async () => {
+    await withHandle(async (handle) => {
+      seedFixture(handle);
+      const surfacesRepo = new ChannelSurfacesRepo(handle.storage.db);
+      surfacesRepo.upsert({
+        id: "surface_1",
+        channelType: "lark",
+        channelInstallationId: "default",
+        conversationId: "conv_main",
+        branchId: "branch_main",
+        surfaceKey: buildLarkChatSurfaceKey("oc_chat_1"),
+        surfaceObjectJson: JSON.stringify({ chat_id: "oc_chat_1" }),
+      });
+
+      const submitMessage = vi.fn(async () => ({ status: "started" as const }));
+      const messageResourceGet = vi.fn(async (input: { path: { file_key: string } }) => {
+        if (input.path.file_key === "img_v3_post_ok") {
+          return {
+            headers: { "content-type": "text/html; charset=utf-8" },
+            getReadableStream: () => Readable.from(Buffer.from("post-image-ok")),
+          };
+        }
+        throw new Error("download failed");
+      });
+      const clients = {
+        getOrCreate: vi.fn(() => ({
+          sdk: {
+            im: {
+              messageResource: {
+                get: messageResourceGet,
+              },
+            },
+          },
+        })),
+      } as unknown as { getOrCreate(installationId: string): LarkSdkClient };
+
+      const handler = createLarkMessageReceiveHandler({
+        installationId: "default",
+        storage: handle.storage.db,
+        ingress: { submitMessage, submitApprovalDecision: vi.fn(() => false) },
+        control: new RuntimeControlService(new SessionRunAbortRegistry()),
+        clients,
+      });
+
+      await handler(
+        makeMessageEvent("post", {
+          zh_cn: {
+            content: [
+              [
+                { tag: "md", text: "Two images" },
+                { tag: "img", image_key: "img_v3_post_ok" },
+                { tag: "img", image_key: "img_v3_post_fail" },
+              ],
+            ],
+          },
+        }),
+      );
+
+      expect(messageResourceGet).toHaveBeenCalledTimes(2);
+      expect(submitMessage).toHaveBeenCalledExactlyOnceWith({
+        sessionId: "sess_chat_1",
+        scenario: "chat",
+        content: "Two images![image](img_v3_post_ok)![image](img_v3_post_fail)",
+        userPayload: {
+          content: "Two images![image](img_v3_post_ok)![image](img_v3_post_fail)",
+          images: [
+            {
+              type: "image",
+              id: "img_v3_post_ok",
+              messageId: "om_msg_1",
+              mimeType: "image/png",
+            },
+          ],
+        },
+        runtimeImages: [
+          {
+            type: "image",
+            id: "img_v3_post_ok",
+            messageId: "om_msg_1",
+            data: Buffer.from("post-image-ok").toString("base64"),
+            mimeType: "image/png",
+          },
+        ],
+        channelMessageId: "om_msg_1",
+        createdAt: new Date("2026-03-27T00:00:00.000Z"),
+      });
+    });
+  });
+
+  test("drops empty downloaded image resources from payload metadata", async () => {
+    await withHandle(async (handle) => {
+      seedFixture(handle);
+      const surfacesRepo = new ChannelSurfacesRepo(handle.storage.db);
+      surfacesRepo.upsert({
+        id: "surface_1",
+        channelType: "lark",
+        channelInstallationId: "default",
+        conversationId: "conv_main",
+        branchId: "branch_main",
+        surfaceKey: buildLarkChatSurfaceKey("oc_chat_1"),
+        surfaceObjectJson: JSON.stringify({ chat_id: "oc_chat_1" }),
+      });
+
+      const submitMessage = vi.fn(async () => ({ status: "started" as const }));
+      const messageResourceGet = vi.fn(async () => ({
+        headers: { "content-type": "image/jpeg" },
+        getReadableStream: () => Readable.from(Buffer.alloc(0)),
+      }));
+      const clients = {
+        getOrCreate: vi.fn(() => ({
+          sdk: {
+            im: {
+              messageResource: {
+                get: messageResourceGet,
+              },
+            },
+          },
+        })),
+      } as unknown as { getOrCreate(installationId: string): LarkSdkClient };
+
+      const handler = createLarkMessageReceiveHandler({
+        installationId: "default",
+        storage: handle.storage.db,
+        ingress: { submitMessage, submitApprovalDecision: vi.fn(() => false) },
+        control: new RuntimeControlService(new SessionRunAbortRegistry()),
+        clients,
+      });
+
+      await handler(makeMessageEvent("image", { image_key: "img_v3_empty" }));
+
+      expect(messageResourceGet).toHaveBeenCalledOnce();
+      expect(submitMessage).toHaveBeenCalledExactlyOnceWith({
+        sessionId: "sess_chat_1",
+        scenario: "chat",
+        content: "[图片 img_v3_empty]",
+        channelMessageId: "om_msg_1",
         createdAt: new Date("2026-03-27T00:00:00.000Z"),
       });
     });

--- a/tests/channels/lark/inbound.test.ts
+++ b/tests/channels/lark/inbound.test.ts
@@ -1,3 +1,4 @@
+import { Readable } from "node:stream";
 import { describe, expect, test, vi } from "vitest";
 import { AgentSessionService } from "@/src/agent/session.js";
 import type { LarkSdkClient } from "@/src/channels/lark/client.js";
@@ -71,6 +72,24 @@ function makeTextEvent(text: string) {
   return makeMessageEvent("text", { text });
 }
 
+function makeRawMessage(messageType: string, content: unknown) {
+  return {
+    sender: {
+      id: "ou_sender_raw",
+      id_type: "open_id",
+      sender_type: "user",
+    },
+    message_id: "om_msg_raw_1",
+    chat_id: "oc_chat_1",
+    chat_type: "p2p",
+    msg_type: messageType,
+    create_time: "1774569600000",
+    body: {
+      content: JSON.stringify(content),
+    },
+  };
+}
+
 describe("lark inbound message handling", () => {
   test("normalizes a text event into plain text facts", () => {
     expect(normalizeLarkTextMessage(makeTextEvent(" hello "))).toMatchObject({
@@ -106,6 +125,29 @@ describe("lark inbound message handling", () => {
       parentMessageId: "om_parent_1",
       threadId: null,
       text: "Why is this written this way?",
+    });
+  });
+
+  test("extracts image keys from image messages", () => {
+    expect(
+      normalizeLarkTextMessage(makeMessageEvent("image", { image_key: "img_v3_123" })),
+    ).toMatchObject({
+      text: "[图片 img_v3_123]",
+      imageKeys: ["img_v3_123"],
+    });
+  });
+
+  test("normalizes raw lark image payloads using msg_type and body.content", () => {
+    expect(
+      normalizeLarkTextMessage(makeRawMessage("image", { image_key: "img_v3_raw_123" })),
+    ).toMatchObject({
+      chatId: "oc_chat_1",
+      messageId: "om_msg_raw_1",
+      senderOpenId: "ou_sender_raw",
+      senderType: "user",
+      messageType: "image",
+      text: "[图片 img_v3_raw_123]",
+      imageKeys: ["img_v3_raw_123"],
     });
   });
 
@@ -169,6 +211,150 @@ describe("lark inbound message handling", () => {
         scenario: "chat",
         content: "hello from lark",
         channelMessageId: "om_msg_1",
+        createdAt: new Date("2026-03-27T00:00:00.000Z"),
+      });
+    });
+  });
+
+  test("downloads inbound image messages and forwards them in userPayload", async () => {
+    await withHandle(async (handle) => {
+      seedFixture(handle);
+      const surfacesRepo = new ChannelSurfacesRepo(handle.storage.db);
+      surfacesRepo.upsert({
+        id: "surface_1",
+        channelType: "lark",
+        channelInstallationId: "default",
+        conversationId: "conv_main",
+        branchId: "branch_main",
+        surfaceKey: buildLarkChatSurfaceKey("oc_chat_1"),
+        surfaceObjectJson: JSON.stringify({ chat_id: "oc_chat_1" }),
+      });
+
+      const submitMessage = vi.fn(async () => ({ status: "started" as const }));
+      const messageResourceGet = vi.fn(async () => ({
+        headers: { "content-type": "image/jpeg" },
+        getReadableStream: () => Readable.from(Buffer.from("fake-image")),
+      }));
+      const clients = {
+        getOrCreate: vi.fn(() => ({
+          sdk: {
+            im: {
+              messageResource: {
+                get: messageResourceGet,
+              },
+            },
+          },
+        })),
+      } as unknown as { getOrCreate(installationId: string): LarkSdkClient };
+
+      const handler = createLarkMessageReceiveHandler({
+        installationId: "default",
+        storage: handle.storage.db,
+        ingress: { submitMessage, submitApprovalDecision: vi.fn(() => false) },
+        control: new RuntimeControlService(new SessionRunAbortRegistry()),
+        clients,
+      });
+
+      await handler(makeMessageEvent("image", { image_key: "img_v3_123" }));
+
+      expect(messageResourceGet).toHaveBeenCalledOnce();
+      expect(submitMessage).toHaveBeenCalledExactlyOnceWith({
+        sessionId: "sess_chat_1",
+        scenario: "chat",
+        content: "[图片 img_v3_123]",
+        userPayload: {
+          content: "[图片 img_v3_123]",
+          images: [
+            {
+              type: "image",
+              id: "img_v3_123",
+              messageId: "om_msg_1",
+              mimeType: "image/jpeg",
+            },
+          ],
+        },
+        runtimeImages: [
+          {
+            type: "image",
+            id: "img_v3_123",
+            messageId: "om_msg_1",
+            data: Buffer.from("fake-image").toString("base64"),
+            mimeType: "image/jpeg",
+          },
+        ],
+        channelMessageId: "om_msg_1",
+        createdAt: new Date("2026-03-27T00:00:00.000Z"),
+      });
+    });
+  });
+
+  test("downloads inbound image messages from raw lark payloads and forwards runtimeImages", async () => {
+    await withHandle(async (handle) => {
+      seedFixture(handle);
+      const surfacesRepo = new ChannelSurfacesRepo(handle.storage.db);
+      surfacesRepo.upsert({
+        id: "surface_1",
+        channelType: "lark",
+        channelInstallationId: "default",
+        conversationId: "conv_main",
+        branchId: "branch_main",
+        surfaceKey: buildLarkChatSurfaceKey("oc_chat_1"),
+        surfaceObjectJson: JSON.stringify({ chat_id: "oc_chat_1" }),
+      });
+
+      const submitMessage = vi.fn(async () => ({ status: "started" as const }));
+      const messageResourceGet = vi.fn(async () => ({
+        headers: { "content-type": "image/png" },
+        getReadableStream: () => Readable.from(Buffer.from("raw-image")),
+      }));
+      const clients = {
+        getOrCreate: vi.fn(() => ({
+          sdk: {
+            im: {
+              messageResource: {
+                get: messageResourceGet,
+              },
+            },
+          },
+        })),
+      } as unknown as { getOrCreate(installationId: string): LarkSdkClient };
+
+      const handler = createLarkMessageReceiveHandler({
+        installationId: "default",
+        storage: handle.storage.db,
+        ingress: { submitMessage, submitApprovalDecision: vi.fn(() => false) },
+        control: new RuntimeControlService(new SessionRunAbortRegistry()),
+        clients,
+      });
+
+      await handler(makeRawMessage("image", { image_key: "img_v3_raw_123" }));
+
+      expect(messageResourceGet).toHaveBeenCalledOnce();
+      expect(submitMessage).toHaveBeenCalledExactlyOnceWith({
+        sessionId: "sess_chat_1",
+        scenario: "chat",
+        content: "[图片 img_v3_raw_123]",
+        userPayload: {
+          content: "[图片 img_v3_raw_123]",
+          images: [
+            {
+              type: "image",
+              id: "img_v3_raw_123",
+              messageId: "om_msg_raw_1",
+              mimeType: "image/png",
+            },
+          ],
+        },
+        runtimeImages: [
+          {
+            type: "image",
+            id: "img_v3_raw_123",
+            messageId: "om_msg_raw_1",
+            data: Buffer.from("raw-image").toString("base64"),
+            mimeType: "image/png",
+          },
+        ],
+        channelMessageId: "om_msg_raw_1",
         createdAt: new Date("2026-03-27T00:00:00.000Z"),
       });
     });

--- a/tests/runtime/session-lane.test.ts
+++ b/tests/runtime/session-lane.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { RunAgentLoopResult } from "@/src/agent/loop.js";
+import { InMemorySessionLane } from "@/src/runtime/session-lane.js";
+import { MessagesRepo } from "@/src/storage/repos/messages.repo.js";
+import { SessionsRepo } from "@/src/storage/repos/sessions.repo.js";
+import {
+  createTestDatabase,
+  destroyTestDatabase,
+  type TestDatabaseHandle,
+} from "@/tests/storage/helpers/test-db.js";
+
+function seedConversationFixture(handle: TestDatabaseHandle): void {
+  handle.storage.sqlite.exec(`
+    INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+    VALUES ('ci_1', 'lark', 'acct_a', '2026-03-22T00:00:00.000Z', '2026-03-22T00:00:00.000Z');
+
+    INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+    VALUES ('conv_1', 'ci_1', 'chat_1', 'dm', '2026-03-22T00:00:00.000Z', '2026-03-22T00:00:00.000Z');
+
+    INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+    VALUES ('branch_1', 'conv_1', 'dm_main', 'main', '2026-03-22T00:00:00.000Z', '2026-03-22T00:00:00.000Z');
+  `);
+}
+
+describe("session lane image normalization", () => {
+  let handle: TestDatabaseHandle | null = null;
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (handle != null) {
+      await destroyTestDatabase(handle);
+      handle = null;
+    }
+  });
+
+  test("extracts legacy inline image data into runtime-only images before starting a run", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationFixture(handle);
+    const messages = new MessagesRepo(handle.storage.db);
+    const sessions = new SessionsRepo(handle.storage.db);
+    sessions.create({
+      id: "sess_1",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      purpose: "chat",
+      createdAt: new Date("2026-03-22T00:00:00.000Z"),
+    });
+    const run = vi.fn(
+      async (): Promise<RunAgentLoopResult> => ({
+        runId: "run_1",
+        sessionId: "sess_1",
+        scenario: "chat",
+        modelId: "model_1",
+        appendedMessageIds: [],
+        toolExecutions: 0,
+        compaction: {
+          shouldCompact: false,
+          thresholdTokens: 0,
+          effectiveWindow: 0,
+          reason: null,
+        },
+        events: [],
+        stopSignal: null,
+      }),
+    );
+
+    const lane = new InMemorySessionLane({
+      messages,
+      loop: {
+        enqueueSteerInput: vi.fn(() => false),
+        run,
+        submitApprovalResponse: vi.fn(() => false),
+      } as never,
+    });
+
+    await lane.submitMessage({
+      sessionId: "sess_1",
+      scenario: "chat",
+      content: "[图片 img_v3_123]",
+      userPayload: {
+        content: "[图片 img_v3_123]",
+        images: [
+          {
+            type: "image",
+            id: "img_v3_123",
+            messageId: "om_msg_1",
+            data: "ZmFrZS1pbWFnZQ==",
+            mimeType: "image/png",
+          } as never,
+        ],
+      },
+    });
+
+    const rows = messages.listBySession("sess_1");
+    expect(rows).toHaveLength(1);
+    expect(JSON.parse(rows[0]?.payloadJson ?? "{}")).toEqual({
+      content: "[图片 img_v3_123]",
+      images: [
+        {
+          type: "image",
+          id: "img_v3_123",
+          messageId: "om_msg_1",
+          mimeType: "image/png",
+        },
+      ],
+    });
+
+    expect(run).toHaveBeenCalledTimes(1);
+    const firstRunCall = (
+      run as unknown as {
+        mock: {
+          calls: Array<
+            [
+              {
+                initialRuntimeImagesByMessageId?: Record<string, unknown>;
+                sessionId?: string;
+                scenario?: string;
+              },
+            ]
+          >;
+        };
+      }
+    ).mock.calls[0];
+    expect(firstRunCall).toBeTruthy();
+    const firstRunInput = firstRunCall?.[0];
+    expect(firstRunInput).toMatchObject({
+      sessionId: "sess_1",
+      scenario: "chat",
+    });
+    const initialRuntimeImagesByMessageId = firstRunInput?.initialRuntimeImagesByMessageId;
+    expect(initialRuntimeImagesByMessageId).toBeTruthy();
+    const messageId = Object.keys(initialRuntimeImagesByMessageId ?? {})[0];
+    expect(messageId).toBeTruthy();
+    expect(initialRuntimeImagesByMessageId?.[messageId as string]).toEqual([
+      {
+        type: "image",
+        id: "img_v3_123",
+        messageId: "om_msg_1",
+        data: "ZmFrZS1pbWFnZQ==",
+        mimeType: "image/png",
+      },
+    ]);
+  });
+
+  test("extracts legacy inline image data into runtime-only images for steered messages too", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationFixture(handle);
+    const messages = new MessagesRepo(handle.storage.db);
+    const sessions = new SessionsRepo(handle.storage.db);
+    sessions.create({
+      id: "sess_1",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      purpose: "chat",
+      createdAt: new Date("2026-03-22T00:00:00.000Z"),
+    });
+    const enqueueSteerInput = vi.fn(() => true);
+
+    const deferredRun = new Promise<RunAgentLoopResult>(() => {});
+    const lane = new InMemorySessionLane({
+      messages,
+      loop: {
+        enqueueSteerInput,
+        run: vi.fn(() => deferredRun),
+        submitApprovalResponse: vi.fn(() => false),
+      } as never,
+    });
+
+    void lane.submitMessage({
+      sessionId: "sess_1",
+      scenario: "chat",
+      content: "first",
+    });
+
+    await lane.submitMessage({
+      sessionId: "sess_1",
+      scenario: "chat",
+      content: "[图片 img_v3_123]",
+      userPayload: {
+        content: "[图片 img_v3_123]",
+        images: [
+          {
+            type: "image",
+            id: "img_v3_123",
+            messageId: "om_msg_1",
+            data: "ZmFrZS1pbWFnZQ==",
+            mimeType: "image/png",
+          } as never,
+        ],
+      },
+    });
+
+    expect(enqueueSteerInput).toHaveBeenCalledTimes(1);
+    const firstSteerCall = (
+      enqueueSteerInput as unknown as {
+        mock: { calls: Array<[Record<string, unknown>]> };
+      }
+    ).mock.calls[0];
+    expect(firstSteerCall).toBeTruthy();
+    const firstSteerInput = firstSteerCall?.[0];
+    expect(firstSteerInput).toMatchObject({
+      sessionId: "sess_1",
+      content: "[图片 img_v3_123]",
+      userPayload: {
+        content: "[图片 img_v3_123]",
+        images: [
+          {
+            type: "image",
+            id: "img_v3_123",
+            messageId: "om_msg_1",
+            mimeType: "image/png",
+          },
+        ],
+      },
+      runtimeImages: [
+        {
+          type: "image",
+          id: "img_v3_123",
+          messageId: "om_msg_1",
+          data: "ZmFrZS1pbWFnZQ==",
+          mimeType: "image/png",
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add memory-only, turn-scoped runtime image handling for inbound Lark images
- persist only lightweight image metadata in transcript history and keep base64 out of storage
- inject vision image blocks only when the current model supports vision, with a clear fallback note otherwise
- fix PiAgentModelRunner so resolveRuntimeImages is forwarded all the way into the pi bridge
- add regression coverage and reduce image-path logging noise to only the most important info logs

## Testing
- pnpm preflight
