### PR TITLE
Fix cron isolated context and tighten group guidance

### DIFF
--- a/src/orchestration/agent-manager.ts
+++ b/src/orchestration/agent-manager.ts
@@ -383,13 +383,16 @@ export class AgentManager {
           lastSuccessfulRun == null ? null : summarizeCronTaskRunForKickoff(lastSuccessfulRun),
       },
     });
-    const forkSourceSession = sessionsRepo.findLatestByConversationBranch(
-      cronJob.targetConversationId,
-      cronJob.targetBranchId,
-      {
-        purpose: "chat",
-      },
-    );
+    const forkSourceSession =
+      cronJob.contextMode === "group"
+        ? sessionsRepo.findLatestByConversationBranch(
+            cronJob.targetConversationId,
+            cronJob.targetBranchId,
+            {
+              purpose: "chat",
+            },
+          )
+        : null;
 
     const created = this.createTaskExecution({
       runType: "cron",

--- a/src/tasks/runner.ts
+++ b/src/tasks/runner.ts
@@ -208,9 +208,18 @@ export class TaskExecutionRunner {
     | Extract<SubmitMessageResult, { status: "started" }>
     | Extract<TaskExecutionRunResult, { status: "failed" }>
   > {
+    const normalizedContextMode =
+      input.created.executionSession.contextMode === "group"
+        ? "group"
+        : input.created.executionSession.contextMode === "isolated"
+          ? "isolated"
+          : null;
+
     const envelope =
       input.pass === 1
-        ? buildTaskExecutionKickoffEnvelope(input.created.taskRun)
+        ? buildTaskExecutionKickoffEnvelope(input.created.taskRun, {
+            contextMode: normalizedContextMode,
+          })
         : buildTaskExecutionSupervisorReminderEnvelope({
             runType: input.created.taskRun.runType,
             nextPass: input.pass,

--- a/src/tasks/task-session.ts
+++ b/src/tasks/task-session.ts
@@ -9,6 +9,11 @@ export interface TaskExecutionKickoffEnvelope {
   visibility: "hidden_system";
 }
 
+export interface TaskExecutionKickoffOptions {
+  cronContext?: CronKickoffContext;
+  contextMode?: "group" | "isolated" | null;
+}
+
 export interface CronKickoffRunReference {
   startedAt: string;
   status: string;
@@ -62,15 +67,20 @@ const CRON_EXECUTION_GUIDANCE_LINES = [
   "If the previous run failed, avoid blindly repeating the same failing path.",
 ];
 
+const GROUP_CRON_TRANSCRIPT_GUIDANCE_LINES = [
+  "If inherited transcript is present, use it only for task-relevant background, standing instructions, constraints, and user preferences.",
+  "Do not resume unrelated unfinished discussion just because it appears in inherited transcript.",
+  "Do not treat inherited transcript as a request to continue the broader conversation.",
+  "Complete the scheduled objective for this run, then end the task instead of continuing broader conversation.",
+];
+
 export function resolveTaskExecutionScenario(runType: string): ModelScenario {
   return runType === "cron" ? "cron" : "subagent";
 }
 
 export function buildTaskExecutionKickoffEnvelope(
   taskRun: Pick<TaskRun, "runType" | "description" | "inputJson">,
-  options: {
-    cronContext?: CronKickoffContext;
-  } = {},
+  options: TaskExecutionKickoffOptions = {},
 ): TaskExecutionKickoffEnvelope {
   return {
     scenario: resolveTaskExecutionScenario(taskRun.runType),
@@ -100,14 +110,12 @@ export function buildTaskExecutionSupervisorReminderEnvelope(input: {
 
 function renderTaskKickoffMessage(
   taskRun: Pick<TaskRun, "runType" | "description" | "inputJson">,
-  options: {
-    cronContext?: CronKickoffContext;
-  },
+  options: TaskExecutionKickoffOptions,
 ) {
   const cronContext = options.cronContext ?? extractCronContextFromInput(taskRun);
   const guidanceLines =
     taskRun.runType === "cron"
-      ? [...TASK_EXECUTION_GUIDANCE_LINES, ...CRON_EXECUTION_GUIDANCE_LINES]
+      ? buildCronExecutionGuidanceLines(options.contextMode)
       : TASK_EXECUTION_GUIDANCE_LINES;
 
   return renderXmlEnvelope("task_execution", [
@@ -116,6 +124,14 @@ function renderTaskKickoffMessage(
     ...renderKickoffInput(taskRun, cronContext),
     ...renderLineBlock("guidance", guidanceLines),
   ]);
+}
+
+function buildCronExecutionGuidanceLines(contextMode?: string | null): string[] {
+  return [
+    ...TASK_EXECUTION_GUIDANCE_LINES,
+    ...CRON_EXECUTION_GUIDANCE_LINES,
+    ...(contextMode === "group" ? GROUP_CRON_TRANSCRIPT_GUIDANCE_LINES : []),
+  ];
 }
 
 function formatTaskInput(inputJson: string): string {

--- a/tests/orchestration/agent-manager.test.ts
+++ b/tests/orchestration/agent-manager.test.ts
@@ -789,6 +789,84 @@ describe("AgentManager", () => {
     });
   });
 
+  test("creates isolated cron task executions without forking chat context", async () => {
+    await withHandle(async (handle) => {
+      seedFixture(handle);
+      const messagesRepo = new MessagesRepo(handle.storage.db);
+      handle.storage.sqlite.exec(`
+        INSERT INTO cron_jobs (
+          id, owner_agent_id, target_conversation_id, target_branch_id,
+          schedule_kind, schedule_value, context_mode, payload_json, created_at, updated_at
+        ) VALUES (
+          'cron_isolated', 'agent_sub', 'conv_sub', 'branch_sub',
+          'cron', '*/5 * * * *', 'isolated', '{"job":"reconcile"}',
+          '2026-03-25T00:00:00.000Z', '2026-03-25T00:00:00.000Z'
+        );
+        INSERT INTO sessions (
+          id, conversation_id, branch_id, owner_agent_id, purpose, context_mode, status,
+          compact_cursor, compact_summary, compact_summary_token_total, compact_summary_usage_json,
+          created_at, updated_at
+        ) VALUES (
+          'sess_sub_chat', 'conv_sub', 'branch_sub', 'agent_sub', 'chat', 'group', 'active',
+          1, 'subagent summary', 9, '{"input":5,"output":4,"cacheRead":0,"cacheWrite":0,"totalTokens":9}',
+          '2026-03-25T00:00:02.000Z', '2026-03-25T00:00:03.000Z'
+        );
+      `);
+      messagesRepo.append({
+        id: "msg_sub_1",
+        sessionId: "sess_sub_chat",
+        seq: 1,
+        role: "user",
+        payloadJson: '{"content":"older"}',
+        createdAt: new Date("2026-03-25T00:00:02.100Z"),
+      });
+      messagesRepo.append({
+        id: "msg_sub_2",
+        sessionId: "sess_sub_chat",
+        seq: 2,
+        role: "assistant",
+        provider: "anthropic_main",
+        model: "claude-sonnet-4-5",
+        modelApi: "anthropic-messages",
+        stopReason: "stop",
+        payloadJson: '{"content":[{"type":"text","text":"latest branch context"}]}',
+        createdAt: new Date("2026-03-25T00:00:02.200Z"),
+      });
+
+      const manager = new AgentManager({
+        storage: handle.storage.db,
+        ingress: {
+          submitMessage: vi.fn(async () => ({ status: "steered" as const })),
+          submitApprovalDecision: vi.fn(() => false),
+        },
+      });
+
+      const created = manager.createCronTaskExecutionFromJob({
+        cronJobId: "cron_isolated",
+        attempt: 1,
+        createdAt: new Date("2026-03-25T00:00:10.000Z"),
+      });
+
+      expect(created.executionSession).toMatchObject({
+        purpose: "task",
+        contextMode: "isolated",
+        conversationId: "conv_sub",
+        branchId: "branch_sub",
+        ownerAgentId: "agent_sub",
+        forkedFromSessionId: null,
+        forkSourceSeq: null,
+        compactSummary: null,
+      });
+
+      const context = new AgentSessionService(
+        new SessionsRepo(handle.storage.db),
+        messagesRepo,
+      ).getContext(created.executionSession.id);
+      expect(context.compactSummary).toBeNull();
+      expect(context.messages).toHaveLength(0);
+    });
+  });
+
   test("runs cron task executions from cron job definitions", async () => {
     await withHandle(async (handle) => {
       seedFixture(handle);
@@ -811,6 +889,10 @@ describe("AgentManager", () => {
             visibility: "hidden_system",
           });
           expect(input.content).toContain("<run_type>cron</run_type>");
+          expect(input.content).toContain("If inherited transcript is present");
+          expect(input.content).toContain(
+            "Do not treat inherited transcript as a request to continue the broader conversation",
+          );
 
           expect(input.afterToolResultHook).toBeDefined();
           return createStartedTaskRunResult({

--- a/tests/tasks/task-session.test.ts
+++ b/tests/tasks/task-session.test.ts
@@ -42,26 +42,31 @@ describe("buildTaskExecutionKickoffEnvelope", () => {
   });
 
   test("renders only the latest successful run when no failure history is relevant", () => {
-    const envelope = buildTaskExecutionKickoffEnvelope({
-      runType: "cron",
-      description: null,
-      inputJson: JSON.stringify({
-        taskDefinition:
-          "Seeing this message means you should check today's PR queue and give the user a complete update.",
-        recentRuns: {
-          lastRun: {
-            startedAt: "2026-03-27T08:00:00.000Z",
-            status: "completed",
-            summary: "Reviewed 3 pull requests.",
+    const envelope = buildTaskExecutionKickoffEnvelope(
+      {
+        runType: "cron",
+        description: null,
+        inputJson: JSON.stringify({
+          taskDefinition:
+            "Seeing this message means you should check today's PR queue and give the user a complete update.",
+          recentRuns: {
+            lastRun: {
+              startedAt: "2026-03-27T08:00:00.000Z",
+              status: "completed",
+              summary: "Reviewed 3 pull requests.",
+            },
+            lastSuccessfulRun: {
+              startedAt: "2026-03-27T08:00:00.000Z",
+              status: "completed",
+              summary: "Reviewed 3 pull requests.",
+            },
           },
-          lastSuccessfulRun: {
-            startedAt: "2026-03-27T08:00:00.000Z",
-            status: "completed",
-            summary: "Reviewed 3 pull requests.",
-          },
-        },
-      }),
-    });
+        }),
+      },
+      {
+        contextMode: "group",
+      },
+    );
 
     expect(envelope.content).toContain("<recent_runs>");
     expect(envelope.content).toContain("<reference_only>");
@@ -69,6 +74,11 @@ describe("buildTaskExecutionKickoffEnvelope", () => {
     expect(envelope.content).toContain("<last_run>");
     expect(envelope.content).toContain("Reviewed 3 pull requests.");
     expect(envelope.content).not.toContain("<last_successful_run>");
+    expect(envelope.content).toContain("If inherited transcript is present");
+    expect(envelope.content).toContain("Do not resume unrelated unfinished discussion");
+    expect(envelope.content).toContain(
+      "Complete the scheduled objective for this run, then end the task instead of continuing broader conversation",
+    );
   });
 
   test("renders failed last run plus last successful run and escapes xml content", () => {
@@ -101,6 +111,7 @@ describe("buildTaskExecutionKickoffEnvelope", () => {
     expect(envelope.content).toContain("Slack &lt;API&gt; timeout &amp; retry exhausted");
     expect(envelope.content).toContain("<last_successful_run>");
     expect(envelope.content).toContain("Posted report with 5 &lt;items&gt; &amp; links.");
+    expect(envelope.content).not.toContain("If inherited transcript is present");
   });
 
   test("renders a supervisor reminder for task runs that ended without finish_task", () => {


### PR DESCRIPTION
## Summary
- stop isolated cron executions from forking the latest chat session
- make cron kickoff guidance context-mode aware so group runs treat inherited transcript as task-only reference
- add regression coverage for isolated context behavior and group prompt wiring

## Testing
- pnpm preflight
