### PR TITLE
Add harness stop events and retry empty replies

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,60 +43,51 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
             LANGUAGE: TypeScript
-            REPO STAGE: Early implementation, design-doc-driven architecture
             </pr_context>
 
             <project_context>
-            Consult the repository guidance before reviewing:
+            Consult repository guidance before reviewing:
             - .claude/CLAUDE.md
-            - design-docs/dev-plan.md
-            - design-docs/tech-decisions.md
-            - design-docs/product-principles.md
+            - any touched docs, design docs, or README files that are directly relevant to the changed code
 
-            Important repository constraints:
-            - The system must preserve the dependency order: Foundation -> Persistence -> Agent runtime -> Security/execution -> Orchestration -> Messaging adaptation -> Feishu channel -> Built-in capabilities -> End-to-end hardening.
-            - Feishu/Lark-specific behavior must not leak into lower runtime or persistence abstractions unless the boundary is explicitly channel-specific.
-            - Runtime state belongs in SQLite; global defaults belong in config; secrets belong in secrets handling.
-            - TypeScript is intentionally strict and explicit any should be treated as a real issue.
-            - Avoid unnecessary abstractions and avoid adding service seams like logger/time injection unless there is a concrete production need.
+            Respect repo-specific constraints and conventions, but keep the review general and practical rather than overfitting to any single architecture document.
             </project_context>
 
             <review_instructions>
-            Review this pull request and report only merge-relevant issues and meaningful architectural risks.
+            Review this pull request and report only merge-relevant issues.
 
-            Prioritize findings in this order:
-            1. Architecture layering violations
-               - changes that skip the intended build order from design-docs/dev-plan.md
-               - Feishu/Lark-specific logic leaking into runtime, orchestration, storage, or other lower layers
-               - messaging adaptation boundaries being bypassed
+            Focus on these areas, in this order:
+            1. Functional correctness
+               - whether the intended behavior is implemented correctly
+               - whether the end-to-end flow can actually work, not just isolated pieces
+               - whether there are missing edge cases, broken integrations, or incorrect state transitions
 
-            2. Config, secrets, and storage boundary violations
-               - runtime or instance state incorrectly moved into config files
-               - secrets handled in the wrong layer
-               - violations of the repo's config/secrets/SQLite split
+            2. Engineering and design quality
+               - whether the design is sufficiently complete and robust for the scope of the change
+               - whether there are meaningful security, reliability, or performance risks
+               - whether important failure modes, data consistency issues, or operational concerns were missed
 
-            3. Agent/runtime model correctness
-               - Main Agent, SubAgent, and TaskAgent responsibilities getting mixed together
-               - regressions to observability, interruptibility, or permission control
-               - changes that break task/thread/context isolation expectations
+            3. Code quality and maintainability
+               - whether the structure is clear and appropriately modular
+               - whether the change introduces unnecessary coupling, fragile logic, or obvious technical debt
+               - whether abstractions are appropriate for current needs without being over-engineered
 
-            4. TypeScript safety and maintainability
-               - explicit any or weakly typed boundaries
-               - unsafe assumptions hidden behind casts
-               - premature abstractions or over-engineering that conflict with current repo guidance
-               - test-only seams leaking into production interfaces
+            4. Tests, docs, and change clarity
+               - whether important behavior changes have adequate test coverage
+               - whether necessary comments, documentation, or migration/change notes were added where needed
+               - whether the change is understandable enough for future maintainers to debug and extend
 
-            5. Security, correctness, and tests
-               - unsafe trust boundaries, injection risks, or secret exposure
-               - missing or incorrect handling for meaningful edge cases
-               - missing regression coverage for non-trivial behavior changes
-               - changes that weaken the repo's stated real-LLM integration test discipline
+            Output format:
+            - Write the final review as a numbered list ordered by priority.
+            - Each numbered item should contain one review conclusion or issue.
+            - If there are multiple issues, put the highest-priority items first.
+            - If there are no meaningful issues, say so briefly.
 
             Review style:
