### PR TITLE
Fix Lark card retry idempotency

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,44 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,6 +38,7 @@ jobs:
           ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.ANTHROPIC_API_KEY }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,27 +2,24 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    types: [opened]
+  issue_comment:
+    types: [created]
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    if: |
+      (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       (contains(github.event.comment.body, '@claude review') ||
+        contains(github.event.comment.body, '@claude code review')))
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
+      actions: read
       id-token: write
 
     steps:
@@ -39,8 +36,68 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.ANTHROPIC_API_KEY }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          additional_permissions: |
+            actions: read
+          prompt: |
+            <pr_context>
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+            LANGUAGE: TypeScript
+            REPO STAGE: Early implementation, design-doc-driven architecture
+            </pr_context>
+
+            <project_context>
+            Consult the repository guidance before reviewing:
+            - .claude/CLAUDE.md
+            - design-docs/dev-plan.md
+            - design-docs/tech-decisions.md
+            - design-docs/product-principles.md
+
+            Important repository constraints:
+            - The system must preserve the dependency order: Foundation -> Persistence -> Agent runtime -> Security/execution -> Orchestration -> Messaging adaptation -> Feishu channel -> Built-in capabilities -> End-to-end hardening.
+            - Feishu/Lark-specific behavior must not leak into lower runtime or persistence abstractions unless the boundary is explicitly channel-specific.
+            - Runtime state belongs in SQLite; global defaults belong in config; secrets belong in secrets handling.
+            - TypeScript is intentionally strict and explicit any should be treated as a real issue.
+            - Avoid unnecessary abstractions and avoid adding service seams like logger/time injection unless there is a concrete production need.
+            </project_context>
+
+            <review_instructions>
+            Review this pull request and report only merge-relevant issues and meaningful architectural risks.
+
+            Prioritize findings in this order:
+            1. Architecture layering violations
+               - changes that skip the intended build order from design-docs/dev-plan.md
+               - Feishu/Lark-specific logic leaking into runtime, orchestration, storage, or other lower layers
+               - messaging adaptation boundaries being bypassed
+
+            2. Config, secrets, and storage boundary violations
+               - runtime or instance state incorrectly moved into config files
+               - secrets handled in the wrong layer
+               - violations of the repo's config/secrets/SQLite split
+
+            3. Agent/runtime model correctness
+               - Main Agent, SubAgent, and TaskAgent responsibilities getting mixed together
+               - regressions to observability, interruptibility, or permission control
+               - changes that break task/thread/context isolation expectations
+
+            4. TypeScript safety and maintainability
+               - explicit any or weakly typed boundaries
+               - unsafe assumptions hidden behind casts
+               - premature abstractions or over-engineering that conflict with current repo guidance
+               - test-only seams leaking into production interfaces
+
+            5. Security, correctness, and tests
+               - unsafe trust boundaries, injection risks, or secret exposure
+               - missing or incorrect handling for meaningful edge cases
+               - missing regression coverage for non-trivial behavior changes
+               - changes that weaken the repo's stated real-LLM integration test discipline
+
+            Review style:
+            - Use concise bullet points.
+            - Explain what is wrong, why it matters in this repo, and the concrete fix direction.
+            - Do not report style nits or speculative improvements.
+            - If no meaningful issues are found, say so briefly.
+
+            Use gh pr comment to post the review.
+            </review_instructions>
+          claude_args: '--allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh run view:*),Bash(gh run list:*)"'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
@@ -41,4 +43,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,6 +37,7 @@ jobs:
           ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,7 +13,10 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issue_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       !contains(github.event.comment.body, '@claude review') &&
+       !contains(github.event.comment.body, '@claude code review')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,6 +33,8 @@ jobs:
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
@@ -47,4 +49,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/src/channels/lark/outbound.ts
+++ b/src/channels/lark/outbound.ts
@@ -36,6 +36,7 @@ import { createSubsystemLogger } from "@/src/shared/logger.js";
 import type { StorageDb } from "@/src/storage/db/client.js";
 import { ChannelSurfacesRepo } from "@/src/storage/repos/channel-surfaces.repo.js";
 import { LarkObjectBindingsRepo } from "@/src/storage/repos/lark-object-bindings.repo.js";
+import type { LarkObjectBinding } from "@/src/storage/schema/types.js";
 
 const logger = createSubsystemLogger("channels/lark-outbound");
 const LARK_CHANNEL_TYPE = "lark";
@@ -73,6 +74,13 @@ interface LarkCardUpdateInput {
       data: string;
     };
     sequence: number;
+  };
+}
+
+interface LarkInteractiveMessageResponse {
+  data?: {
+    message_id?: string;
+    open_message_id?: string;
   };
 }
 
@@ -193,6 +201,141 @@ export function createLarkOutboundRuntime(
     }
   };
 
+  const ensureInteractiveCardReferenceBinding = async (bindingInput: {
+    bindingsRepo: LarkObjectBindingsRepo;
+    client: LarkSdkClient;
+    cardkit: ReturnType<typeof getCardkitSdk>;
+    channelInstallationId: string;
+    conversationId: string;
+    branchId: string;
+    internalObjectKind: string;
+    internalObjectId: string;
+    chatId: string;
+    surfaceObject: Record<string, unknown>;
+    cardJson: string;
+    cardElementId?: string | null;
+    lastSequence?: number | null;
+    status: "active" | "finalized" | "stale";
+    metadataJson: string;
+    logContext: Record<string, unknown>;
+  }): Promise<LarkObjectBinding | null> => {
+    const threadRootMessageId = readStringValue(bindingInput.surfaceObject.thread_id);
+    let binding = bindingInput.bindingsRepo.reserveBinding({
+      id: randomUUID(),
+      channelInstallationId: bindingInput.channelInstallationId,
+      conversationId: bindingInput.conversationId,
+      branchId: bindingInput.branchId,
+      internalObjectKind: bindingInput.internalObjectKind,
+      internalObjectId: bindingInput.internalObjectId,
+      larkMessageUuid: randomUUID(),
+      threadRootMessageId,
+      cardElementId: bindingInput.cardElementId,
+      lastSequence: bindingInput.lastSequence,
+      status: bindingInput.status,
+      metadataJson: bindingInput.metadataJson,
+    });
+
+    if (binding.larkMessageUuid == null) {
+      throw new Error(
+        `Missing lark message uuid for ${bindingInput.internalObjectKind}:${bindingInput.internalObjectId}`,
+      );
+    }
+
+    if (binding.larkCardId == null) {
+      const createResp = await bindingInput.cardkit.card.create({
+        data: {
+          type: "card_json",
+          data: bindingInput.cardJson,
+        },
+      });
+      const larkCardId = createResp.data?.card_id ?? createResp.card_id ?? null;
+      logger.debug("created lark cardkit card response", {
+        ...bindingInput.logContext,
+        channelInstallationId: bindingInput.channelInstallationId,
+        responsePreview: truncateLogText(safeJson(createResp), LARK_CARD_LOG_PREVIEW_MAX_LENGTH),
+      });
+      if (larkCardId == null) {
+        logger.warn("lark card create returned no card id", {
+          ...bindingInput.logContext,
+          channelInstallationId: bindingInput.channelInstallationId,
+          responsePreview: truncateLogText(safeJson(createResp), LARK_CARD_LOG_PREVIEW_MAX_LENGTH),
+        });
+        return null;
+      }
+
+      const attachedBinding = bindingInput.bindingsRepo.attachCardAnchor({
+        channelInstallationId: bindingInput.channelInstallationId,
+        internalObjectKind: bindingInput.internalObjectKind,
+        internalObjectId: bindingInput.internalObjectId,
+        conversationId: bindingInput.conversationId,
+        branchId: bindingInput.branchId,
+        larkCardId,
+        threadRootMessageId,
+        cardElementId: bindingInput.cardElementId,
+        lastSequence: bindingInput.lastSequence,
+        status: bindingInput.status,
+        metadataJson: bindingInput.metadataJson,
+      });
+      if (attachedBinding == null) {
+        return null;
+      }
+      binding = attachedBinding;
+    }
+
+    if (binding.larkMessageId == null) {
+      const larkCardId = binding.larkCardId;
+      if (larkCardId == null) {
+        return null;
+      }
+      logger.debug("sending lark card reference message", {
+        ...bindingInput.logContext,
+        channelInstallationId: bindingInput.channelInstallationId,
+        chatId: bindingInput.chatId,
+        larkCardId,
+        larkMessageUuid: binding.larkMessageUuid,
+      });
+      const response = await sendLarkInteractiveCardReferenceMessage({
+        client: bindingInput.client,
+        chatId: bindingInput.chatId,
+        surfaceObject: bindingInput.surfaceObject,
+        larkCardId,
+        larkMessageUuid: binding.larkMessageUuid,
+      });
+      const larkMessageId = response.data?.message_id ?? null;
+      if (larkMessageId == null) {
+        logger.warn("lark card reference send returned no message id", {
+          ...bindingInput.logContext,
+          channelInstallationId: bindingInput.channelInstallationId,
+          larkCardId: binding.larkCardId,
+          larkMessageUuid: binding.larkMessageUuid,
+        });
+        return null;
+      }
+
+      const attachedBinding = bindingInput.bindingsRepo.attachMessageAnchor({
+        channelInstallationId: bindingInput.channelInstallationId,
+        internalObjectKind: bindingInput.internalObjectKind,
+        internalObjectId: bindingInput.internalObjectId,
+        conversationId: bindingInput.conversationId,
+        branchId: bindingInput.branchId,
+        larkMessageId,
+        larkOpenMessageId: response.data?.open_message_id ?? null,
+        larkCardId: binding.larkCardId,
+        threadRootMessageId,
+        cardElementId: bindingInput.cardElementId,
+        lastSequence: bindingInput.lastSequence,
+        status: bindingInput.status,
+        metadataJson: bindingInput.metadataJson,
+      });
+      if (attachedBinding == null) {
+        return null;
+      }
+      binding = attachedBinding;
+    }
+
+    return binding;
+  };
+
   const flushRunCard = async (runCardObjectId: string) => {
     const state = runStates.get(runCardObjectId);
     if (state == null) {
@@ -292,87 +435,35 @@ export function createLarkOutboundRuntime(
           structureSignaturePreview: truncateLogText(renderedPage.structureSignature, 160),
         });
 
-        if (existing?.larkCardId == null) {
-          const createResp = await cardkit.card.create({
-            data: {
-              type: "card_json",
-              data: JSON.stringify(renderedPage.card),
-            },
-          });
-          logger.debug("created lark cardkit card response", {
-            runId: state.runId,
-            runCardObjectId,
-            pageObjectId,
-            pageIndex: renderedPage.pageIndex,
-            channelInstallationId: surface.channelInstallationId,
-            responsePreview: truncateLogText(
-              safeJson(createResp),
-              LARK_CARD_LOG_PREVIEW_MAX_LENGTH,
-            ),
-          });
-          const larkCardId = createResp.data?.card_id ?? createResp.card_id ?? null;
-          if (larkCardId == null) {
-            logger.warn("lark run card create returned no card id", {
-              runId: state.runId,
-              runCardObjectId,
-              pageObjectId,
-              channelInstallationId: surface.channelInstallationId,
-              responsePreview: truncateLogText(
-                safeJson(createResp),
-                LARK_CARD_LOG_PREVIEW_MAX_LENGTH,
-              ),
-            });
-            continue;
-          }
-
-          logger.debug("sending lark card reference message", {
-            runId: state.runId,
-            runCardObjectId,
-            pageObjectId,
-            pageIndex: renderedPage.pageIndex,
-            channelInstallationId: surface.channelInstallationId,
-            chatId,
-            larkCardId,
-            cardPreview: truncateLogText(
-              JSON.stringify(renderedPage.card),
-              LARK_CARD_LOG_PREVIEW_MAX_LENGTH,
-            ),
-          });
-          const response = (await sendLarkInteractiveCardReferenceMessage({
+        if (existing?.larkCardId == null || existing.larkMessageId == null) {
+          const binding = await ensureInteractiveCardReferenceBinding({
+            bindingsRepo,
             client,
-            chatId,
-            surfaceObject,
-            larkCardId,
-          })) as { data?: { message_id?: string; open_message_id?: string } };
-          const larkMessageId = response.data?.message_id ?? null;
-          if (larkMessageId == null) {
-            logger.warn("lark run card create returned no message id", {
-              runId: state.runId,
-              runCardObjectId,
-              pageObjectId,
-              channelInstallationId: surface.channelInstallationId,
-              larkCardId,
-            });
-            continue;
-          }
-
-          bindingsRepo.upsert({
-            id: randomUUID(),
+            cardkit,
             channelInstallationId: surface.channelInstallationId,
             conversationId: state.conversationId,
             branchId: state.branchId,
             internalObjectKind: RUN_CARD_OBJECT_KIND,
             internalObjectId: pageObjectId,
-            larkMessageId,
-            larkOpenMessageId: response.data?.open_message_id ?? null,
-            larkCardId,
-            threadRootMessageId: readStringValue(surfaceObject.thread_id),
+            chatId,
+            surfaceObject,
+            cardJson: JSON.stringify(renderedPage.card),
             cardElementId: activeAssistantBlockId,
             lastSequence: 0,
             status: pageStatus,
             metadataJson,
+            logContext: {
+              runId: state.runId,
+              runCardObjectId,
+              pageObjectId,
+              pageIndex: renderedPage.pageIndex,
+            },
           });
+          if (binding == null) {
+            continue;
+          }
 
+          existingBindingsByObjectId.set(pageObjectId, binding);
           deliverySnapshots.set(snapshotKey, {
             structureSignature: renderedPage.structureSignature,
             activeAssistantElementId: activeAssistantBlockId,
@@ -385,8 +476,9 @@ export function createLarkOutboundRuntime(
             pageObjectId,
             pageIndex: renderedPage.pageIndex,
             channelInstallationId: surface.channelInstallationId,
-            larkMessageId,
-            larkCardId,
+            larkMessageId: binding.larkMessageId,
+            larkCardId: binding.larkCardId,
+            larkMessageUuid: binding.larkMessageUuid,
           });
           continue;
         }
@@ -566,59 +658,41 @@ export function createLarkOutboundRuntime(
       });
       const rendered = buildLarkRenderedApprovalCard(state);
 
-      if (existing?.larkCardId == null) {
-        const createResp = await cardkit.card.create({
-          data: {
-            type: "card_json",
-            data: JSON.stringify(rendered.card),
-          },
-        });
-        logger.debug("created lark approval cardkit response", {
-          approvalId,
-          runId: state.runId,
-          channelInstallationId: surface.channelInstallationId,
-          responsePreview: truncateLogText(safeJson(createResp), LARK_CARD_LOG_PREVIEW_MAX_LENGTH),
-        });
-        const larkCardId = createResp.data?.card_id ?? createResp.card_id ?? null;
-        if (larkCardId == null) {
-          continue;
-        }
-
-        const response = (await sendLarkInteractiveCardReferenceMessage({
+      if (existing?.larkCardId == null || existing.larkMessageId == null) {
+        const binding = await ensureInteractiveCardReferenceBinding({
+          bindingsRepo,
           client,
-          chatId,
-          surfaceObject,
-          larkCardId,
-        })) as { data?: { message_id?: string; open_message_id?: string } };
-        const larkMessageId = response.data?.message_id ?? null;
-        if (larkMessageId == null) {
-          continue;
-        }
-
-        bindingsRepo.upsert({
-          id: randomUUID(),
+          cardkit,
           channelInstallationId: surface.channelInstallationId,
           conversationId: state.conversationId,
           branchId: state.branchId,
           internalObjectKind: APPROVAL_CARD_OBJECT_KIND,
           internalObjectId: approvalId,
-          larkMessageId,
-          larkOpenMessageId: response.data?.open_message_id ?? null,
-          larkCardId,
+          chatId,
+          surfaceObject,
+          cardJson: JSON.stringify(rendered.card),
           lastSequence: 0,
           status: state.resolved ? "finalized" : "active",
           metadataJson: JSON.stringify({
             approvalId,
             runId: state.runId,
           }),
+          logContext: {
+            approvalId,
+            runId: state.runId,
+          },
         });
+        if (binding == null) {
+          continue;
+        }
 
         logger.info("created standalone lark approval card", {
           approvalId,
           runId: state.runId,
           channelInstallationId: surface.channelInstallationId,
-          larkMessageId,
-          larkCardId,
+          larkMessageId: binding.larkMessageId,
+          larkCardId: binding.larkCardId,
+          larkMessageUuid: binding.larkMessageUuid,
         });
         continue;
       }
@@ -688,46 +762,33 @@ export function createLarkOutboundRuntime(
       });
       const rendered = buildLarkRenderedSubagentCreationRequestCard(entry.state);
 
-      if (existing?.larkCardId == null) {
-        const createResp = await cardkit.card.create({
-          data: {
-            type: "card_json",
-            data: JSON.stringify(rendered.card),
-          },
-        });
-        const larkCardId = createResp.data?.card_id ?? createResp.card_id ?? null;
-        if (larkCardId == null) {
-          continue;
-        }
-
-        const response = (await sendLarkInteractiveCardReferenceMessage({
+      if (existing?.larkCardId == null || existing.larkMessageId == null) {
+        const binding = await ensureInteractiveCardReferenceBinding({
+          bindingsRepo,
           client,
-          chatId,
-          surfaceObject,
-          larkCardId,
-        })) as { data?: { message_id?: string; open_message_id?: string } };
-        const larkMessageId = response.data?.message_id ?? null;
-        if (larkMessageId == null) {
-          continue;
-        }
-
-        bindingsRepo.upsert({
-          id: randomUUID(),
+          cardkit,
           channelInstallationId: surface.channelInstallationId,
           conversationId: entry.conversationId,
           branchId: entry.branchId,
           internalObjectKind: SUBAGENT_REQUEST_CARD_OBJECT_KIND,
           internalObjectId: requestId,
-          larkMessageId,
-          larkOpenMessageId: response.data?.open_message_id ?? null,
-          larkCardId,
+          chatId,
+          surfaceObject,
+          cardJson: JSON.stringify(rendered.card),
           lastSequence: 0,
           status: entry.state.status === "pending" ? "active" : "finalized",
           metadataJson: JSON.stringify({
             requestId,
             status: entry.state.status,
           }),
+          logContext: {
+            requestId,
+            status: entry.state.status,
+          },
         });
+        if (binding == null) {
+          continue;
+        }
         continue;
       }
 
@@ -1158,7 +1219,8 @@ async function sendLarkInteractiveCardReferenceMessage(input: {
   chatId: string;
   surfaceObject: Record<string, unknown>;
   larkCardId: string;
-}): Promise<unknown> {
+  larkMessageUuid?: string | null;
+}): Promise<LarkInteractiveMessageResponse> {
   const threadReplyMessageId = readStringValue(input.surfaceObject.reply_to_message_id);
   const content = JSON.stringify({
     type: "card",
@@ -1174,8 +1236,9 @@ async function sendLarkInteractiveCardReferenceMessage(input: {
         msg_type: "interactive",
         content,
         reply_in_thread: true,
+        ...(input.larkMessageUuid == null ? {} : { uuid: input.larkMessageUuid }),
       },
-    });
+    }) as Promise<LarkInteractiveMessageResponse>;
   }
 
   return input.client.sdk.im.message.create({
@@ -1184,8 +1247,9 @@ async function sendLarkInteractiveCardReferenceMessage(input: {
       receive_id: input.chatId,
       msg_type: "interactive",
       content,
+      ...(input.larkMessageUuid == null ? {} : { uuid: input.larkMessageUuid }),
     },
-  });
+  }) as Promise<LarkInteractiveMessageResponse>;
 }
 
 function readStringValue(value: unknown): string | null {

--- a/src/storage/db/init.ts
+++ b/src/storage/db/init.ts
@@ -20,6 +20,7 @@ export function initSchemaIfNeeded(
   sqlite.exec(initSql);
   upgradeCronJobsSchema(sqlite);
   upgradeMessagesSchema(sqlite);
+  upgradeLarkObjectBindingsSchema(sqlite);
 }
 
 function upgradeCronJobsSchema(sqlite: Database.Database): void {
@@ -57,5 +58,24 @@ function upgradeMessagesSchema(sqlite: Database.Database): void {
       ON messages(channel_parent_message_id);
     CREATE INDEX IF NOT EXISTS idx_messages_channel_thread
       ON messages(channel_thread_id);
+  `);
+}
+
+function upgradeLarkObjectBindingsSchema(sqlite: Database.Database): void {
+  const larkObjectBindingColumns = new Set(
+    (
+      sqlite.prepare("PRAGMA table_info(lark_object_bindings)").all() as Array<{
+        name: string;
+      }>
+    ).map((column) => column.name),
+  );
+
+  if (!larkObjectBindingColumns.has("lark_message_uuid")) {
+    sqlite.exec("ALTER TABLE lark_object_bindings ADD COLUMN lark_message_uuid TEXT");
+  }
+
+  sqlite.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS uidx_lark_object_bindings_message_uuid
+      ON lark_object_bindings(channel_installation_id, lark_message_uuid);
   `);
 }

--- a/src/storage/migrate/files/0001_init.sql
+++ b/src/storage/migrate/files/0001_init.sql
@@ -244,6 +244,7 @@ CREATE TABLE IF NOT EXISTS lark_object_bindings (
   branch_id TEXT NOT NULL REFERENCES conversation_branches(id) ON DELETE CASCADE,
   internal_object_kind TEXT NOT NULL,
   internal_object_id TEXT NOT NULL,
+  lark_message_uuid TEXT,
   lark_message_id TEXT,
   lark_open_message_id TEXT,
   lark_card_id TEXT,
@@ -256,6 +257,7 @@ CREATE TABLE IF NOT EXISTS lark_object_bindings (
   created_at TEXT NOT NULL CHECK (created_at GLOB '????-??-??T??:??:??*Z' AND datetime(created_at) IS NOT NULL),
   updated_at TEXT NOT NULL CHECK (updated_at GLOB '????-??-??T??:??:??*Z' AND datetime(updated_at) IS NOT NULL),
   UNIQUE(channel_installation_id, internal_object_kind, internal_object_id),
+  UNIQUE(channel_installation_id, lark_message_uuid),
   UNIQUE(channel_installation_id, lark_message_id),
   UNIQUE(channel_installation_id, lark_open_message_id),
   UNIQUE(channel_installation_id, lark_card_id)

--- a/src/storage/repos/lark-object-bindings.repo.ts
+++ b/src/storage/repos/lark-object-bindings.repo.ts
@@ -8,6 +8,8 @@ import type { LarkObjectBinding, NewLarkObjectBinding } from "@/src/storage/sche
 
 const logger = createSubsystemLogger("storage/lark-object-bindings");
 
+type LarkObjectBindingStatus = "active" | "finalized" | "stale";
+
 export interface UpsertLarkObjectBindingInput {
   id: string;
   channelInstallationId: string;
@@ -15,16 +17,52 @@ export interface UpsertLarkObjectBindingInput {
   branchId: string;
   internalObjectKind: string;
   internalObjectId: string;
-  larkMessageId?: string | null;
-  larkOpenMessageId?: string | null;
-  larkCardId?: string | null;
-  threadRootMessageId?: string | null;
-  cardElementId?: string | null;
-  lastSequence?: number | null;
-  status?: "active" | "finalized" | "stale";
-  metadataJson?: string | null;
-  createdAt?: Date;
-  updatedAt?: Date;
+  larkMessageUuid?: string | null | undefined;
+  larkMessageId?: string | null | undefined;
+  larkOpenMessageId?: string | null | undefined;
+  larkCardId?: string | null | undefined;
+  threadRootMessageId?: string | null | undefined;
+  cardElementId?: string | null | undefined;
+  lastSequence?: number | null | undefined;
+  status?: LarkObjectBindingStatus | undefined;
+  metadataJson?: string | null | undefined;
+  createdAt?: Date | undefined;
+  updatedAt?: Date | undefined;
+}
+
+export interface ReserveLarkObjectBindingInput {
+  id: string;
+  channelInstallationId: string;
+  conversationId: string;
+  branchId: string;
+  internalObjectKind: string;
+  internalObjectId: string;
+  larkMessageUuid?: string | null | undefined;
+  threadRootMessageId?: string | null | undefined;
+  cardElementId?: string | null | undefined;
+  lastSequence?: number | null | undefined;
+  status?: LarkObjectBindingStatus | undefined;
+  metadataJson?: string | null | undefined;
+  createdAt?: Date | undefined;
+  updatedAt?: Date | undefined;
+}
+
+export interface PatchLarkObjectBindingInput {
+  channelInstallationId: string;
+  internalObjectKind: string;
+  internalObjectId: string;
+  conversationId?: string | undefined;
+  branchId?: string | undefined;
+  larkMessageUuid?: string | null | undefined;
+  larkMessageId?: string | null | undefined;
+  larkOpenMessageId?: string | null | undefined;
+  larkCardId?: string | null | undefined;
+  threadRootMessageId?: string | null | undefined;
+  cardElementId?: string | null | undefined;
+  lastSequence?: number | null | undefined;
+  status?: LarkObjectBindingStatus | undefined;
+  metadataJson?: string | null | undefined;
+  updatedAt?: Date | undefined;
 }
 
 export class LarkObjectBindingsRepo {
@@ -40,6 +78,7 @@ export class LarkObjectBindingsRepo {
       branchId: input.branchId,
       internalObjectKind: input.internalObjectKind,
       internalObjectId: input.internalObjectId,
+      larkMessageUuid: input.larkMessageUuid ?? null,
       larkMessageId: input.larkMessageId ?? null,
       larkOpenMessageId: input.larkOpenMessageId ?? null,
       larkCardId: input.larkCardId ?? null,
@@ -57,6 +96,7 @@ export class LarkObjectBindingsRepo {
       channelInstallationId: input.channelInstallationId,
       internalObjectKind: input.internalObjectKind,
       internalObjectId: input.internalObjectId,
+      larkMessageUuid: input.larkMessageUuid,
       larkMessageId: input.larkMessageId,
       larkCardId: input.larkCardId,
     });
@@ -73,6 +113,7 @@ export class LarkObjectBindingsRepo {
         set: {
           conversationId: row.conversationId,
           branchId: row.branchId,
+          ...(input.larkMessageUuid === undefined ? {} : { larkMessageUuid: row.larkMessageUuid }),
           larkMessageId: row.larkMessageId,
           larkOpenMessageId: row.larkOpenMessageId,
           larkCardId: row.larkCardId,
@@ -99,12 +140,173 @@ export class LarkObjectBindingsRepo {
       channelInstallationId: binding.channelInstallationId,
       internalObjectKind: binding.internalObjectKind,
       internalObjectId: binding.internalObjectId,
+      larkMessageUuid: binding.larkMessageUuid,
       larkMessageId: binding.larkMessageId,
       larkCardId: binding.larkCardId,
       status: binding.status,
     });
 
     return binding;
+  }
+
+  reserveBinding(input: ReserveLarkObjectBindingInput): LarkObjectBinding {
+    const existing = this.getByInternalObject({
+      channelInstallationId: input.channelInstallationId,
+      internalObjectKind: input.internalObjectKind,
+      internalObjectId: input.internalObjectId,
+    });
+
+    if (existing == null) {
+      return this.upsert({
+        id: input.id,
+        channelInstallationId: input.channelInstallationId,
+        conversationId: input.conversationId,
+        branchId: input.branchId,
+        internalObjectKind: input.internalObjectKind,
+        internalObjectId: input.internalObjectId,
+        larkMessageUuid: input.larkMessageUuid ?? null,
+        threadRootMessageId: input.threadRootMessageId,
+        cardElementId: input.cardElementId,
+        lastSequence: input.lastSequence,
+        status: input.status,
+        metadataJson: input.metadataJson,
+        createdAt: input.createdAt,
+        updatedAt: input.updatedAt,
+      });
+    }
+
+    return (
+      this.patchByInternalObject({
+        channelInstallationId: input.channelInstallationId,
+        internalObjectKind: input.internalObjectKind,
+        internalObjectId: input.internalObjectId,
+        conversationId: input.conversationId,
+        branchId: input.branchId,
+        larkMessageUuid: existing.larkMessageUuid ?? input.larkMessageUuid ?? null,
+        threadRootMessageId: input.threadRootMessageId,
+        cardElementId: input.cardElementId,
+        lastSequence: input.lastSequence,
+        status: input.status,
+        metadataJson: input.metadataJson,
+        updatedAt: input.updatedAt,
+      }) ?? existing
+    );
+  }
+
+  attachCardAnchor(
+    input: PatchLarkObjectBindingInput & {
+      larkCardId: string;
+    },
+  ): LarkObjectBinding | null {
+    const existing = this.getByInternalObject({
+      channelInstallationId: input.channelInstallationId,
+      internalObjectKind: input.internalObjectKind,
+      internalObjectId: input.internalObjectId,
+    });
+    if (existing == null) {
+      return null;
+    }
+
+    return this.patchByInternalObject({
+      channelInstallationId: input.channelInstallationId,
+      internalObjectKind: input.internalObjectKind,
+      internalObjectId: input.internalObjectId,
+      conversationId: input.conversationId,
+      branchId: input.branchId,
+      larkMessageUuid: existing.larkMessageUuid ?? input.larkMessageUuid,
+      larkCardId: existing.larkCardId ?? input.larkCardId,
+      threadRootMessageId: existing.threadRootMessageId ?? input.threadRootMessageId,
+      cardElementId: input.cardElementId,
+      lastSequence: input.lastSequence,
+      status: input.status,
+      metadataJson: input.metadataJson,
+      updatedAt: input.updatedAt,
+    });
+  }
+
+  attachMessageAnchor(
+    input: PatchLarkObjectBindingInput & {
+      larkMessageId: string;
+    },
+  ): LarkObjectBinding | null {
+    const existing = this.getByInternalObject({
+      channelInstallationId: input.channelInstallationId,
+      internalObjectKind: input.internalObjectKind,
+      internalObjectId: input.internalObjectId,
+    });
+    if (existing == null) {
+      return null;
+    }
+
+    return this.patchByInternalObject({
+      channelInstallationId: input.channelInstallationId,
+      internalObjectKind: input.internalObjectKind,
+      internalObjectId: input.internalObjectId,
+      conversationId: input.conversationId,
+      branchId: input.branchId,
+      larkMessageUuid: existing.larkMessageUuid ?? input.larkMessageUuid,
+      larkMessageId: existing.larkMessageId ?? input.larkMessageId,
+      larkOpenMessageId: existing.larkOpenMessageId ?? input.larkOpenMessageId,
+      larkCardId: existing.larkCardId ?? input.larkCardId,
+      threadRootMessageId: existing.threadRootMessageId ?? input.threadRootMessageId,
+      cardElementId: input.cardElementId,
+      lastSequence: input.lastSequence,
+      status: input.status,
+      metadataJson: input.metadataJson,
+      updatedAt: input.updatedAt,
+    });
+  }
+
+  patchByInternalObject(input: PatchLarkObjectBindingInput): LarkObjectBinding | null {
+    const updatedAt = input.updatedAt ?? new Date();
+    const result = this.db
+      .update(larkObjectBindings)
+      .set({
+        ...(input.conversationId === undefined ? {} : { conversationId: input.conversationId }),
+        ...(input.branchId === undefined ? {} : { branchId: input.branchId }),
+        ...(input.larkMessageUuid === undefined ? {} : { larkMessageUuid: input.larkMessageUuid }),
+        ...(input.larkMessageId === undefined ? {} : { larkMessageId: input.larkMessageId }),
+        ...(input.larkOpenMessageId === undefined
+          ? {}
+          : { larkOpenMessageId: input.larkOpenMessageId }),
+        ...(input.larkCardId === undefined ? {} : { larkCardId: input.larkCardId }),
+        ...(input.threadRootMessageId === undefined
+          ? {}
+          : { threadRootMessageId: input.threadRootMessageId }),
+        ...(input.cardElementId === undefined ? {} : { cardElementId: input.cardElementId }),
+        ...(input.lastSequence === undefined ? {} : { lastSequence: input.lastSequence }),
+        ...(input.status === undefined ? {} : { status: input.status }),
+        ...(input.metadataJson === undefined ? {} : { metadataJson: input.metadataJson }),
+        updatedAt: toCanonicalUtcIsoTimestamp(updatedAt),
+      })
+      .where(
+        and(
+          eq(larkObjectBindings.channelInstallationId, input.channelInstallationId),
+          eq(larkObjectBindings.internalObjectKind, input.internalObjectKind),
+          eq(larkObjectBindings.internalObjectId, input.internalObjectId),
+        ),
+      )
+      .run();
+
+    if ((result.changes ?? 0) < 1) {
+      return null;
+    }
+
+    logger.debug("patched lark object binding", {
+      channelInstallationId: input.channelInstallationId,
+      internalObjectKind: input.internalObjectKind,
+      internalObjectId: input.internalObjectId,
+      larkMessageUuid: input.larkMessageUuid,
+      larkMessageId: input.larkMessageId,
+      larkCardId: input.larkCardId,
+      status: input.status,
+    });
+
+    return this.getByInternalObject({
+      channelInstallationId: input.channelInstallationId,
+      internalObjectKind: input.internalObjectKind,
+      internalObjectId: input.internalObjectId,
+    });
   }
 
   getByInternalObject(input: {
@@ -213,7 +415,7 @@ export class LarkObjectBindingsRepo {
     internalObjectKind: string;
     internalObjectId: string;
     lastSequence?: number | null;
-    status?: "active" | "finalized" | "stale";
+    status?: LarkObjectBindingStatus;
     metadataJson?: string | null;
     updatedAt?: Date;
   }): LarkObjectBinding | null {

--- a/src/storage/schema/tables.ts
+++ b/src/storage/schema/tables.ts
@@ -418,6 +418,7 @@ export const larkObjectBindings = sqliteTable(
       .references(() => conversationBranches.id, { onDelete: "cascade" }),
     internalObjectKind: text("internal_object_kind").notNull(),
     internalObjectId: text("internal_object_id").notNull(),
+    larkMessageUuid: text("lark_message_uuid"),
     larkMessageId: text("lark_message_id"),
     larkOpenMessageId: text("lark_open_message_id"),
     larkCardId: text("lark_card_id"),
@@ -434,6 +435,10 @@ export const larkObjectBindings = sqliteTable(
       table.channelInstallationId,
       table.internalObjectKind,
       table.internalObjectId,
+    ),
+    uniqueIndex("uidx_lark_object_bindings_message_uuid").on(
+      table.channelInstallationId,
+      table.larkMessageUuid,
     ),
     uniqueIndex("uidx_lark_object_bindings_message").on(
       table.channelInstallationId,

--- a/tests/channels/lark/outbound-pagination.test.ts
+++ b/tests/channels/lark/outbound-pagination.test.ts
@@ -256,6 +256,9 @@ describe("lark outbound pagination", () => {
 
     expect(createCard.mock.calls.length).toBeGreaterThan(1);
     expect(createMessage).toHaveBeenCalledTimes(createCard.mock.calls.length);
+    for (const call of createMessage.mock.calls as unknown[][]) {
+      expect((call[0] as { data?: { uuid?: string } }).data?.uuid).toEqual(expect.any(String));
+    }
 
     const createdCards = (createCard.mock.calls as unknown[][]).map((call) =>
       parseCardPayload(call[0]),

--- a/tests/channels/lark/outbound.test.ts
+++ b/tests/channels/lark/outbound.test.ts
@@ -330,6 +330,7 @@ describe("lark outbound runtime", () => {
       internalObjectKind: "run_card",
       internalObjectId: "run_1:seg:1",
     });
+    expect(binding?.larkMessageUuid).toBeTruthy();
     expect(binding?.larkMessageId).toBe("om_card_1");
     expect(binding?.larkCardId).toBe("card_1");
 
@@ -393,6 +394,154 @@ describe("lark outbound runtime", () => {
       path: { card_id: "card_1" },
     });
 
+    await runtime.shutdown();
+  });
+
+  test("retries run-card visible message send with the same uuid after local finalize failure", async () => {
+    vi.useFakeTimers();
+    handle = await createTestDatabase(import.meta.url);
+    handle.storage.sqlite.exec(`
+      INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+      VALUES ('ci_lark_default', 'lark', 'default', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+      VALUES ('conv_1', 'ci_lark_default', 'oc_chat_1', 'dm', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+      VALUES ('branch_1', 'conv_1', 'dm_main', 'main', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+    `);
+
+    new ChannelSurfacesRepo(handle.storage.db).upsert({
+      id: "surface_1",
+      channelType: "lark",
+      channelInstallationId: "default",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      surfaceKey: "chat:oc_chat_1",
+      surfaceObjectJson: JSON.stringify({ chat_id: "oc_chat_1" }),
+    });
+
+    const createCard = vi.fn(async () => ({ data: { card_id: "card_retry_1" } }));
+    let sendCount = 0;
+    const createMessage = vi.fn(async (_input: unknown) => {
+      sendCount += 1;
+      return {
+        data: {
+          message_id: "om_retry_1",
+          open_message_id: "open_retry_1",
+        },
+      };
+    });
+    const updateCard = vi.fn(async () => ({}));
+    const streamContent = vi.fn(async () => ({}));
+    const originalAttachMessageAnchor = LarkObjectBindingsRepo.prototype.attachMessageAnchor;
+    const attachMessageAnchor = vi
+      .spyOn(LarkObjectBindingsRepo.prototype, "attachMessageAnchor")
+      .mockImplementation(function (this: LarkObjectBindingsRepo, input) {
+        if (sendCount === 1) {
+          return null;
+        }
+        return originalAttachMessageAnchor.call(this, input);
+      });
+
+    const bus = new RuntimeEventBus<OrchestratedOutboundEventEnvelope>();
+    const runtime = createLarkOutboundRuntime({
+      storage: handle.storage.db,
+      outboundEventBus: bus,
+      clients: {
+        getOrCreate: () =>
+          ({
+            sdk: {
+              cardkit: {
+                v1: {
+                  card: {
+                    create: createCard,
+                    update: updateCard,
+                  },
+                  cardElement: {
+                    content: streamContent,
+                  },
+                },
+              },
+              im: {
+                message: {
+                  create: createMessage,
+                },
+              },
+            },
+          }) as never,
+      },
+    });
+
+    runtime.start();
+    bus.publish(
+      makeEnvelope({
+        type: "assistant_message_completed",
+        eventId: "evt_retry_1",
+        createdAt: "2026-03-28T00:00:00.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_retry_1",
+        turn: 1,
+        messageId: "msg_retry_1",
+        text: "retry me",
+        reasoningText: null,
+        toolCalls: [],
+        usage: null,
+      }),
+    );
+
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(createCard).toHaveBeenCalledOnce();
+    expect(createMessage).toHaveBeenCalledOnce();
+
+    const firstUuid = (createMessage.mock.calls[0]?.[0] as { data?: { uuid?: string } } | undefined)
+      ?.data?.uuid;
+    expect(firstUuid).toBeTruthy();
+
+    bus.publish(
+      makeEnvelope({
+        type: "assistant_message_completed",
+        eventId: "evt_retry_2",
+        createdAt: "2026-03-28T00:00:01.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_retry_1",
+        turn: 2,
+        messageId: "msg_retry_2",
+        text: "retry me again",
+        reasoningText: null,
+        toolCalls: [],
+        usage: null,
+      }),
+    );
+
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(createCard).toHaveBeenCalledOnce();
+    expect(createMessage).toHaveBeenCalledTimes(2);
+    const secondUuid = (
+      createMessage.mock.calls[1]?.[0] as { data?: { uuid?: string } } | undefined
+    )?.data?.uuid;
+    expect(secondUuid).toBe(firstUuid);
+
+    const binding = new LarkObjectBindingsRepo(handle.storage.db).getByInternalObject({
+      channelInstallationId: "default",
+      internalObjectKind: "run_card",
+      internalObjectId: "run_1:seg:1",
+    });
+    expect(binding).toMatchObject({
+      larkMessageUuid: firstUuid,
+      larkMessageId: "om_retry_1",
+      larkCardId: "card_retry_1",
+    });
+
+    attachMessageAnchor.mockRestore();
     await runtime.shutdown();
   });
 
@@ -509,6 +658,7 @@ describe("lark outbound runtime", () => {
         data: {
           msg_type: "interactive",
           reply_in_thread: true,
+          uuid: expect.any(String),
         },
       },
     );

--- a/tests/storage/lark-object-bindings.repo.test.ts
+++ b/tests/storage/lark-object-bindings.repo.test.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import { afterEach, describe, expect, test } from "vitest";
 
 import { LarkObjectBindingsRepo } from "@/src/storage/repos/lark-object-bindings.repo.js";
@@ -55,6 +57,7 @@ describe("lark object bindings repo", () => {
       channelInstallationId: "lark_install_1",
       internalObjectKind: "task_run",
       internalObjectId: "run_1",
+      larkMessageUuid: null,
       larkMessageId: "om_message_1",
       larkCardId: "card_1",
       threadRootMessageId: "om_root_1",
@@ -90,6 +93,94 @@ describe("lark object bindings repo", () => {
     ).toMatchObject({
       id: "lark_binding_1",
       internalObjectId: "run_1",
+    });
+  });
+
+  test("reserves a stable message uuid and preserves anchors across partial delivery updates", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedFixture(handle);
+
+    const repo = new LarkObjectBindingsRepo(handle.storage.db);
+    const reserved = repo.reserveBinding({
+      id: "lark_binding_reserved_1",
+      channelInstallationId: "lark_install_1",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      internalObjectKind: "run_card",
+      internalObjectId: "run_retry_1",
+      larkMessageUuid: randomUUID(),
+      status: "active",
+      metadataJson: '{"phase":"reserved"}',
+    });
+
+    expect(reserved.larkMessageUuid).toBeTruthy();
+    expect(reserved.larkCardId).toBeNull();
+    expect(reserved.larkMessageId).toBeNull();
+
+    const reservedAgain = repo.reserveBinding({
+      id: "lark_binding_reserved_2",
+      channelInstallationId: "lark_install_1",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      internalObjectKind: "run_card",
+      internalObjectId: "run_retry_1",
+      larkMessageUuid: randomUUID(),
+      status: "active",
+      metadataJson: '{"phase":"reserved-again"}',
+    });
+
+    expect(reservedAgain.id).toBe(reserved.id);
+    expect(reservedAgain.larkMessageUuid).toBe(reserved.larkMessageUuid);
+
+    const withCard = repo.attachCardAnchor({
+      channelInstallationId: "lark_install_1",
+      internalObjectKind: "run_card",
+      internalObjectId: "run_retry_1",
+      larkCardId: "card_retry_1",
+      status: "active",
+      metadataJson: '{"phase":"card"}',
+    });
+    expect(withCard).toMatchObject({
+      id: reserved.id,
+      larkMessageUuid: reserved.larkMessageUuid,
+      larkCardId: "card_retry_1",
+      larkMessageId: null,
+    });
+
+    const withMessage = repo.attachMessageAnchor({
+      channelInstallationId: "lark_install_1",
+      internalObjectKind: "run_card",
+      internalObjectId: "run_retry_1",
+      larkMessageId: "om_retry_1",
+      larkOpenMessageId: "open_retry_1",
+      larkCardId: "card_retry_2",
+      status: "finalized",
+      metadataJson: '{"phase":"message"}',
+    });
+    expect(withMessage).toMatchObject({
+      id: reserved.id,
+      larkMessageUuid: reserved.larkMessageUuid,
+      larkCardId: "card_retry_1",
+      larkMessageId: "om_retry_1",
+      larkOpenMessageId: "open_retry_1",
+      status: "finalized",
+    });
+
+    const repeatedMessageAttach = repo.attachMessageAnchor({
+      channelInstallationId: "lark_install_1",
+      internalObjectKind: "run_card",
+      internalObjectId: "run_retry_1",
+      larkMessageId: "om_retry_2",
+      larkOpenMessageId: "open_retry_2",
+      status: "finalized",
+      metadataJson: '{"phase":"message-repeat"}',
+    });
+    expect(repeatedMessageAttach).toMatchObject({
+      id: reserved.id,
+      larkMessageUuid: reserved.larkMessageUuid,
+      larkCardId: "card_retry_1",
+      larkMessageId: "om_retry_1",
+      larkOpenMessageId: "open_retry_1",
     });
   });
 


### PR DESCRIPTION
## Problem
- in Feishu/Lark, the same scheduled task could sometimes produce two visible run cards for what should be a single run
- one of the cards stayed permanently in the running state, while the later card continued updating and eventually showed the final result
- this left users with a stale orphan card in the conversation and made task progress look duplicated and inconsistent

## Summary
- persist a Lark-specific message UUID in object bindings so visible interactive card sends can be retried idempotently
- refactor Lark outbound delivery to reserve bindings before create/send and reuse the same recovery path for run, approval, and subagent cards
- add regression coverage for binding reservation, retry recovery, thread replies, and paginated run card delivery

## Test plan
- [x] pnpm build
- [x] pnpm format
- [x] pnpm lint
- [x] pnpm test