-            - Use concise bullet points.
-            - Explain what is wrong, why it matters in this repo, and the concrete fix direction.
-            - Do not report style nits or speculative improvements.
-            - If no meaningful issues are found, say so briefly.
+            - Use concise, practical review comments.
+            - For each finding, explain what is wrong, why it matters, and the concrete fix direction.
+            - Do not report minor style nits or speculative nice-to-haves.
+            - Keep the review practical and decision-oriented.
 
             Use gh pr comment to post the review.
             </review_instructions>

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -746,6 +746,30 @@ export class AgentLoop {
         const assistantText = collectAssistantText(response.content);
         const reasoningText = collectAssistantThinking(response.content);
         const toolCalls = collectAgentToolCalls(response.content);
+        const successfulEmptyOutputRetry = shouldRetrySuccessfulEmptyAssistantOutput({
+          assistantText,
+          reasoningText,
+          toolCallsRequested: toolCalls.length,
+          sawStreamedText,
+          sawStreamedReasoning,
+          retryCount: emptyOutputRetryCount,
+        });
+        if (successfulEmptyOutputRetry) {
+          emptyOutputRetryCount += 1;
+          logger.warn("retrying assistant response after successful empty output", {
+            sessionId: input.sessionId,
+            conversationId: context.session.conversationId,
+            branchId: context.session.branchId,
+            scenario: input.scenario,
+            turn: turn + 1,
+            runId,
+            assistantMessageId,
+            modelId: model.id,
+            retryAttempt: emptyOutputRetryCount,
+            retryLimit: EMPTY_OUTPUT_LLM_RETRY_LIMIT,
+          });
+          continue;
+        }
         // Some runners will stream deltas incrementally, others may only return
         // the final assistant payload. We keep one event shape and only fall back
         // to a single full-text delta if nothing was streamed.
@@ -1730,6 +1754,29 @@ function appendMessageAndHydrate(input: {
     usageJson: input.usage == null ? null : JSON.stringify(input.usage),
     createdAt: input.createdAt.toISOString(),
   };
+}
+
+function shouldRetrySuccessfulEmptyAssistantOutput(input: {
+  assistantText: string;
+  reasoningText: string;
+  toolCallsRequested: number;
+  sawStreamedText: boolean;
+  sawStreamedReasoning: boolean;
+  retryCount: number;
+}): boolean {
+  if (
+    input.retryCount >= EMPTY_OUTPUT_LLM_RETRY_LIMIT ||
+    input.sawStreamedText ||
+    input.sawStreamedReasoning
+  ) {
+    return false;
+  }
+
+  return (
+    input.assistantText.length === 0 &&
+    input.reasoningText.length === 0 &&
+    input.toolCallsRequested === 0
+  );
 }
 
 function getRetryableLlmFailureWithoutVisibleOutput(input: {

--- a/src/channels/lark/inbound.ts
+++ b/src/channels/lark/inbound.ts
@@ -361,6 +361,8 @@ export function createLarkMessageReceiveHandler(input: {
                 hydrated.senderOpenId == null
                   ? `lark:${input.installationId}:unknown`
                   : `lark:${input.installationId}:${hydrated.senderOpenId}`,
+              sourceKind: "command",
+              requestScope: "conversation",
               reasonText: "stop requested from lark command",
             })
           : input.control.stopSession({
@@ -369,6 +371,8 @@ export function createLarkMessageReceiveHandler(input: {
                 hydrated.senderOpenId == null
                   ? `lark:${input.installationId}:unknown`
                   : `lark:${input.installationId}:${hydrated.senderOpenId}`,
+              sourceKind: "command",
+              requestScope: "session",
               reasonText: "stop requested from lark command",
             });
       logger.info("processed lark stop command", {
@@ -656,6 +660,8 @@ export function createLarkCardActionHandler(input: {
           normalized.actorOpenId == null
             ? `lark:${input.installationId}:unknown`
             : `lark:${input.installationId}:${normalized.actorOpenId}`,
+        sourceKind: "button",
+        requestScope: "run",
         reasonText: "stop requested from lark card action",
       });
 

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -34,8 +34,10 @@ import {
 import { RuntimeStatusService } from "@/src/runtime/status.js";
 import { createSubsystemLogger } from "@/src/shared/logger.js";
 import type { StorageDb } from "@/src/storage/db/client.js";
+import { HarnessEventsRepo } from "@/src/storage/repos/harness-events.repo.js";
 import { MessagesRepo } from "@/src/storage/repos/messages.repo.js";
 import { SessionsRepo } from "@/src/storage/repos/sessions.repo.js";
+import { TaskRunsRepo } from "@/src/storage/repos/task-runs.repo.js";
 import { createBuiltinToolRegistry } from "@/src/tools/builtins.js";
 
 const logger = createSubsystemLogger("runtime-bootstrap");
@@ -70,7 +72,11 @@ export function createRuntimeBootstrap(input: CreateRuntimeBootstrapInput): Runt
   const bridge = createRuntimeOrchestrationBridge();
   const outboundEventBus = new RuntimeEventBus<OrchestratedOutboundEventEnvelope>();
   const cancel = new SessionRunAbortRegistry();
-  const control = new RuntimeControlService(cancel);
+  const control = new RuntimeControlService(cancel, {
+    harnessEvents: new HarnessEventsRepo(input.storage),
+    sessions,
+    taskRuns: new TaskRunsRepo(input.storage),
+  });
   const models = new ProviderRegistry(input.config);
   const providerApiKeyResolver = new CodexProviderApiKeyResolver();
   const status = new RuntimeStatusService({

--- a/src/runtime/control.ts
+++ b/src/runtime/control.ts
@@ -474,6 +474,10 @@ export class RuntimeControlService {
     this.observabilityByRunId.set(runId, updater(existing));
   }
 
+  /**
+   * Persist the explicit stop fact for the concrete active run that was
+   * actually cancelled. Canonical semantics live with the harness_events schema.
+   */
   private recordHarnessStopEvent(
     run: ActiveRunRecord,
     input: StopRunInput | StopSessionInput | StopConversationInput,

--- a/src/runtime/control.ts
+++ b/src/runtime/control.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 /**
  * Runtime control-plane service for active runs.
  *
@@ -21,8 +23,20 @@ import {
   toRunLiveObservabilitySnapshot,
 } from "@/src/runtime/run-observability.js";
 import { createSubsystemLogger } from "@/src/shared/logger.js";
+import type { HarnessEventsRepo } from "@/src/storage/repos/harness-events.repo.js";
+import type { SessionsRepo } from "@/src/storage/repos/sessions.repo.js";
+import type { TaskRunsRepo } from "@/src/storage/repos/task-runs.repo.js";
 
 const logger = createSubsystemLogger("runtime-control");
+
+export type HarnessStopSourceKind = "command" | "button";
+export type HarnessStopRequestScope = "run" | "session" | "conversation";
+
+export interface RuntimeControlPersistence {
+  harnessEvents: HarnessEventsRepo;
+  sessions: SessionsRepo;
+  taskRuns: TaskRunsRepo;
+}
 
 export interface ActiveRunRecord {
   runId: string;
@@ -35,18 +49,24 @@ export interface ActiveRunRecord {
 export interface StopRunInput {
   runId: string;
   actor: string;
+  sourceKind: HarnessStopSourceKind;
+  requestScope: HarnessStopRequestScope;
   reasonText?: string;
 }
 
 export interface StopConversationInput {
   conversationId: string;
   actor: string;
+  sourceKind: HarnessStopSourceKind;
+  requestScope: HarnessStopRequestScope;
   reasonText?: string;
 }
 
 export interface StopSessionInput {
   sessionId: string;
   actor: string;
+  sourceKind: HarnessStopSourceKind;
+  requestScope: HarnessStopRequestScope;
   reasonText?: string;
 }
 
@@ -75,7 +95,10 @@ export class RuntimeControlService {
   private readonly runsByRunId = new Map<string, ActiveRunRecord>();
   private readonly observabilityByRunId = new Map<string, RunLiveObservabilityState>();
 
-  constructor(private readonly cancel: SessionRunAbortRegistry) {}
+  constructor(
+    private readonly cancel: SessionRunAbortRegistry,
+    private readonly persistence?: RuntimeControlPersistence,
+  ) {}
 
   beginRun(input: ActiveRunRecord): void {
     this.runsByRunId.set(input.runId, input);
@@ -131,6 +154,9 @@ export class RuntimeControlService {
       run.sessionId,
       input.reasonText ?? `stop requested by ${input.actor}`,
     );
+    if (accepted) {
+      this.recordHarnessStopEvent(run, input);
+    }
     logger.info("processed stop run request", {
       runId: input.runId,
       sessionId: run.sessionId,
@@ -160,6 +186,7 @@ export class RuntimeControlService {
       );
       if (accepted) {
         stopped.push(run);
+        this.recordHarnessStopEvent(run, input);
       }
     }
 
@@ -191,6 +218,7 @@ export class RuntimeControlService {
       );
       if (accepted) {
         stopped.push(run);
+        this.recordHarnessStopEvent(run, input);
       }
     }
 
@@ -444,6 +472,33 @@ export class RuntimeControlService {
     }
 
     this.observabilityByRunId.set(runId, updater(existing));
+  }
+
+  private recordHarnessStopEvent(
+    run: ActiveRunRecord,
+    input: StopRunInput | StopSessionInput | StopConversationInput,
+  ): void {
+    if (this.persistence == null) {
+      return;
+    }
+
+    const taskRun = this.persistence.taskRuns.getByExecutionSessionId(run.sessionId);
+    const session = this.persistence.sessions.getById(run.sessionId);
+    this.persistence.harnessEvents.create({
+      id: randomUUID(),
+      eventType: "user_stop",
+      runId: run.runId,
+      sessionId: run.sessionId,
+      conversationId: run.conversationId,
+      branchId: run.branchId,
+      agentId: session?.ownerAgentId ?? taskRun?.ownerAgentId ?? null,
+      taskRunId: taskRun?.id ?? null,
+      cronJobId: taskRun?.cronJobId ?? null,
+      actor: input.actor,
+      sourceKind: input.sourceKind,
+      requestScope: input.requestScope,
+      reasonText: input.reasonText ?? null,
+    });
   }
 }
 

--- a/src/storage/db/init.ts
+++ b/src/storage/db/init.ts
@@ -20,6 +20,7 @@ export function initSchemaIfNeeded(
   sqlite.exec(initSql);
   upgradeCronJobsSchema(sqlite);
   upgradeMessagesSchema(sqlite);
+  upgradeHarnessEventsSchema(sqlite);
   upgradeLarkObjectBindingsSchema(sqlite);
 }
 
@@ -58,6 +59,39 @@ function upgradeMessagesSchema(sqlite: Database.Database): void {
       ON messages(channel_parent_message_id);
     CREATE INDEX IF NOT EXISTS idx_messages_channel_thread
       ON messages(channel_thread_id);
+  `);
+}
+
+function upgradeHarnessEventsSchema(sqlite: Database.Database): void {
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS harness_events (
+      id TEXT PRIMARY KEY,
+      event_type TEXT NOT NULL,
+      run_id TEXT NOT NULL,
+      session_id TEXT REFERENCES sessions(id) ON DELETE SET NULL,
+      conversation_id TEXT REFERENCES conversations(id) ON DELETE SET NULL,
+      branch_id TEXT REFERENCES conversation_branches(id) ON DELETE SET NULL,
+      agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
+      task_run_id TEXT REFERENCES task_runs(id) ON DELETE SET NULL,
+      cron_job_id TEXT REFERENCES cron_jobs(id) ON DELETE SET NULL,
+      actor TEXT NOT NULL,
+      source_kind TEXT NOT NULL,
+      request_scope TEXT NOT NULL,
+      reason_text TEXT,
+      details_json TEXT,
+      created_at TEXT NOT NULL CHECK (created_at GLOB '????-??-??T??:??:??*Z' AND datetime(created_at) IS NOT NULL)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_harness_events_run_time
+      ON harness_events(run_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_harness_events_session_time
+      ON harness_events(session_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_harness_events_conversation_time
+      ON harness_events(conversation_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_harness_events_task_run_time
+      ON harness_events(task_run_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_harness_events_type_time
+      ON harness_events(event_type, created_at);
   `);
 }
 

--- a/src/storage/migrate/files/0001_init.sql
+++ b/src/storage/migrate/files/0001_init.sql
@@ -237,6 +237,24 @@ CREATE TABLE IF NOT EXISTS auth_events (
   created_at TEXT NOT NULL CHECK (created_at GLOB '????-??-??T??:??:??*Z' AND datetime(created_at) IS NOT NULL)
 );
 
+CREATE TABLE IF NOT EXISTS harness_events (
+  id TEXT PRIMARY KEY,
+  event_type TEXT NOT NULL,
+  run_id TEXT NOT NULL,
+  session_id TEXT REFERENCES sessions(id) ON DELETE SET NULL,
+  conversation_id TEXT REFERENCES conversations(id) ON DELETE SET NULL,
+  branch_id TEXT REFERENCES conversation_branches(id) ON DELETE SET NULL,
+  agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL,
+  task_run_id TEXT REFERENCES task_runs(id) ON DELETE SET NULL,
+  cron_job_id TEXT REFERENCES cron_jobs(id) ON DELETE SET NULL,
+  actor TEXT NOT NULL,
+  source_kind TEXT NOT NULL,
+  request_scope TEXT NOT NULL,
+  reason_text TEXT,
+  details_json TEXT,
+  created_at TEXT NOT NULL CHECK (created_at GLOB '????-??-??T??:??:??*Z' AND datetime(created_at) IS NOT NULL)
+);
+
 CREATE TABLE IF NOT EXISTS lark_object_bindings (
   id TEXT PRIMARY KEY,
   channel_installation_id TEXT NOT NULL,
@@ -297,6 +315,16 @@ CREATE INDEX IF NOT EXISTS idx_subagent_creation_requests_source_session
   ON subagent_creation_requests(source_session_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_auth_events_time
   ON auth_events(created_at);
+CREATE INDEX IF NOT EXISTS idx_harness_events_run_time
+  ON harness_events(run_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_harness_events_session_time
+  ON harness_events(session_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_harness_events_conversation_time
+  ON harness_events(conversation_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_harness_events_task_run_time
+  ON harness_events(task_run_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_harness_events_type_time
+  ON harness_events(event_type, created_at);
 CREATE INDEX IF NOT EXISTS idx_lark_object_bindings_conversation_branch
   ON lark_object_bindings(conversation_id, branch_id);
 CREATE INDEX IF NOT EXISTS idx_lark_object_bindings_thread_root

--- a/src/storage/migrate/files/0001_init.sql
+++ b/src/storage/migrate/files/0001_init.sql
@@ -237,6 +237,34 @@ CREATE TABLE IF NOT EXISTS auth_events (
   created_at TEXT NOT NULL CHECK (created_at GLOB '????-??-??T??:??:??*Z' AND datetime(created_at) IS NOT NULL)
 );
 
+-- Durable, append-only harness facts used for later runtime analysis.
+--
+-- Current v1 meaning for event_type = 'user_stop':
+--   one row = one explicit user stop intent that was resolved to one concrete
+--   active run and accepted for cancellation.
+--
+-- Important semantic guardrail:
+--   run_id points to the run that was actually being stopped.
+--   It does NOT point to the next user follow-up message sent after stop.
+--   If a user presses stop and then immediately explains/corrects intent, that
+--   later message belongs to the next turn and must be correlated separately
+--   via session_id + created_at against the messages table.
+--
+-- Practical SQL pattern:
+--   1) SELECT * FROM harness_events WHERE event_type = 'user_stop'
+--      ORDER BY created_at DESC;
+--   2) SELECT seq, role, created_at, stop_reason, error_message, payload_json
+--      FROM messages
+--      WHERE session_id = :session_id
+--        AND datetime(created_at) BETWEEN datetime(:stop_created_at, '-3 minutes')
+--                                    AND datetime(:stop_created_at, '+2 minutes')
+--      ORDER BY created_at ASC, seq ASC;
+--   3) SELECT seq, role, created_at, payload_json
+--      FROM messages
+--      WHERE session_id = :session_id AND role = 'user'
+--        AND datetime(created_at) > datetime(:stop_created_at)
+--      ORDER BY created_at ASC, seq ASC
+--      LIMIT 1;
 CREATE TABLE IF NOT EXISTS harness_events (
   id TEXT PRIMARY KEY,
   event_type TEXT NOT NULL,

--- a/src/storage/repos/harness-events.repo.ts
+++ b/src/storage/repos/harness-events.repo.ts
@@ -26,6 +26,10 @@ export interface CreateHarnessEventInput {
 export class HarnessEventsRepo {
   constructor(private readonly db: StorageDb) {}
 
+  /**
+   * Insert one append-only harness event. Canonical user_stop semantics live
+   * with the harness_events schema/table definition.
+   */
   create(input: CreateHarnessEventInput): void {
     const row: NewHarnessEvent = {
       id: input.id,

--- a/src/storage/repos/harness-events.repo.ts
+++ b/src/storage/repos/harness-events.repo.ts
@@ -1,0 +1,60 @@
+import { desc, eq } from "drizzle-orm";
+
+import { toCanonicalUtcIsoTimestamp } from "@/src/shared/time.js";
+import type { StorageDb } from "@/src/storage/db/client.js";
+import { harnessEvents } from "@/src/storage/schema/tables.js";
+import type { HarnessEvent, NewHarnessEvent } from "@/src/storage/schema/types.js";
+
+export interface CreateHarnessEventInput {
+  id: string;
+  eventType: string;
+  runId: string;
+  sessionId?: string | null;
+  conversationId?: string | null;
+  branchId?: string | null;
+  agentId?: string | null;
+  taskRunId?: string | null;
+  cronJobId?: string | null;
+  actor: string;
+  sourceKind: string;
+  requestScope: string;
+  reasonText?: string | null;
+  detailsJson?: string | null;
+  createdAt?: Date;
+}
+
+export class HarnessEventsRepo {
+  constructor(private readonly db: StorageDb) {}
+
+  create(input: CreateHarnessEventInput): void {
+    const row: NewHarnessEvent = {
+      id: input.id,
+      eventType: input.eventType,
+      runId: input.runId,
+      sessionId: input.sessionId ?? null,
+      conversationId: input.conversationId ?? null,
+      branchId: input.branchId ?? null,
+      agentId: input.agentId ?? null,
+      taskRunId: input.taskRunId ?? null,
+      cronJobId: input.cronJobId ?? null,
+      actor: input.actor,
+      sourceKind: input.sourceKind,
+      requestScope: input.requestScope,
+      reasonText: input.reasonText ?? null,
+      detailsJson: input.detailsJson ?? null,
+      createdAt: toCanonicalUtcIsoTimestamp(input.createdAt ?? new Date()),
+    };
+
+    this.db.insert(harnessEvents).values(row).run();
+  }
+
+  listByRunId(runId: string, limit = 50): HarnessEvent[] {
+    return this.db
+      .select()
+      .from(harnessEvents)
+      .where(eq(harnessEvents.runId, runId))
+      .orderBy(desc(harnessEvents.createdAt), desc(harnessEvents.id))
+      .limit(limit)
+      .all();
+  }
+}

--- a/src/storage/schema/relations.ts
+++ b/src/storage/schema/relations.ts
@@ -10,6 +10,7 @@ import {
   conversationBranches,
   conversations,
   cronJobs,
+  harnessEvents,
   larkObjectBindings,
   messages,
   sessions,
@@ -32,6 +33,7 @@ export const conversationsRelations = relations(conversations, ({ one, many }) =
   larkObjectBindings: many(larkObjectBindings),
   sessions: many(sessions),
   taskRuns: many(taskRuns),
+  harnessEvents: many(harnessEvents),
   subagentCreationRequests: many(subagentCreationRequests),
 }));
 
@@ -44,6 +46,7 @@ export const conversationBranchesRelations = relations(conversationBranches, ({ 
   larkObjectBindings: many(larkObjectBindings),
   sessions: many(sessions),
   taskRuns: many(taskRuns),
+  harnessEvents: many(harnessEvents),
 }));
 
 export const channelSurfacesRelations = relations(channelSurfaces, ({ one }) => ({
@@ -75,6 +78,7 @@ export const agentsRelations = relations(agents, ({ one, many }) => ({
   approvals: many(approvalLedger),
   permissionGrants: many(agentPermissionGrants),
   authEvents: many(authEvents),
+  harnessEvents: many(harnessEvents),
   subagentCreationRequests: many(subagentCreationRequests, {
     relationName: "subagent_creation_request_source_agent",
   }),
@@ -99,6 +103,7 @@ export const sessionsRelations = relations(sessions, ({ one, many }) => ({
   messages: many(messages),
   approvals: many(approvalLedger),
   subagentCreationRequests: many(subagentCreationRequests),
+  harnessEvents: many(harnessEvents),
 }));
 
 export const messagesRelations = relations(messages, ({ one }) => ({
@@ -122,6 +127,7 @@ export const cronJobsRelations = relations(cronJobs, ({ one, many }) => ({
     references: [conversationBranches.id],
   }),
   taskRuns: many(taskRuns),
+  harnessEvents: many(harnessEvents),
 }));
 
 export const taskRunsRelations = relations(taskRuns, ({ one }) => ({
@@ -173,6 +179,33 @@ export const authEventsRelations = relations(authEvents, ({ one }) => ({
   agent: one(agents, {
     fields: [authEvents.agentId],
     references: [agents.id],
+  }),
+}));
+
+export const harnessEventsRelations = relations(harnessEvents, ({ one }) => ({
+  session: one(sessions, {
+    fields: [harnessEvents.sessionId],
+    references: [sessions.id],
+  }),
+  conversation: one(conversations, {
+    fields: [harnessEvents.conversationId],
+    references: [conversations.id],
+  }),
+  branch: one(conversationBranches, {
+    fields: [harnessEvents.branchId],
+    references: [conversationBranches.id],
+  }),
+  agent: one(agents, {
+    fields: [harnessEvents.agentId],
+    references: [agents.id],
+  }),
+  taskRun: one(taskRuns, {
+    fields: [harnessEvents.taskRunId],
+    references: [taskRuns.id],
+  }),
+  cronJob: one(cronJobs, {
+    fields: [harnessEvents.cronJobId],
+    references: [cronJobs.id],
   }),
 }));
 

--- a/src/storage/schema/tables.ts
+++ b/src/storage/schema/tables.ts
@@ -405,6 +405,50 @@ export const authEvents = sqliteTable(
   (table) => [index("idx_auth_events_time").on(table.createdAt)],
 );
 
+/**
+ * Durable, append-only harness facts used for later runtime analysis.
+ *
+ * Current v1 meaning for `event_type = "user_stop"`:
+ * - one row means the user expressed explicit stop intent
+ * - and that intent was resolved to one concrete active run
+ * - and that concrete run was successfully accepted for cancellation
+ *
+ * This table is intentionally about the interrupted run itself, not about the
+ * next user turn that may arrive after the stop. In practice those are often
+ * adjacent but they are semantically different:
+ * - `run_id` = the run that was actually being stopped
+ * - later user messages = follow-up explanation / correction / retry intent
+ *
+ * Analysts must not infer from `run_id` that it points at the next user turn.
+ * If you need the follow-up intent, correlate separately using `session_id`
+ * and `created_at` against the `messages` table.
+ *
+ * Practical SQL pattern:
+ * ```sql
+ * -- 1) Start from the explicit stop fact.
+ * SELECT *
+ * FROM harness_events
+ * WHERE event_type = 'user_stop'
+ * ORDER BY created_at DESC;
+ *
+ * -- 2) Inspect the transcript around the stop moment.
+ * SELECT seq, role, created_at, stop_reason, error_message, payload_json
+ * FROM messages
+ * WHERE session_id = :session_id
+ *   AND datetime(created_at) BETWEEN datetime(:stop_created_at, '-3 minutes')
+ *                               AND datetime(:stop_created_at, '+2 minutes')
+ * ORDER BY created_at ASC, seq ASC;
+ *
+ * -- 3) If needed, find the next user follow-up after the stop.
+ * SELECT seq, role, created_at, payload_json
+ * FROM messages
+ * WHERE session_id = :session_id
+ *   AND role = 'user'
+ *   AND datetime(created_at) > datetime(:stop_created_at)
+ * ORDER BY created_at ASC, seq ASC
+ * LIMIT 1;
+ * ```
+ */
 export const harnessEvents = sqliteTable(
   "harness_events",
   {

--- a/src/storage/schema/tables.ts
+++ b/src/storage/schema/tables.ts
@@ -405,6 +405,38 @@ export const authEvents = sqliteTable(
   (table) => [index("idx_auth_events_time").on(table.createdAt)],
 );
 
+export const harnessEvents = sqliteTable(
+  "harness_events",
+  {
+    id: text("id").primaryKey(),
+    eventType: text("event_type").notNull(),
+    runId: text("run_id").notNull(),
+    sessionId: text("session_id").references(() => sessions.id, { onDelete: "set null" }),
+    conversationId: text("conversation_id").references(() => conversations.id, {
+      onDelete: "set null",
+    }),
+    branchId: text("branch_id").references(() => conversationBranches.id, {
+      onDelete: "set null",
+    }),
+    agentId: text("agent_id").references(() => agents.id, { onDelete: "set null" }),
+    taskRunId: text("task_run_id").references(() => taskRuns.id, { onDelete: "set null" }),
+    cronJobId: text("cron_job_id").references(() => cronJobs.id, { onDelete: "set null" }),
+    actor: text("actor").notNull(),
+    sourceKind: text("source_kind").notNull(),
+    requestScope: text("request_scope").notNull(),
+    reasonText: text("reason_text"),
+    detailsJson: text("details_json"),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    index("idx_harness_events_run_time").on(table.runId, table.createdAt),
+    index("idx_harness_events_session_time").on(table.sessionId, table.createdAt),
+    index("idx_harness_events_conversation_time").on(table.conversationId, table.createdAt),
+    index("idx_harness_events_task_run_time").on(table.taskRunId, table.createdAt),
+    index("idx_harness_events_type_time").on(table.eventType, table.createdAt),
+  ],
+);
+
 export const larkObjectBindings = sqliteTable(
   "lark_object_bindings",
   {

--- a/src/storage/schema/types.ts
+++ b/src/storage/schema/types.ts
@@ -10,6 +10,7 @@ import type {
   conversationBranches,
   conversations,
   cronJobs,
+  harnessEvents,
   larkObjectBindings,
   messages,
   sessions,
@@ -55,6 +56,9 @@ export type NewSubagentCreationRequest = InferInsertModel<typeof subagentCreatio
 
 export type AuthEvent = InferSelectModel<typeof authEvents>;
 export type NewAuthEvent = InferInsertModel<typeof authEvents>;
+
+export type HarnessEvent = InferSelectModel<typeof harnessEvents>;
+export type NewHarnessEvent = InferInsertModel<typeof harnessEvents>;
 
 export type LarkObjectBinding = InferSelectModel<typeof larkObjectBindings>;
 export type NewLarkObjectBinding = InferInsertModel<typeof larkObjectBindings>;

--- a/tests/agent/loop.test.ts
+++ b/tests/agent/loop.test.ts
@@ -3221,6 +3221,130 @@ describe("agent loop", () => {
     });
   });
 
+  test("retries a successful empty assistant output once when nothing visible was streamed", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationFixture(handle);
+
+    const sessionsRepo = new SessionsRepo(handle.storage.db);
+    const messagesRepo = new MessagesRepo(handle.storage.db);
+    sessionsRepo.create({
+      id: "sess_1",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      purpose: "chat",
+      createdAt: new Date("2026-03-22T00:00:00.000Z"),
+    });
+    messagesRepo.append({
+      id: "msg_user",
+      sessionId: "sess_1",
+      seq: 1,
+      role: "user",
+      payloadJson: '{"content":"hello"}',
+      createdAt: new Date("2026-03-22T00:00:01.000Z"),
+    });
+
+    let runTurnCount = 0;
+    const runner: AgentModelRunner = {
+      async runTurn() {
+        runTurnCount += 1;
+        if (runTurnCount === 1) {
+          return makeAssistantResult({
+            content: [],
+          });
+        }
+
+        return makeAssistantResult({
+          content: [{ type: "text", text: "recovered reply" }],
+        });
+      },
+    };
+
+    const loop = new AgentLoop({
+      sessions: new AgentSessionService(sessionsRepo, messagesRepo),
+      messages: messagesRepo,
+      models: new ProviderRegistry(createModelConfig()),
+      tools: new ToolRegistry(),
+      cancel: new SessionRunAbortRegistry(),
+      modelRunner: runner,
+      storage: handle.storage.db,
+      securityConfig: DEFAULT_CONFIG.security,
+      compaction: DEFAULT_CONFIG.compaction,
+    });
+
+    const result = await loop.run({ sessionId: "sess_1", scenario: "chat" });
+
+    expect(runTurnCount).toBe(2);
+    expect(
+      result.events.filter((event) => event.type === "assistant_message_started"),
+    ).toHaveLength(2);
+    const rows = messagesRepo.listBySession("sess_1");
+    expect(rows).toHaveLength(2);
+    expect(JSON.parse(rows[1]?.payloadJson ?? "{}")).toEqual({
+      content: [{ type: "text", text: "recovered reply" }],
+    });
+  });
+
+  test("does not retry a successful empty final response when thinking was already streamed", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationFixture(handle);
+
+    const sessionsRepo = new SessionsRepo(handle.storage.db);
+    const messagesRepo = new MessagesRepo(handle.storage.db);
+    sessionsRepo.create({
+      id: "sess_1",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      purpose: "chat",
+      createdAt: new Date("2026-03-22T00:00:00.000Z"),
+    });
+    messagesRepo.append({
+      id: "msg_user",
+      sessionId: "sess_1",
+      seq: 1,
+      role: "user",
+      payloadJson: '{"content":"hello"}',
+      createdAt: new Date("2026-03-22T00:00:01.000Z"),
+    });
+
+    let runTurnCount = 0;
+    const runner: AgentModelRunner = {
+      async runTurn(input) {
+        runTurnCount += 1;
+        input.onThinkingDelta?.({
+          delta: "Let me think...",
+        });
+        return makeAssistantResult({
+          content: [],
+        });
+      },
+    };
+
+    const loop = new AgentLoop({
+      sessions: new AgentSessionService(sessionsRepo, messagesRepo),
+      messages: messagesRepo,
+      models: new ProviderRegistry(createModelConfig()),
+      tools: new ToolRegistry(),
+      cancel: new SessionRunAbortRegistry(),
+      modelRunner: runner,
+      storage: handle.storage.db,
+      securityConfig: DEFAULT_CONFIG.security,
+      compaction: DEFAULT_CONFIG.compaction,
+    });
+
+    const result = await loop.run({ sessionId: "sess_1", scenario: "chat" });
+
+    expect(runTurnCount).toBe(1);
+    const rows = messagesRepo.listBySession("sess_1");
+    expect(rows).toHaveLength(2);
+    expect(JSON.parse(rows[1]?.payloadJson ?? "{}")).toEqual({ content: [] });
+    expect(result.events.find((event) => event.type === "assistant_reasoning_delta")).toMatchObject(
+      {
+        type: "assistant_reasoning_delta",
+        delta: "Let me think...",
+      },
+    );
+  });
+
   test("persists partial streamed output and does not retry when visible output already exists", async () => {
     handle = await createTestDatabase(import.meta.url);
     seedConversationFixture(handle);

--- a/tests/channels/lark/inbound.test.ts
+++ b/tests/channels/lark/inbound.test.ts
@@ -1525,6 +1525,8 @@ describe("lark inbound message handling", () => {
       expect(control.stopConversation).toHaveBeenCalledExactlyOnceWith({
         conversationId: "conv_main",
         actor: "lark:default:ou_sender",
+        sourceKind: "command",
+        requestScope: "conversation",
         reasonText: "stop requested from lark command",
       });
     });
@@ -1592,6 +1594,8 @@ describe("lark inbound message handling", () => {
       expect(control.stopSession).toHaveBeenCalledExactlyOnceWith({
         sessionId: "sess_thread_1",
         actor: "lark:default:ou_sender",
+        sourceKind: "command",
+        requestScope: "session",
         reasonText: "stop requested from lark command",
       });
       expect(control.stopConversation).not.toHaveBeenCalled();
@@ -1660,6 +1664,8 @@ describe("lark inbound message handling", () => {
       expect(control.stopSession).toHaveBeenCalledExactlyOnceWith({
         sessionId: "sess_task_1",
         actor: "lark:default:ou_sender",
+        sourceKind: "command",
+        requestScope: "session",
         reasonText: "stop requested from lark command",
       });
       expect(control.stopConversation).not.toHaveBeenCalled();
@@ -1940,6 +1946,8 @@ describe("lark card actions", () => {
     expect(control.stopRun).toHaveBeenCalledExactlyOnceWith({
       runId: "run_123",
       actor: "lark:default:ou_sender",
+      sourceKind: "button",
+      requestScope: "run",
       reasonText: "stop requested from lark card action",
     });
     expect(result).toEqual({

--- a/tests/runtime/control.test.ts
+++ b/tests/runtime/control.test.ts
@@ -1,150 +1,281 @@
 import { describe, expect, test } from "vitest";
-
 import { SessionRunAbortRegistry } from "@/src/runtime/cancel.js";
 import { RuntimeControlService } from "@/src/runtime/control.js";
+import { HarnessEventsRepo } from "@/src/storage/repos/harness-events.repo.js";
+import { SessionsRepo } from "@/src/storage/repos/sessions.repo.js";
+import { TaskRunsRepo } from "@/src/storage/repos/task-runs.repo.js";
+import { createTestDatabase, destroyTestDatabase } from "@/tests/storage/helpers/test-db.js";
+
+async function withStorageFixture<T>(
+  run: (deps: {
+    cancel: SessionRunAbortRegistry;
+    control: RuntimeControlService;
+    harnessEvents: HarnessEventsRepo;
+    taskRuns: TaskRunsRepo;
+  }) => T | Promise<T>,
+): Promise<T> {
+  const handle = await createTestDatabase(import.meta.url);
+  try {
+    handle.storage.sqlite.exec(`
+      INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+      VALUES ('ci_1', 'lark', 'acct_a', '2026-04-05T00:00:00.000Z', '2026-04-05T00:00:00.000Z');
+
+      INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+      VALUES ('conv_1', 'ci_1', 'chat_1', 'dm', '2026-04-05T00:00:00.000Z', '2026-04-05T00:00:00.000Z');
+
+      INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+      VALUES ('branch_1', 'conv_1', 'dm_main', 'main', '2026-04-05T00:00:00.000Z', '2026-04-05T00:00:00.000Z');
+
+      INSERT INTO agents (id, conversation_id, kind, created_at)
+      VALUES ('agent_1', 'conv_1', 'main', '2026-04-05T00:00:00.000Z');
+
+      INSERT INTO sessions (id, conversation_id, branch_id, owner_agent_id, purpose, status, created_at, updated_at)
+      VALUES ('sess_1', 'conv_1', 'branch_1', 'agent_1', 'chat', 'active', '2026-04-05T00:00:00.000Z', '2026-04-05T00:00:00.000Z');
+
+      INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+      VALUES ('branch_2', 'conv_1', 'dm_thread', 'thread:2', '2026-04-05T00:00:00.000Z', '2026-04-05T00:00:00.000Z');
+      INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+      VALUES ('conv_2', 'ci_1', 'chat_2', 'dm', '2026-04-05T00:00:00.000Z', '2026-04-05T00:00:00.000Z');
+      INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+      VALUES ('branch_3', 'conv_2', 'dm_main', 'main', '2026-04-05T00:00:00.000Z', '2026-04-05T00:00:00.000Z');
+      INSERT INTO sessions (id, conversation_id, branch_id, owner_agent_id, purpose, status, created_at, updated_at)
+      VALUES ('sess_2', 'conv_1', 'branch_2', 'agent_1', 'chat', 'active', '2026-04-05T00:00:00.000Z', '2026-04-05T00:00:00.000Z');
+      INSERT INTO sessions (id, conversation_id, branch_id, owner_agent_id, purpose, status, created_at, updated_at)
+      VALUES ('sess_3', 'conv_2', 'branch_3', 'agent_1', 'chat', 'active', '2026-04-05T00:00:00.000Z', '2026-04-05T00:00:00.000Z');
+
+      INSERT INTO cron_jobs (id, owner_agent_id, target_conversation_id, target_branch_id, schedule_kind, schedule_value, payload_json, created_at, updated_at)
+      VALUES ('cron_1', 'agent_1', 'conv_1', 'branch_1', 'cron', '0 * * * *', '{}', '2026-04-05T00:00:00.000Z', '2026-04-05T00:00:00.000Z');
+    `);
+
+    const cancel = new SessionRunAbortRegistry();
+    const harnessEvents = new HarnessEventsRepo(handle.storage.db);
+    const taskRuns = new TaskRunsRepo(handle.storage.db);
+    const control = new RuntimeControlService(cancel, {
+      harnessEvents,
+      sessions: new SessionsRepo(handle.storage.db),
+      taskRuns,
+    });
+    return await run({ cancel, control, harnessEvents, taskRuns });
+  } finally {
+    await destroyTestDatabase(handle);
+  }
+}
 
 describe("RuntimeControlService", () => {
-  test("stops a specific active run", () => {
-    const cancel = new SessionRunAbortRegistry();
-    const control = new RuntimeControlService(cancel);
-    const handle = cancel.begin("sess_1");
+  test("stops a specific active run", async () => {
+    await withStorageFixture(async ({ cancel, control, harnessEvents }) => {
+      const handle = cancel.begin("sess_1");
 
-    control.beginRun({
-      runId: "run_1",
-      sessionId: "sess_1",
-      conversationId: "conv_1",
-      branchId: "branch_1",
-      scenario: "chat",
-    });
+      control.beginRun({
+        runId: "run_1",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        scenario: "chat",
+      });
 
-    const result = control.stopRun({
-      runId: "run_1",
-      actor: "test",
-    });
+      const result = control.stopRun({
+        runId: "run_1",
+        actor: "test",
+        sourceKind: "button",
+        requestScope: "run",
+      });
 
-    expect(result).toEqual({
-      accepted: true,
-      runId: "run_1",
-      sessionId: "sess_1",
-      conversationId: "conv_1",
-    });
-    expect(handle.signal.aborted).toBe(true);
-    expect(cancel.isActive("sess_1")).toBe(false);
-  });
-
-  test("stops all active runs for a conversation", () => {
-    const cancel = new SessionRunAbortRegistry();
-    const control = new RuntimeControlService(cancel);
-    const handle1 = cancel.begin("sess_1");
-    const handle2 = cancel.begin("sess_2");
-    const handle3 = cancel.begin("sess_3");
-
-    control.beginRun({
-      runId: "run_1",
-      sessionId: "sess_1",
-      conversationId: "conv_1",
-      branchId: "branch_1",
-      scenario: "chat",
-    });
-    control.beginRun({
-      runId: "run_2",
-      sessionId: "sess_2",
-      conversationId: "conv_1",
-      branchId: "branch_1",
-      scenario: "chat",
-    });
-    control.beginRun({
-      runId: "run_3",
-      sessionId: "sess_3",
-      conversationId: "conv_2",
-      branchId: "branch_2",
-      scenario: "chat",
-    });
-
-    const result = control.stopConversation({
-      conversationId: "conv_1",
-      actor: "test",
-    });
-
-    expect(result).toEqual({
-      acceptedCount: 2,
-      conversationId: "conv_1",
-      runIds: ["run_1", "run_2"],
-      sessionIds: ["sess_1", "sess_2"],
-    });
-    expect(handle1.signal.aborted).toBe(true);
-    expect(handle2.signal.aborted).toBe(true);
-    expect(handle3.signal.aborted).toBe(false);
-    expect(cancel.isActive("sess_1")).toBe(false);
-    expect(cancel.isActive("sess_2")).toBe(false);
-    expect(cancel.isActive("sess_3")).toBe(true);
-  });
-
-  test("releases finished runs so stop ignores them", () => {
-    const cancel = new SessionRunAbortRegistry();
-    const control = new RuntimeControlService(cancel);
-    cancel.begin("sess_1");
-
-    control.beginRun({
-      runId: "run_1",
-      sessionId: "sess_1",
-      conversationId: "conv_1",
-      branchId: "branch_1",
-      scenario: "chat",
-    });
-    control.finishRun("run_1");
-
-    const result = control.stopRun({
-      runId: "run_1",
-      actor: "test",
-    });
-
-    expect(result).toEqual({
-      accepted: false,
-      runId: "run_1",
-      sessionId: null,
-      conversationId: null,
+      expect(result).toEqual({
+        accepted: true,
+        runId: "run_1",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+      });
+      expect(handle.signal.aborted).toBe(true);
+      expect(cancel.isActive("sess_1")).toBe(false);
+      expect(harnessEvents.listByRunId("run_1")).toMatchObject([
+        {
+          eventType: "user_stop",
+          runId: "run_1",
+          sessionId: "sess_1",
+          conversationId: "conv_1",
+          branchId: "branch_1",
+          actor: "test",
+          sourceKind: "button",
+          requestScope: "run",
+        },
+      ]);
     });
   });
 
-  test("stops only runs for the requested session", () => {
-    const cancel = new SessionRunAbortRegistry();
-    const control = new RuntimeControlService(cancel);
-    const handle1 = cancel.begin("sess_1");
-    const handle2 = cancel.begin("sess_2");
+  test("stops all active runs for a conversation", async () => {
+    await withStorageFixture(async ({ cancel, control, harnessEvents }) => {
+      const handle1 = cancel.begin("sess_1");
+      const handle2 = cancel.begin("sess_2");
+      const handle3 = cancel.begin("sess_3");
 
-    control.beginRun({
-      runId: "run_1",
-      sessionId: "sess_1",
-      conversationId: "conv_1",
-      branchId: "branch_1",
-      scenario: "chat",
-    });
-    control.beginRun({
-      runId: "run_2",
-      sessionId: "sess_2",
-      conversationId: "conv_1",
-      branchId: "branch_2",
-      scenario: "chat",
-    });
+      control.beginRun({
+        runId: "run_1",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        scenario: "chat",
+      });
+      control.beginRun({
+        runId: "run_2",
+        sessionId: "sess_2",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        scenario: "chat",
+      });
+      control.beginRun({
+        runId: "run_3",
+        sessionId: "sess_3",
+        conversationId: "conv_2",
+        branchId: "branch_2",
+        scenario: "chat",
+      });
 
-    const result = control.stopSession({
-      sessionId: "sess_2",
-      actor: "test",
-    });
+      const result = control.stopConversation({
+        conversationId: "conv_1",
+        actor: "test",
+        sourceKind: "command",
+        requestScope: "conversation",
+      });
 
-    expect(result).toEqual({
-      accepted: true,
-      sessionId: "sess_2",
-      runIds: ["run_2"],
-      conversationId: "conv_1",
+      expect(result).toEqual({
+        acceptedCount: 2,
+        conversationId: "conv_1",
+        runIds: ["run_1", "run_2"],
+        sessionIds: ["sess_1", "sess_2"],
+      });
+      expect(handle1.signal.aborted).toBe(true);
+      expect(handle2.signal.aborted).toBe(true);
+      expect(handle3.signal.aborted).toBe(false);
+      expect(cancel.isActive("sess_1")).toBe(false);
+      expect(cancel.isActive("sess_2")).toBe(false);
+      expect(cancel.isActive("sess_3")).toBe(true);
+      expect(harnessEvents.listByRunId("run_1")[0]).toMatchObject({
+        sourceKind: "command",
+        requestScope: "conversation",
+      });
+      expect(harnessEvents.listByRunId("run_2")[0]).toMatchObject({
+        sourceKind: "command",
+        requestScope: "conversation",
+      });
+      expect(harnessEvents.listByRunId("run_3")).toEqual([]);
     });
-    expect(handle1.signal.aborted).toBe(false);
-    expect(handle2.signal.aborted).toBe(true);
-    expect(cancel.isActive("sess_1")).toBe(true);
-    expect(cancel.isActive("sess_2")).toBe(false);
   });
 
+  test("releases finished runs so stop ignores them", async () => {
+    await withStorageFixture(async ({ cancel, control, harnessEvents }) => {
+      cancel.begin("sess_1");
+
+      control.beginRun({
+        runId: "run_1",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        scenario: "chat",
+      });
+      control.finishRun("run_1");
+
+      const result = control.stopRun({
+        runId: "run_1",
+        actor: "test",
+        sourceKind: "button",
+        requestScope: "run",
+      });
+
+      expect(result).toEqual({
+        accepted: false,
+        runId: "run_1",
+        sessionId: null,
+        conversationId: null,
+      });
+      expect(harnessEvents.listByRunId("run_1")).toEqual([]);
+    });
+  });
+
+  test("stops only runs for the requested session", async () => {
+    await withStorageFixture(async ({ cancel, control, harnessEvents }) => {
+      const handle1 = cancel.begin("sess_1");
+      const handle2 = cancel.begin("sess_2");
+
+      control.beginRun({
+        runId: "run_1",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        scenario: "chat",
+      });
+      control.beginRun({
+        runId: "run_2",
+        sessionId: "sess_2",
+        conversationId: "conv_1",
+        branchId: "branch_2",
+        scenario: "chat",
+      });
+
+      const result = control.stopSession({
+        sessionId: "sess_2",
+        actor: "test",
+        sourceKind: "command",
+        requestScope: "session",
+      });
+
+      expect(result).toEqual({
+        accepted: true,
+        sessionId: "sess_2",
+        runIds: ["run_2"],
+        conversationId: "conv_1",
+      });
+      expect(handle1.signal.aborted).toBe(false);
+      expect(handle2.signal.aborted).toBe(true);
+      expect(cancel.isActive("sess_1")).toBe(true);
+      expect(cancel.isActive("sess_2")).toBe(false);
+      expect(harnessEvents.listByRunId("run_1")).toEqual([]);
+      expect(harnessEvents.listByRunId("run_2")[0]).toMatchObject({
+        sourceKind: "command",
+        requestScope: "session",
+      });
+    });
+  });
+
+  test("records task and cron context on explicit stop events", async () => {
+    await withStorageFixture(async ({ cancel, control, harnessEvents, taskRuns }) => {
+      taskRuns.create({
+        id: "task_1",
+        runType: "cron",
+        ownerAgentId: "agent_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        cronJobId: "cron_1",
+        executionSessionId: "sess_1",
+        status: "running",
+        startedAt: new Date("2026-04-05T00:00:01.000Z"),
+      });
+
+      const handle = cancel.begin("sess_1");
+      control.beginRun({
+        runId: "run_1",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        scenario: "cron",
+      });
+
+      control.stopRun({
+        runId: "run_1",
+        actor: "test",
+        sourceKind: "button",
+        requestScope: "run",
+      });
+
+      expect(handle.signal.aborted).toBe(true);
+      expect(harnessEvents.listByRunId("run_1")[0]).toMatchObject({
+        agentId: "agent_1",
+        taskRunId: "task_1",
+        cronJobId: "cron_1",
+      });
+    });
+  });
   test("tracks request-level TTFT without resetting run-level timing", () => {
     const control = new RuntimeControlService(new SessionRunAbortRegistry());
     control.beginRun({

--- a/tests/storage/db.test.ts
+++ b/tests/storage/db.test.ts
@@ -64,6 +64,7 @@ describe("storage db bootstrap", () => {
       expect(tableNames).toContain("approval_ledger");
       expect(tableNames).toContain("agent_permission_grants");
       expect(tableNames).toContain("auth_events");
+      expect(tableNames).toContain("harness_events");
       expect(tableNames).toContain("lark_object_bindings");
     } finally {
       await destroyTestDatabase(handle);
@@ -180,6 +181,250 @@ describe("storage db bootstrap", () => {
       const columnNames = rows.map((row) => row.name);
 
       expect(columnNames).toContain("deleted_at");
+    } finally {
+      upgraded.close();
+      await rm(dbPath, { force: true });
+    }
+  });
+
+  test("adds harness_events table during schema upgrade", async () => {
+    const dbPath = getTestDatabasePath(import.meta.url);
+    await mkdir(path.dirname(dbPath), { recursive: true });
+
+    const legacy = openStorageDatabase({ databasePath: dbPath, initializeSchema: false });
+    try {
+      legacy.sqlite.exec(`
+        CREATE TABLE channel_instances (
+          id TEXT PRIMARY KEY,
+          provider TEXT NOT NULL,
+          account_key TEXT NOT NULL,
+          display_name TEXT,
+          status TEXT NOT NULL DEFAULT 'active',
+          config_ref TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        );
+
+        CREATE TABLE conversations (
+          id TEXT PRIMARY KEY,
+          channel_instance_id TEXT NOT NULL,
+          external_chat_id TEXT NOT NULL,
+          kind TEXT NOT NULL,
+          title TEXT,
+          status TEXT NOT NULL DEFAULT 'active',
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        );
+
+        CREATE TABLE conversation_branches (
+          id TEXT PRIMARY KEY,
+          conversation_id TEXT NOT NULL,
+          kind TEXT NOT NULL,
+          branch_key TEXT NOT NULL,
+          external_branch_id TEXT,
+          parent_branch_id TEXT,
+          status TEXT NOT NULL DEFAULT 'active',
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        );
+
+        CREATE TABLE channel_surfaces (
+          id TEXT PRIMARY KEY,
+          channel_type TEXT NOT NULL,
+          channel_installation_id TEXT NOT NULL,
+          conversation_id TEXT NOT NULL,
+          branch_id TEXT NOT NULL,
+          surface_key TEXT NOT NULL,
+          surface_object_json TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        );
+
+        CREATE TABLE agents (
+          id TEXT PRIMARY KEY,
+          conversation_id TEXT NOT NULL,
+          main_agent_id TEXT,
+          kind TEXT NOT NULL,
+          display_name TEXT,
+          description TEXT,
+          workdir TEXT,
+          policy_profile TEXT,
+          default_model TEXT,
+          status TEXT NOT NULL DEFAULT 'active',
+          created_at TEXT NOT NULL,
+          archived_at TEXT
+        );
+
+        CREATE TABLE sessions (
+          id TEXT PRIMARY KEY,
+          conversation_id TEXT NOT NULL,
+          branch_id TEXT NOT NULL,
+          owner_agent_id TEXT,
+          purpose TEXT NOT NULL,
+          context_mode TEXT NOT NULL DEFAULT 'isolated',
+          approval_for_session_id TEXT,
+          forked_from_session_id TEXT,
+          fork_source_seq INTEGER,
+          status TEXT NOT NULL DEFAULT 'active',
+          compact_cursor INTEGER NOT NULL DEFAULT 0,
+          compact_summary TEXT,
+          compact_summary_token_total INTEGER,
+          compact_summary_usage_json TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          ended_at TEXT
+        );
+
+        CREATE TABLE messages (
+          id TEXT PRIMARY KEY,
+          session_id TEXT NOT NULL,
+          seq INTEGER NOT NULL,
+          role TEXT NOT NULL,
+          message_type TEXT NOT NULL DEFAULT 'text',
+          visibility TEXT NOT NULL DEFAULT 'user_visible',
+          channel_message_id TEXT,
+          provider TEXT,
+          model TEXT,
+          model_api TEXT,
+          stop_reason TEXT,
+          error_message TEXT,
+          payload_json TEXT NOT NULL,
+          token_input INTEGER,
+          token_output INTEGER,
+          token_cache_read INTEGER,
+          token_cache_write INTEGER,
+          token_total INTEGER,
+          usage_json TEXT,
+          created_at TEXT NOT NULL,
+          UNIQUE(session_id, seq)
+        );
+
+        CREATE TABLE cron_jobs (
+          id TEXT PRIMARY KEY,
+          owner_agent_id TEXT NOT NULL,
+          target_conversation_id TEXT NOT NULL,
+          target_branch_id TEXT NOT NULL,
+          schedule_kind TEXT NOT NULL,
+          schedule_value TEXT NOT NULL,
+          enabled INTEGER NOT NULL DEFAULT 1,
+          payload_json TEXT NOT NULL,
+          next_run_at TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        );
+
+        CREATE TABLE task_runs (
+          id TEXT PRIMARY KEY,
+          run_type TEXT NOT NULL,
+          owner_agent_id TEXT NOT NULL,
+          conversation_id TEXT NOT NULL,
+          branch_id TEXT NOT NULL,
+          initiator_session_id TEXT,
+          parent_run_id TEXT,
+          cron_job_id TEXT,
+          execution_session_id TEXT,
+          status TEXT NOT NULL,
+          priority INTEGER NOT NULL DEFAULT 0,
+          attempt INTEGER NOT NULL DEFAULT 1,
+          description TEXT,
+          input_json TEXT,
+          result_summary TEXT,
+          error_text TEXT,
+          started_at TEXT NOT NULL,
+          finished_at TEXT,
+          duration_ms INTEGER,
+          cancelled_by TEXT
+        );
+
+        CREATE TABLE approval_ledger (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          owner_agent_id TEXT NOT NULL,
+          requested_by_session_id TEXT,
+          requested_scope_json TEXT NOT NULL,
+          approval_target TEXT NOT NULL,
+          status TEXT NOT NULL,
+          reason_text TEXT,
+          expires_at TEXT,
+          resume_payload_json TEXT,
+          created_at TEXT NOT NULL,
+          decided_at TEXT
+        );
+
+        CREATE TABLE agent_permission_grants (
+          id TEXT PRIMARY KEY,
+          owner_agent_id TEXT NOT NULL,
+          source_approval_id INTEGER,
+          scope_json TEXT NOT NULL,
+          granted_by TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          expires_at TEXT
+        );
+
+        CREATE TABLE subagent_creation_requests (
+          id TEXT PRIMARY KEY,
+          source_session_id TEXT NOT NULL,
+          source_agent_id TEXT NOT NULL,
+          source_conversation_id TEXT NOT NULL,
+          channel_instance_id TEXT NOT NULL,
+          title TEXT NOT NULL,
+          description TEXT NOT NULL,
+          initial_task TEXT NOT NULL,
+          workdir TEXT NOT NULL,
+          initial_extra_scopes_json TEXT NOT NULL,
+          status TEXT NOT NULL,
+          created_subagent_agent_id TEXT,
+          failure_reason TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          decided_at TEXT,
+          expires_at TEXT
+        );
+
+        CREATE TABLE auth_events (
+          id TEXT PRIMARY KEY,
+          conversation_id TEXT,
+          agent_id TEXT,
+          event_type TEXT NOT NULL,
+          provider TEXT,
+          status TEXT NOT NULL,
+          details_json TEXT,
+          created_at TEXT NOT NULL
+        );
+
+        CREATE TABLE lark_object_bindings (
+          id TEXT PRIMARY KEY,
+          channel_installation_id TEXT NOT NULL,
+          conversation_id TEXT NOT NULL,
+          branch_id TEXT NOT NULL,
+          internal_object_kind TEXT NOT NULL,
+          internal_object_id TEXT NOT NULL,
+          lark_message_id TEXT,
+          lark_open_message_id TEXT,
+          lark_card_id TEXT,
+          thread_root_message_id TEXT,
+          card_element_id TEXT,
+          last_sequence INTEGER,
+          status TEXT NOT NULL DEFAULT 'active',
+          metadata_json TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        );
+      `);
+    } finally {
+      legacy.close();
+    }
+
+    const upgraded = openStorageDatabase({ databasePath: dbPath, initializeSchema: true });
+    try {
+      const rows = upgraded.sqlite.prepare("PRAGMA table_info(harness_events)").all() as Array<{
+        name: string;
+      }>;
+      const columnNames = rows.map((row) => row.name);
+
+      expect(columnNames).toContain("event_type");
+      expect(columnNames).toContain("run_id");
+      expect(columnNames).toContain("source_kind");
+      expect(columnNames).toContain("request_scope");
     } finally {
       upgraded.close();
       await rm(dbPath, { force: true });

--- a/tests/storage/harness-events.repo.test.ts
+++ b/tests/storage/harness-events.repo.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, test } from "vitest";
+
+import { HarnessEventsRepo } from "@/src/storage/repos/harness-events.repo.js";
+import {
+  createTestDatabase,
+  destroyTestDatabase,
+  type TestDatabaseHandle,
+} from "@/tests/storage/helpers/test-db.js";
+
+function seedFixture(handle: TestDatabaseHandle): void {
+  handle.storage.sqlite.exec(`
+    INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+    VALUES ('ci_1', 'lark', 'acct_a', '2026-03-26T00:00:00.000Z', '2026-03-26T00:00:00.000Z');
+
+    INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+    VALUES ('conv_1', 'ci_1', 'chat_1', 'dm', '2026-03-26T00:00:00.000Z', '2026-03-26T00:00:00.000Z');
+
+    INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+    VALUES ('branch_1', 'conv_1', 'dm_main', 'main', '2026-03-26T00:00:00.000Z', '2026-03-26T00:00:00.000Z');
+
+    INSERT INTO agents (id, conversation_id, main_agent_id, kind, created_at)
+    VALUES ('agent_1', 'conv_1', NULL, 'main', '2026-03-26T00:00:00.000Z');
+
+    INSERT INTO sessions (id, conversation_id, branch_id, owner_agent_id, purpose, context_mode, status, compact_cursor, created_at, updated_at)
+    VALUES ('sess_1', 'conv_1', 'branch_1', 'agent_1', 'chat', 'isolated', 'active', 0, '2026-03-26T00:00:00.000Z', '2026-03-26T00:00:00.000Z');
+
+    INSERT INTO cron_jobs (
+      id, owner_agent_id, target_conversation_id, target_branch_id,
+      schedule_kind, schedule_value, payload_json, created_at, updated_at
+    ) VALUES (
+      'cron_1', 'agent_1', 'conv_1', 'branch_1',
+      'cron', '0 * * * *', '{}', '2026-03-26T00:00:00.000Z', '2026-03-26T00:00:00.000Z'
+    );
+
+    INSERT INTO task_runs (
+      id, run_type, owner_agent_id, conversation_id, branch_id, cron_job_id,
+      execution_session_id, status, started_at
+    ) VALUES (
+      'task_1', 'cron', 'agent_1', 'conv_1', 'branch_1', 'cron_1',
+      'sess_1', 'running', '2026-03-26T00:00:01.000Z'
+    );
+  `);
+}
+
+describe("harness events repo", () => {
+  let handle: TestDatabaseHandle | null = null;
+
+  afterEach(async () => {
+    if (handle != null) {
+      await destroyTestDatabase(handle);
+      handle = null;
+    }
+  });
+
+  test("creates and lists explicit user stop events by run id", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedFixture(handle);
+    const repo = new HarnessEventsRepo(handle.storage.db);
+
+    repo.create({
+      id: "evt_1",
+      eventType: "user_stop",
+      runId: "run_1",
+      sessionId: "sess_1",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      agentId: "agent_1",
+      actor: "lark:default:ou_sender",
+      sourceKind: "command",
+      requestScope: "conversation",
+      reasonText: "stop requested from lark command",
+      createdAt: new Date("2026-03-26T00:00:03.000Z"),
+    });
+
+    repo.create({
+      id: "evt_2",
+      eventType: "user_stop",
+      runId: "run_1",
+      sessionId: "sess_1",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      agentId: "agent_1",
+      taskRunId: "task_1",
+      cronJobId: "cron_1",
+      actor: "lark:default:ou_sender",
+      sourceKind: "button",
+      requestScope: "run",
+      reasonText: "stop requested from lark card action",
+      detailsJson: '{"note":"explicit"}',
+      createdAt: new Date("2026-03-26T00:00:04.000Z"),
+    });
+
+    expect(repo.listByRunId("run_1")).toMatchObject([
+      {
+        id: "evt_2",
+        taskRunId: "task_1",
+        cronJobId: "cron_1",
+        sourceKind: "button",
+        requestScope: "run",
+        detailsJson: '{"note":"explicit"}',
+      },
+      {
+        id: "evt_1",
+        sourceKind: "command",
+        requestScope: "conversation",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add durable `harness_events` persistence for explicit user stop intent and wire stop metadata through runtime + Lark entrypoints
- document `user_stop` semantics at the schema/SQL layer so analysis distinguishes the stopped run from later follow-up turns
- retry one successful-but-empty assistant response when nothing visible streamed, with tests covering retry and no-retry-after-thinking

## Test plan
- [x] pnpm preflight
- [x] pnpm exec vitest run tests/agent/loop.test.ts tests/runtime/control.test.ts