### PR TITLE
feat: add live config model switching in chat（by Pokoclaw）

### DIFF
--- a/src/agent/compaction.ts
+++ b/src/agent/compaction.ts
@@ -16,6 +16,10 @@ import type {
 } from "@/src/agent/llm/messages.js";
 import type { ResolvedModel } from "@/src/agent/llm/models.js";
 import type { ProviderRegistry } from "@/src/agent/llm/provider-registry.js";
+import {
+  type ProviderRegistrySource,
+  resolveProviderRegistry,
+} from "@/src/agent/llm/provider-registry-source.js";
 import type { AgentSessionService } from "@/src/agent/session.js";
 import type { CompactionConfig } from "@/src/config/schema.js";
 import { createSubsystemLogger } from "@/src/shared/logger.js";
@@ -169,7 +173,7 @@ export type CompactionLifecycleEventInput =
 
 export interface AgentCompactionServiceDependencies {
   sessions: AgentSessionService;
-  models: ProviderRegistry;
+  models: ProviderRegistry | ProviderRegistrySource;
   runner: CompactionModelRunner;
   config: CompactionConfig;
 }
@@ -374,7 +378,7 @@ export class AgentCompactionService {
   }
 
   private async execute(input: AgentCompactionInput): Promise<AgentCompactionResult> {
-    const model = this.deps.models.getRequiredScenarioModel("compaction");
+    const model = resolveProviderRegistry(this.deps.models).getRequiredScenarioModel("compaction");
     logger.info("starting compaction pass", {
       sessionId: input.sessionId,
       reason: input.reason,

--- a/src/agent/llm/models.ts
+++ b/src/agent/llm/models.ts
@@ -49,8 +49,7 @@ export interface ResolvedModel {
 const MODEL_SCENARIOS = [
   "chat",
   "compaction",
-  "subagent",
-  "cron",
+  "task",
   "meditationBucket",
   "meditationConsolidation",
 ] as const;

--- a/src/agent/llm/provider-registry-source.ts
+++ b/src/agent/llm/provider-registry-source.ts
@@ -1,0 +1,46 @@
+import { ProviderRegistry } from "@/src/agent/llm/provider-registry.js";
+import type { LiveConfigManager } from "@/src/config/live-manager.js";
+import type { AppConfig } from "@/src/config/schema.js";
+
+export interface ProviderRegistrySource {
+  current(): ProviderRegistry;
+}
+
+export class StaticProviderRegistrySource implements ProviderRegistrySource {
+  constructor(private readonly registry: ProviderRegistry) {}
+
+  current(): ProviderRegistry {
+    return this.registry;
+  }
+}
+
+export class LiveProviderRegistrySource implements ProviderRegistrySource {
+  private version = -1;
+  private registry: ProviderRegistry | null = null;
+
+  constructor(private readonly config: Pick<LiveConfigManager, "getSnapshot" | "getVersion">) {}
+
+  current(): ProviderRegistry {
+    const currentVersion = this.config.getVersion();
+    if (this.registry != null && this.version === currentVersion) {
+      return this.registry;
+    }
+
+    this.registry = new ProviderRegistry(selectModelConfig(this.config.getSnapshot()));
+    this.version = currentVersion;
+    return this.registry;
+  }
+}
+
+export function resolveProviderRegistry(
+  input: ProviderRegistry | ProviderRegistrySource,
+): ProviderRegistry {
+  return input instanceof ProviderRegistry ? input : input.current();
+}
+
+function selectModelConfig(snapshot: AppConfig): Pick<AppConfig, "providers" | "models"> {
+  return {
+    providers: snapshot.providers,
+    models: snapshot.models,
+  };
+}

--- a/src/agent/llm/provider-registry.ts
+++ b/src/agent/llm/provider-registry.ts
@@ -31,8 +31,7 @@ export class ProviderRegistry {
     this.scenarioModelIds = {
       chat: [...config.models.scenarios.chat],
       compaction: [...config.models.scenarios.compaction],
-      subagent: [...config.models.scenarios.subagent],
-      cron: [...config.models.scenarios.cron],
+      task: [...config.models.scenarios.task],
       meditationBucket: [...config.models.scenarios.meditationBucket],
       meditationConsolidation: [...config.models.scenarios.meditationConsolidation],
     };
@@ -136,5 +135,5 @@ export class ProviderRegistry {
 }
 
 function getScenarioKeys(): ModelScenario[] {
-  return ["chat", "compaction", "subagent", "cron", "meditationBucket", "meditationConsolidation"];
+  return ["chat", "compaction", "task", "meditationBucket", "meditationConsolidation"];
 }

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -32,6 +32,10 @@ import type {
 } from "@/src/agent/llm/messages.js";
 import type { ModelScenario, ResolvedModel } from "@/src/agent/llm/models.js";
 import type { ProviderRegistry } from "@/src/agent/llm/provider-registry.js";
+import {
+  type ProviderRegistrySource,
+  resolveProviderRegistry,
+} from "@/src/agent/llm/provider-registry-source.js";
 import { type AgentMemoryResolver, FilesystemAgentMemoryResolver } from "@/src/agent/memory.js";
 import type { AgentSessionService } from "@/src/agent/session.js";
 import { assertToolAllowedForSession } from "@/src/agent/session-policy.js";
@@ -185,7 +189,7 @@ export interface AgentLoopAfterToolResultHook {
 export interface AgentLoopDependencies {
   sessions: AgentSessionService;
   messages: MessagesRepo;
-  models: ProviderRegistry;
+  models: ProviderRegistry | ProviderRegistrySource;
   tools: ToolRegistry;
   skillsResolver?: AgentSkillsResolver;
   bootstrapResolver?: AgentBootstrapResolver;
@@ -400,7 +404,8 @@ export class AgentLoop {
         })),
       ),
     });
-    const model = this.deps.models.getRequiredScenarioModel(input.scenario);
+    const models = resolveProviderRegistry(this.deps.models);
+    const model = models.getRequiredScenarioModel(input.scenario);
     assertSessionModelSupportsTools({
       sessionPurpose: context.session.purpose,
       scenario: input.scenario,

--- a/src/channels/lark/channel.ts
+++ b/src/channels/lark/channel.ts
@@ -22,6 +22,7 @@ import {
   listConfiguredLarkInstallations,
   listEnabledLarkInstallations,
 } from "@/src/channels/lark/types.js";
+import type { ScenarioModelSwitchService } from "@/src/config/scenario-model-switch.js";
 import type { LarkChannelConfig } from "@/src/config/schema.js";
 import type { ResolveSubagentCreationRequestResult } from "@/src/orchestration/agent-manager.js";
 import type { OrchestratedOutboundEventEnvelope } from "@/src/orchestration/outbound-events.js";
@@ -56,6 +57,7 @@ export interface CreateLarkChannelRuntimeInput {
   ingress: LarkInboundIngress;
   control: RuntimeControlService;
   status?: RuntimeStatusService;
+  modelSwitch?: ScenarioModelSwitchService;
   outboundEventBus: RuntimeEventBus<OrchestratedOutboundEventEnvelope>;
   wsClientFactory?: (installation: ConfiguredLarkInstallation) => Lark.WSClient;
   clients?: LarkClientRegistry;
@@ -77,6 +79,7 @@ export function createLarkChannelRuntime(input: CreateLarkChannelRuntimeInput): 
     ingress: input.ingress,
     control: input.control,
     ...(input.status == null ? {} : { status: input.status }),
+    ...(input.modelSwitch == null ? {} : { modelSwitch: input.modelSwitch }),
     clients,
     ...(input.wsClientFactory == null ? {} : { wsClientFactory: input.wsClientFactory }),
     ...(input.subagentRequests == null ? {} : { subagentRequests: input.subagentRequests }),

--- a/src/channels/lark/inbound.ts
+++ b/src/channels/lark/inbound.ts
@@ -54,7 +54,7 @@ const LARK_INTERACTIVE_TEXT_TRUNCATED_NOTICE = "[卡片内容过长，引用文�
 export interface LarkInboundIngress {
   submitMessage(input: {
     sessionId: string;
-    scenario: "chat" | "cron" | "subagent";
+    scenario: "chat" | "task";
     content: string;
     userPayload?: AgentUserPayload;
     runtimeImages?: AgentUserRuntimeImagePayload[];
@@ -191,7 +191,7 @@ interface LarkInboundRoute {
   conversationId: string;
   branchId: string;
   sessionId: string;
-  scenario: "chat" | "cron" | "subagent";
+  scenario: "chat" | "task";
   stopScope: "conversation" | "session";
   chatId: string;
   replyToMessageId: string | null;
@@ -1008,6 +1008,7 @@ export function createLarkInboundRuntime(input: CreateLarkInboundRuntimeInput): 
           control: input.control,
           ...(input.clients == null ? {} : { clients: input.clients }),
           ...(input.status == null ? {} : { status: input.status }),
+          ...(input.modelSwitch == null ? {} : { modelSwitch: input.modelSwitch }),
           ...(input.clients == null
             ? {}
             : {
@@ -1579,7 +1580,6 @@ function buildTaskThreadRouteFromBinding(input: {
   }
   const metadata = parseBindingMetadata(input.binding.metadataJson);
   const sessionId = readString(metadata.sessionId);
-  const taskRunType = readString(metadata.taskRunType);
   const taskRunId = readString(metadata.taskRunId);
   if (sessionId == null || taskRunId == null) {
     return null;
@@ -1614,7 +1614,7 @@ function buildTaskThreadRouteFromBinding(input: {
     conversationId: session.conversationId,
     branchId: session.branchId,
     sessionId: session.id,
-    scenario: taskRunType === "cron" ? "cron" : "subagent",
+    scenario: "task",
     stopScope: "session",
     chatId: input.chatId,
     replyToMessageId: input.replyToMessageId,
@@ -2541,7 +2541,10 @@ function buildLarkModelSwitchCardCallbackResponse(input: {
     content: string;
   };
 }): {
-  card: Record<string, unknown>;
+  card: {
+    type: "raw";
+    data: Record<string, unknown>;
+  };
   toast?: {
     type: "success" | "info" | "error" | "warning";
     content: string;
@@ -2555,7 +2558,10 @@ function buildLarkModelSwitchCardCallbackResponse(input: {
   };
   const rendered = buildLarkRenderedModelSwitchCard(state);
   return {
-    card: rendered.card,
+    card: {
+      type: "raw",
+      data: rendered.card,
+    },
     ...(input.toast == null ? {} : { toast: input.toast }),
   };
 }
@@ -2712,8 +2718,7 @@ function parseBindingMetadata(raw: string | null): Record<string, unknown> {
 function normalizeModelScenario(value: unknown): ModelScenario | null {
   return value === "chat" ||
     value === "compaction" ||
-    value === "subagent" ||
-    value === "cron" ||
+    value === "task" ||
     value === "meditationBucket" ||
     value === "meditationConsolidation"
     ? value

--- a/src/channels/lark/inbound.ts
+++ b/src/channels/lark/inbound.ts
@@ -15,8 +15,14 @@ import {
   type AgentUserRuntimeImagePayload,
   normalizeAgentUserImageMessageId,
 } from "@/src/agent/llm/messages.js";
+import type { ModelScenario } from "@/src/agent/llm/models.js";
 import type { LarkSdkClient } from "@/src/channels/lark/client.js";
+import {
+  buildLarkRenderedModelSwitchCard,
+  type LarkModelSwitchCardState,
+} from "@/src/channels/lark/render.js";
 import type { ConfiguredLarkInstallation } from "@/src/channels/lark/types.js";
+import type { ScenarioModelSwitchService } from "@/src/config/scenario-model-switch.js";
 import type { ResolveSubagentCreationRequestResult } from "@/src/orchestration/agent-manager.js";
 import { materializeForkedSessionSnapshotInStorage } from "@/src/orchestration/session-fork.js";
 import type { RuntimeControlService } from "@/src/runtime/control.js";
@@ -74,6 +80,7 @@ export interface CreateLarkInboundRuntimeInput {
   ingress: LarkInboundIngress;
   control: RuntimeControlService;
   status?: RuntimeStatusService;
+  modelSwitch?: ScenarioModelSwitchService;
   clients?: {
     getOrCreate(installationId: string): LarkSdkClient;
   };
@@ -167,6 +174,8 @@ export interface NormalizedLarkCardAction {
   requestId: string | null;
   grantTtl: "one_day" | "permanent" | null;
   actorOpenId: string | null;
+  scenario: ModelScenario | null;
+  modelId: string | null;
 }
 
 export function buildLarkChatSurfaceKey(chatId: string): string {
@@ -281,6 +290,7 @@ export function createLarkMessageReceiveHandler(input: {
   ingress: LarkInboundIngress;
   control: RuntimeControlService;
   status?: RuntimeStatusService;
+  modelSwitch?: ScenarioModelSwitchService;
   clients?: {
     getOrCreate(installationId: string): LarkSdkClient;
   };
@@ -415,6 +425,36 @@ export function createLarkMessageReceiveHandler(input: {
         conversationId: route.conversationId,
         sessionId: route.sessionId,
         scenario: route.scenario,
+        routeKind: route.kind,
+      });
+      return;
+    }
+
+    if (hydrated.text === "/model") {
+      if (input.modelSwitch == null) {
+        logger.warn("ignoring lark model command because no model switch service is configured", {
+          installationId: input.installationId,
+          chatId: hydrated.chatId,
+          messageId: hydrated.messageId,
+        });
+        return;
+      }
+      await sendLarkModelSwitchCard({
+        installationId: input.installationId,
+        chatId: route.chatId,
+        replyToMessageId: route.replyToMessageId,
+        state: {
+          overview: input.modelSwitch.getOverview(),
+          selectedScenario: null,
+        },
+        ...(input.clients == null ? {} : { clients: input.clients }),
+      });
+      logger.info("processed lark model command", {
+        installationId: input.installationId,
+        chatId: hydrated.chatId,
+        messageId: hydrated.messageId,
+        conversationId: route.conversationId,
+        sessionId: route.sessionId,
         routeKind: route.kind,
       });
       return;
@@ -572,6 +612,11 @@ export function normalizeLarkCardAction(
     operator != null && typeof operator.open_id === "string" && operator.open_id.length > 0
       ? operator.open_id
       : null;
+  const scenario = normalizeModelScenario(value?.scenario);
+  const modelId =
+    typeof value?.modelId === "string" && value.modelId.trim().length > 0
+      ? value.modelId.trim()
+      : null;
 
   return {
     action: actionName,
@@ -583,6 +628,8 @@ export function normalizeLarkCardAction(
     requestId,
     grantTtl,
     actorOpenId,
+    scenario,
+    modelId,
   };
 }
 
@@ -590,6 +637,7 @@ export function createLarkCardActionHandler(input: {
   installationId: string;
   ingress: LarkInboundIngress;
   control: RuntimeControlService;
+  modelSwitch?: ScenarioModelSwitchService;
   subagentRequests?: {
     approve(requestId: string): Promise<ResolveSubagentCreationRequestResult>;
     deny(
@@ -631,7 +679,9 @@ export function createLarkCardActionHandler(input: {
       normalized.action !== "approve_permission" &&
       normalized.action !== "deny_permission" &&
       normalized.action !== "approve_subagent_creation" &&
-      normalized.action !== "deny_subagent_creation"
+      normalized.action !== "deny_subagent_creation" &&
+      normalized.action !== "model_switch_select_scenario" &&
+      normalized.action !== "model_switch_apply"
     ) {
       logger.debug("ignoring unsupported lark card action", {
         installationId: input.installationId,
@@ -678,6 +728,75 @@ export function createLarkCardActionHandler(input: {
           content: result.accepted ? "正在停止..." : "该运行已结束或无法停止",
         },
       };
+    }
+
+    if (
+      normalized.action === "model_switch_select_scenario" ||
+      normalized.action === "model_switch_apply"
+    ) {
+      if (input.modelSwitch == null) {
+        return {
+          toast: {
+            type: "error",
+            content: "当前环境未启用模型切换",
+          },
+        };
+      }
+      if (normalized.scenario == null) {
+        return {
+          toast: {
+            type: "error",
+            content: "无法识别目标场景",
+          },
+        };
+      }
+
+      try {
+        if (normalized.action === "model_switch_select_scenario") {
+          return buildLarkModelSwitchCardCallbackResponse({
+            overview: input.modelSwitch.getOverview(),
+            selectedScenario: normalized.scenario,
+          });
+        }
+
+        if (normalized.modelId == null) {
+          return {
+            toast: {
+              type: "error",
+              content: "无法识别目标模型",
+            },
+          };
+        }
+
+        const result = await input.modelSwitch.switchScenarioModel({
+          scenario: normalized.scenario,
+          modelId: normalized.modelId,
+        });
+        return buildLarkModelSwitchCardCallbackResponse({
+          overview: input.modelSwitch.getOverview(),
+          selectedScenario: result.scenario,
+          message: `已将 ${result.scenario} 切换到 ${result.nextModelId}。新配置会从下一次新的输入开始生效。`,
+          warnings: result.warnings,
+          toast: {
+            type: "success",
+            content: `已切换 ${result.scenario} → ${result.nextModelId}`,
+          },
+        });
+      } catch (error: unknown) {
+        logger.error("failed to process lark model switch card action", {
+          installationId: input.installationId,
+          action: normalized.action,
+          scenario: normalized.scenario,
+          modelId: normalized.modelId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return {
+          toast: {
+            type: "error",
+            content: error instanceof Error ? error.message : "模型切换失败",
+          },
+        };
+      }
     }
 
     if (
@@ -902,6 +1021,7 @@ export function createLarkInboundRuntime(input: CreateLarkInboundRuntimeInput): 
           installationId: installation.installationId,
           ingress: input.ingress,
           control: input.control,
+          ...(input.modelSwitch == null ? {} : { modelSwitch: input.modelSwitch }),
           ...(input.subagentRequests == null ? {} : { subagentRequests: input.subagentRequests }),
         });
 
@@ -2411,6 +2531,94 @@ async function fetchQuotedLarkMessage(input: {
   });
 }
 
+function buildLarkModelSwitchCardCallbackResponse(input: {
+  overview: ReturnType<ScenarioModelSwitchService["getOverview"]>;
+  selectedScenario: ModelScenario | null;
+  message?: string;
+  warnings?: string[];
+  toast?: {
+    type: "success" | "info" | "error" | "warning";
+    content: string;
+  };
+}): {
+  card: Record<string, unknown>;
+  toast?: {
+    type: "success" | "info" | "error" | "warning";
+    content: string;
+  };
+} {
+  const state: LarkModelSwitchCardState = {
+    overview: input.overview,
+    selectedScenario: input.selectedScenario,
+    ...(input.message == null ? {} : { message: input.message }),
+    ...(input.warnings == null ? {} : { warnings: input.warnings }),
+  };
+  const rendered = buildLarkRenderedModelSwitchCard(state);
+  return {
+    card: rendered.card,
+    ...(input.toast == null ? {} : { toast: input.toast }),
+  };
+}
+
+async function sendLarkModelSwitchCard(input: {
+  installationId: string;
+  chatId: string;
+  replyToMessageId?: string | null;
+  state: LarkModelSwitchCardState;
+  clients?: {
+    getOrCreate(installationId: string): LarkSdkClient;
+  };
+}): Promise<void> {
+  const rendered = buildLarkRenderedModelSwitchCard(input.state);
+  await sendLarkInteractiveCard({
+    installationId: input.installationId,
+    chatId: input.chatId,
+    ...(input.replyToMessageId === undefined ? {} : { replyToMessageId: input.replyToMessageId }),
+    card: rendered.card,
+    ...(input.clients == null ? {} : { clients: input.clients }),
+  });
+}
+
+async function sendLarkInteractiveCard(input: {
+  installationId: string;
+  chatId: string;
+  replyToMessageId?: string | null;
+  card: Record<string, unknown>;
+  clients?: {
+    getOrCreate(installationId: string): LarkSdkClient;
+  };
+}): Promise<void> {
+  if (input.clients == null) {
+    logger.warn("cannot send lark interactive card because no sdk clients are configured", {
+      installationId: input.installationId,
+      chatId: input.chatId,
+    });
+    return;
+  }
+
+  const client = input.clients.getOrCreate(input.installationId);
+  if (input.replyToMessageId != null && input.replyToMessageId.length > 0) {
+    await client.sdk.im.message.reply({
+      path: { message_id: input.replyToMessageId },
+      data: {
+        msg_type: "interactive",
+        content: JSON.stringify(input.card),
+        reply_in_thread: true,
+      },
+    });
+    return;
+  }
+
+  await client.sdk.im.message.create({
+    params: { receive_id_type: "chat_id" },
+    data: {
+      receive_id: input.chatId,
+      msg_type: "interactive",
+      content: JSON.stringify(input.card),
+    },
+  });
+}
+
 async function sendLarkStatusCard(input: {
   installationId: string;
   chatId: string;
@@ -2425,15 +2633,6 @@ async function sendLarkStatusCard(input: {
     getOrCreate(installationId: string): LarkSdkClient;
   };
 }): Promise<void> {
-  if (input.clients == null) {
-    logger.warn("cannot send lark status card because no sdk clients are configured", {
-      installationId: input.installationId,
-      chatId: input.chatId,
-    });
-    return;
-  }
-
-  const client = input.clients.getOrCreate(input.installationId);
   const card = {
     schema: "2.0",
     config: {
@@ -2460,25 +2659,12 @@ async function sendLarkStatusCard(input: {
       ]),
     },
   };
-  if (input.replyToMessageId != null && input.replyToMessageId.length > 0) {
-    await client.sdk.im.message.reply({
-      path: { message_id: input.replyToMessageId },
-      data: {
-        msg_type: "interactive",
-        content: JSON.stringify(card),
-        reply_in_thread: true,
-      },
-    });
-    return;
-  }
-
-  await client.sdk.im.message.create({
-    params: { receive_id_type: "chat_id" },
-    data: {
-      receive_id: input.chatId,
-      msg_type: "interactive",
-      content: JSON.stringify(card),
-    },
+  await sendLarkInteractiveCard({
+    installationId: input.installationId,
+    chatId: input.chatId,
+    ...(input.replyToMessageId === undefined ? {} : { replyToMessageId: input.replyToMessageId }),
+    card,
+    ...(input.clients == null ? {} : { clients: input.clients }),
   });
 }
 
@@ -2521,6 +2707,17 @@ function parseBindingMetadata(raw: string | null): Record<string, unknown> {
   } catch {}
 
   return {};
+}
+
+function normalizeModelScenario(value: unknown): ModelScenario | null {
+  return value === "chat" ||
+    value === "compaction" ||
+    value === "subagent" ||
+    value === "cron" ||
+    value === "meditationBucket" ||
+    value === "meditationConsolidation"
+    ? value
+    : null;
 }
 
 function readString(value: unknown): string | null {

--- a/src/channels/lark/render.ts
+++ b/src/channels/lark/render.ts
@@ -8,6 +8,11 @@ import type { LarkApprovalState } from "@/src/channels/lark/approval-state.js";
 import { describePermissionRequestLines } from "@/src/security/scope.js";
 
 export {
+  buildLarkRenderedModelSwitchCard,
+  type LarkModelSwitchCardState,
+  type LarkRenderedModelSwitchCard,
+} from "@/src/channels/lark/render/model-switch-card.js";
+export {
   buildLarkRenderedRunCard,
   buildLarkRenderedRunCardPages,
   type LarkRenderedRunCard,

--- a/src/channels/lark/render/model-switch-card.ts
+++ b/src/channels/lark/render/model-switch-card.ts
@@ -1,0 +1,220 @@
+import type { ModelScenario } from "@/src/agent/llm/models.js";
+import type {
+  ScenarioModelCatalogSummary,
+  ScenarioModelStateSummary,
+  ScenarioModelSwitchOverview,
+} from "@/src/config/scenario-model-switch.js";
+
+export interface LarkModelSwitchCardState {
+  overview: ScenarioModelSwitchOverview;
+  selectedScenario: ModelScenario | null;
+  message?: string | null;
+  warnings?: string[];
+}
+
+export interface LarkRenderedModelSwitchCard {
+  card: Record<string, unknown>;
+  structureSignature: string;
+}
+
+export function buildLarkRenderedModelSwitchCard(
+  state: LarkModelSwitchCardState,
+): LarkRenderedModelSwitchCard {
+  const selectedScenario =
+    state.selectedScenario == null
+      ? null
+      : (state.overview.scenarios.find(
+          (scenario) => scenario.scenario === state.selectedScenario,
+        ) ?? null);
+  const card = {
+    schema: "2.0",
+    config: {
+      update_multi: true,
+      wide_screen_mode: false,
+      summary: {
+        content: buildSummary(state, selectedScenario),
+      },
+    },
+    header: {
+      title: {
+        tag: "plain_text",
+        content: "模型切换",
+      },
+      subtitle: {
+        tag: "plain_text",
+        content:
+          selectedScenario == null
+            ? "选择一个场景，然后切换它的首选模型"
+            : `当前场景：${selectedScenario.scenario}`,
+      },
+      template: state.warnings != null && state.warnings.length > 0 ? "orange" : "turquoise",
+    },
+    body: {
+      elements: buildModelSwitchCardElements(state, selectedScenario),
+    },
+  };
+
+  return {
+    card,
+    structureSignature: JSON.stringify(card),
+  };
+}
+
+function buildModelSwitchCardElements(
+  state: LarkModelSwitchCardState,
+  selectedScenario: ScenarioModelStateSummary | null,
+): Array<Record<string, unknown>> {
+  const elements: Array<Record<string, unknown>> = [];
+  if (state.message != null && state.message.length > 0) {
+    elements.push({
+      tag: "markdown",
+      content: `> ${state.message}`,
+    });
+  }
+  if (state.warnings != null && state.warnings.length > 0) {
+    elements.push({
+      tag: "markdown",
+      content: state.warnings.map((warning) => `- ⚠️ ${warning}`).join("\n"),
+    });
+  }
+
+  elements.push({
+    tag: "markdown",
+    content: buildOverviewMarkdown(state.overview),
+  });
+  elements.push({ tag: "hr" });
+  elements.push({
+    tag: "markdown",
+    content: "### 选择场景",
+  });
+  for (const scenario of state.overview.scenarios) {
+    elements.push(buildScenarioRow(scenario, state.selectedScenario));
+  }
+
+  if (selectedScenario != null) {
+    elements.push({ tag: "hr" });
+    elements.push({
+      tag: "markdown",
+      content: `### 为 **${selectedScenario.scenario}** 选择模型`,
+    });
+    for (const model of state.overview.models) {
+      elements.push(buildModelRow(selectedScenario, model));
+    }
+  }
+
+  return elements;
+}
+
+function buildOverviewMarkdown(overview: ScenarioModelSwitchOverview): string {
+  const modelLines = overview.models.map(
+    (model) =>
+      `${model.index}. **${model.modelId}** · provider: \`${model.providerId}\` · upstream: \`${model.upstreamModelId}\` · tools: ${model.supportsTools ? "yes" : "no"} · reasoning: ${model.supportsReasoning ? "yes" : "no"}`,
+  );
+  const scenarioLines = overview.scenarios.map(
+    (scenario) =>
+      `- **${scenario.scenario}** → ${scenario.currentModelId == null ? "(未配置)" : `\`${scenario.currentModelId}\``}`,
+  );
+  return ["### 模型目录", ...modelLines, "", "### 当前场景", ...scenarioLines].join("\n");
+}
+
+function buildScenarioRow(
+  scenario: ScenarioModelStateSummary,
+  selectedScenario: ModelScenario | null,
+): Record<string, unknown> {
+  const isSelected = scenario.scenario === selectedScenario;
+  return {
+    tag: "column_set",
+    flex_mode: "none",
+    columns: [
+      {
+        tag: "column",
+        width: "weighted",
+        weight: 4,
+        elements: [
+          {
+            tag: "markdown",
+            content: `**${scenario.scenario}**\n${scenario.currentModelId == null ? "当前未配置" : `当前：\`${scenario.currentModelId}\``}`,
+          },
+        ],
+      },
+      {
+        tag: "column",
+        width: "auto",
+        elements: [
+          {
+            tag: "button",
+            type: isSelected ? "primary" : "default",
+            text: {
+              tag: "plain_text",
+              content: isSelected ? "已选中" : "选择",
+            },
+            value: {
+              action: "model_switch_select_scenario",
+              scenario: scenario.scenario,
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function buildModelRow(
+  scenario: ScenarioModelStateSummary,
+  model: ScenarioModelCatalogSummary,
+): Record<string, unknown> {
+  const isCurrent = scenario.currentModelId === model.modelId;
+  return {
+    tag: "column_set",
+    flex_mode: "none",
+    columns: [
+      {
+        tag: "column",
+        width: "weighted",
+        weight: 5,
+        elements: [
+          {
+            tag: "markdown",
+            content: [
+              `**${model.index}. ${model.modelId}**${isCurrent ? " · 当前使用" : ""}`,
+              `provider: \`${model.providerId}\` · upstream: \`${model.upstreamModelId}\``,
+              `tools: ${model.supportsTools ? "yes" : "no"} · reasoning: ${model.supportsReasoning ? "yes" : "no"}`,
+            ].join("\n"),
+          },
+        ],
+      },
+      {
+        tag: "column",
+        width: "auto",
+        elements: [
+          {
+            tag: "button",
+            type: isCurrent ? "default" : "primary",
+            text: {
+              tag: "plain_text",
+              content: isCurrent ? "当前模型" : "切换到这里",
+            },
+            value: {
+              action: "model_switch_apply",
+              scenario: scenario.scenario,
+              modelId: model.modelId,
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function buildSummary(
+  state: LarkModelSwitchCardState,
+  selectedScenario: ScenarioModelStateSummary | null,
+): string {
+  if (state.message != null && state.message.length > 0) {
+    return state.message;
+  }
+  if (selectedScenario != null) {
+    return `为 ${selectedScenario.scenario} 选择模型`;
+  }
+  return "查看场景当前模型并切换首选模型";
+}

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -15,8 +15,7 @@ export const DEFAULT_CONFIG: RawConfig = {
     scenarios: {
       chat: [],
       compaction: [],
-      subagent: [],
-      cron: [],
+      task: [],
       meditationBucket: [],
       meditationConsolidation: [],
     },

--- a/src/config/live-manager.ts
+++ b/src/config/live-manager.ts
@@ -1,0 +1,195 @@
+import { type FSWatcher, watch } from "node:fs";
+import path from "node:path";
+import { type LoadConfigOptions, loadConfig } from "@/src/config/load.js";
+import type { AppConfig } from "@/src/config/schema.js";
+import { createSubsystemLogger } from "@/src/shared/logger.js";
+
+const logger = createSubsystemLogger("config/live-manager");
+const DEFAULT_WATCH_DEBOUNCE_MS = 150;
+
+export interface LiveConfigManagerOptions {
+  initialSnapshot: AppConfig;
+  filePaths?: Required<LoadConfigOptions>;
+  watchDebounceMs?: number;
+}
+
+export interface LiveConfigChangeEvent {
+  version: number;
+  snapshot: AppConfig;
+  reason: string;
+}
+
+export interface ReloadConfigResult {
+  reloaded: boolean;
+  version: number;
+  reason: string;
+}
+
+export class LiveConfigManager {
+  private snapshot: AppConfig;
+  private snapshotJson: string;
+  private version = 1;
+  private readonly listeners = new Set<(event: LiveConfigChangeEvent) => void>();
+  private readonly watchDebounceMs: number;
+  private readonly watchers = new Map<string, FSWatcher>();
+  private reloadPromise: Promise<ReloadConfigResult> | null = null;
+  private watchTimer: NodeJS.Timeout | null = null;
+  private startedWatching = false;
+
+  constructor(private readonly options: LiveConfigManagerOptions) {
+    this.snapshot = options.initialSnapshot;
+    this.snapshotJson = JSON.stringify(options.initialSnapshot);
+    this.watchDebounceMs = options.watchDebounceMs ?? DEFAULT_WATCH_DEBOUNCE_MS;
+  }
+
+  getSnapshot(): AppConfig {
+    return this.snapshot;
+  }
+
+  getVersion(): number {
+    return this.version;
+  }
+
+  getFilePaths(): Required<LoadConfigOptions> | null {
+    return this.options.filePaths ?? null;
+  }
+
+  subscribe(listener: (event: LiveConfigChangeEvent) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  async reloadFromDisk(reason = "manual_reload"): Promise<ReloadConfigResult> {
+    if (this.options.filePaths == null) {
+      throw new Error(
+        "Live config reload is unavailable because no config file paths were configured.",
+      );
+    }
+    if (this.reloadPromise != null) {
+      return this.reloadPromise;
+    }
+
+    this.reloadPromise = (async () => {
+      const nextSnapshot = await loadConfig(this.options.filePaths);
+      return this.replaceSnapshot(nextSnapshot, reason);
+    })().finally(() => {
+      this.reloadPromise = null;
+    });
+
+    return this.reloadPromise;
+  }
+
+  startWatching(): void {
+    if (this.startedWatching || this.options.filePaths == null) {
+      return;
+    }
+
+    const watchedFiles = [
+      this.options.filePaths.configTomlPath,
+      this.options.filePaths.secretsTomlPath,
+    ];
+    const watchedBasenames = new Set(watchedFiles.map((filePath) => path.basename(filePath)));
+    const watchedDirs = new Set(watchedFiles.map((filePath) => path.dirname(filePath)));
+
+    for (const dirPath of watchedDirs) {
+      try {
+        const watcher = watch(dirPath, (_eventType, filename) => {
+          const normalized = typeof filename === "string" ? filename : "";
+          if (!watchedBasenames.has(normalized)) {
+            return;
+          }
+          this.scheduleReload(`watch:${normalized}`);
+        });
+        this.watchers.set(dirPath, watcher);
+      } catch (error: unknown) {
+        logger.warn("failed to start config directory watcher", {
+          dirPath,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    this.startedWatching = true;
+    logger.info("live config watching started", {
+      watcherCount: this.watchers.size,
+      configTomlPath: this.options.filePaths.configTomlPath,
+      secretsTomlPath: this.options.filePaths.secretsTomlPath,
+    });
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.watchTimer != null) {
+      clearTimeout(this.watchTimer);
+      this.watchTimer = null;
+    }
+    for (const watcher of this.watchers.values()) {
+      watcher.close();
+    }
+    this.watchers.clear();
+    this.startedWatching = false;
+  }
+
+  private scheduleReload(reason: string): void {
+    if (this.watchTimer != null) {
+      clearTimeout(this.watchTimer);
+    }
+
+    this.watchTimer = setTimeout(() => {
+      this.watchTimer = null;
+      void this.reloadFromDisk(reason).catch((error: unknown) => {
+        logger.warn("live config reload failed", {
+          reason,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    }, this.watchDebounceMs);
+  }
+
+  private replaceSnapshot(nextSnapshot: AppConfig, reason: string): ReloadConfigResult {
+    const nextJson = JSON.stringify(nextSnapshot);
+    if (nextJson === this.snapshotJson) {
+      logger.debug("live config reload skipped because snapshot was unchanged", {
+        reason,
+        version: this.version,
+      });
+      return {
+        reloaded: false,
+        version: this.version,
+        reason,
+      };
+    }
+
+    this.snapshot = nextSnapshot;
+    this.snapshotJson = nextJson;
+    this.version += 1;
+    logger.info("live config snapshot replaced", {
+      reason,
+      version: this.version,
+    });
+
+    const event: LiveConfigChangeEvent = {
+      version: this.version,
+      snapshot: this.snapshot,
+      reason,
+    };
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch (error: unknown) {
+        logger.warn("live config subscriber threw during notification", {
+          reason,
+          version: this.version,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    return {
+      reloaded: true,
+      version: this.version,
+      reason,
+    };
+  }
+}

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -5,12 +5,12 @@ import { resolveConfigRefs } from "@/src/config/refs.js";
 import { type AppConfig, validateFileConfig, validateSecretsFile } from "@/src/config/schema.js";
 import { DEFAULT_CONFIG_TOML_PATH, DEFAULT_SECRETS_TOML_PATH } from "@/src/shared/paths.js";
 
-interface LoadConfigOptions {
+export interface LoadConfigOptions {
   configTomlPath?: string;
   secretsTomlPath?: string;
 }
 
-async function readOptionalTomlFile(filePath: string): Promise<unknown | undefined> {
+export async function readOptionalTomlFile(filePath: string): Promise<unknown | undefined> {
   try {
     const content = await readFile(filePath, "utf8");
     return parse(content);
@@ -28,7 +28,7 @@ function isMissingFileError(error: unknown): boolean {
   return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
 }
 
-function getDefaultConfigPaths(): Required<LoadConfigOptions> {
+export function getDefaultConfigPaths(): Required<LoadConfigOptions> {
   return {
     configTomlPath: DEFAULT_CONFIG_TOML_PATH,
     secretsTomlPath: DEFAULT_SECRETS_TOML_PATH,
@@ -43,16 +43,10 @@ async function loadSecretsToml(secretsTomlPath: string): Promise<unknown | undef
   return readOptionalTomlFile(secretsTomlPath);
 }
 
-export async function loadConfig(options?: LoadConfigOptions): Promise<AppConfig> {
-  const defaultPaths = getDefaultConfigPaths();
-  const configTomlPath = options?.configTomlPath ?? defaultPaths.configTomlPath;
-  const secretsTomlPath = options?.secretsTomlPath ?? defaultPaths.secretsTomlPath;
-
-  const [rawConfigInput, rawSecretsInput] = await Promise.all([
-    loadConfigToml(configTomlPath),
-    loadSecretsToml(secretsTomlPath),
-  ]);
-
+export function buildAppConfigFromInputs(
+  rawConfigInput: unknown | undefined,
+  rawSecretsInput: unknown | undefined,
+): AppConfig {
   const secrets = validateSecretsFile(rawSecretsInput).root;
   const resolvedConfigInput = resolveConfigRefs(rawConfigInput, secrets);
   const resolvedConfig = validateFileConfig(resolvedConfigInput, DEFAULT_CONFIG);
@@ -69,4 +63,17 @@ export async function loadConfig(options?: LoadConfigOptions): Promise<AppConfig
     channels: resolvedConfig.channels,
     secrets,
   };
+}
+
+export async function loadConfig(options?: LoadConfigOptions): Promise<AppConfig> {
+  const defaultPaths = getDefaultConfigPaths();
+  const configTomlPath = options?.configTomlPath ?? defaultPaths.configTomlPath;
+  const secretsTomlPath = options?.secretsTomlPath ?? defaultPaths.secretsTomlPath;
+
+  const [rawConfigInput, rawSecretsInput] = await Promise.all([
+    loadConfigToml(configTomlPath),
+    loadSecretsToml(secretsTomlPath),
+  ]);
+
+  return buildAppConfigFromInputs(rawConfigInput, rawSecretsInput);
 }

--- a/src/config/model-scenario-patch.ts
+++ b/src/config/model-scenario-patch.ts
@@ -1,0 +1,178 @@
+const MODELS_SCENARIOS_SECTION_HEADER = "[models.scenarios]";
+
+export interface PatchScenarioModelListInput {
+  tomlText: string;
+  scenario: string;
+  modelIds: string[];
+}
+
+export function patchScenarioModelListInToml(input: PatchScenarioModelListInput): string {
+  const section = findSectionRange(input.tomlText, MODELS_SCENARIOS_SECTION_HEADER);
+  const formattedSingleLine = formatTomlArray(input.modelIds, {
+    multiline: false,
+    indent: "",
+  });
+
+  if (section == null) {
+    const separator =
+      input.tomlText.trim().length === 0 ? "" : input.tomlText.endsWith("\n") ? "\n" : "\n\n";
+    return [
+      input.tomlText,
+      separator,
+      `${MODELS_SCENARIOS_SECTION_HEADER}\n${input.scenario} = ${formattedSingleLine}\n`,
+    ].join("");
+  }
+
+  const sectionText = input.tomlText.slice(section.contentStart, section.contentEnd);
+  const assignment = findScenarioAssignment(sectionText, input.scenario);
+  if (assignment == null) {
+    const insertion = `${input.scenario} = ${formattedSingleLine}\n`;
+    return [
+      input.tomlText.slice(0, section.contentEnd),
+      needsLeadingNewline(sectionText) ? "\n" : "",
+      insertion,
+      input.tomlText.slice(section.contentEnd),
+    ].join("");
+  }
+
+  const valueStart = section.contentStart + assignment.valueStart;
+  const valueEnd = section.contentStart + assignment.valueEnd;
+  const formatted = formatTomlArray(input.modelIds, {
+    multiline: assignment.originalValue.includes("\n"),
+    indent: assignment.indent,
+  });
+  return [input.tomlText.slice(0, valueStart), formatted, input.tomlText.slice(valueEnd)].join("");
+}
+
+function findSectionRange(
+  text: string,
+  header: string,
+): { headerStart: number; contentStart: number; contentEnd: number } | null {
+  const pattern = new RegExp(`^${escapeRegExp(header)}\\s*(?:#.*)?$`, "m");
+  const match = pattern.exec(text);
+  if (match == null || match.index == null) {
+    return null;
+  }
+
+  const headerStart = match.index;
+  const lineEnd = text.indexOf("\n", headerStart);
+  const contentStart = lineEnd === -1 ? text.length : lineEnd + 1;
+  const nextHeaderPattern = /^\[[^\]]+\]\s*(?:#.*)?$/m;
+  const nextHeaderMatch = nextHeaderPattern.exec(text.slice(contentStart));
+  const contentEnd =
+    nextHeaderMatch == null || nextHeaderMatch.index == null
+      ? text.length
+      : contentStart + nextHeaderMatch.index;
+
+  return {
+    headerStart,
+    contentStart,
+    contentEnd,
+  };
+}
+
+function findScenarioAssignment(
+  sectionText: string,
+  scenario: string,
+): { valueStart: number; valueEnd: number; indent: string; originalValue: string } | null {
+  const pattern = new RegExp(`^([ \t]*)${escapeRegExp(scenario)}\\s*=`, "m");
+  const match = pattern.exec(sectionText);
+  if (match == null || match.index == null) {
+    return null;
+  }
+
+  const indent = match[1] ?? "";
+  const equalsIndex = sectionText.indexOf("=", match.index);
+  if (equalsIndex === -1) {
+    return null;
+  }
+
+  const valueStart = skipInlineWhitespace(sectionText, equalsIndex + 1);
+  const valueEnd = findArrayValueEnd(sectionText, valueStart);
+  const originalValue = sectionText.slice(valueStart, valueEnd);
+  return {
+    valueStart,
+    valueEnd,
+    indent,
+    originalValue,
+  };
+}
+
+function skipInlineWhitespace(text: string, start: number): number {
+  let index = start;
+  while (index < text.length && (text[index] === " " || text[index] === "\t")) {
+    index += 1;
+  }
+  return index;
+}
+
+function findArrayValueEnd(text: string, start: number): number {
+  if (text[start] !== "[") {
+    throw new Error(`Expected TOML array value to start with '[' at index ${start}`);
+  }
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let index = start; index < text.length; index += 1) {
+    const char = text[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === "[") {
+      depth += 1;
+      continue;
+    }
+    if (char === "]") {
+      depth -= 1;
+      if (depth === 0) {
+        return index + 1;
+      }
+    }
+  }
+
+  throw new Error("Failed to locate the closing bracket for models.scenarios array value.");
+}
+
+function formatTomlArray(
+  modelIds: string[],
+  input: {
+    multiline: boolean;
+    indent: string;
+  },
+): string {
+  if (!input.multiline) {
+    return `[${modelIds.map((value) => JSON.stringify(value)).join(", ")}]`;
+  }
+
+  const itemIndent = `${input.indent}  `;
+  return [
+    "[",
+    ...modelIds.map((value) => `${itemIndent}${JSON.stringify(value)},`),
+    `${input.indent}]`,
+  ].join("\n");
+}
+
+function needsLeadingNewline(sectionText: string): boolean {
+  return sectionText.length > 0 && !sectionText.endsWith("\n") && !sectionText.endsWith("\r\n");
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/config/scenario-model-switch.ts
+++ b/src/config/scenario-model-switch.ts
@@ -1,0 +1,201 @@
+import { readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { parse } from "toml";
+import type { ModelScenario } from "@/src/agent/llm/models.js";
+import type { LiveConfigManager } from "@/src/config/live-manager.js";
+import { buildAppConfigFromInputs, readOptionalTomlFile } from "@/src/config/load.js";
+import { patchScenarioModelListInToml } from "@/src/config/model-scenario-patch.js";
+import type { AppConfig, ModelCatalogEntry } from "@/src/config/schema.js";
+
+export interface ScenarioModelCatalogSummary {
+  index: number;
+  modelId: string;
+  providerId: string;
+  upstreamModelId: string;
+  supportsTools: boolean;
+  supportsVision: boolean;
+  supportsReasoning: boolean;
+}
+
+export interface ScenarioModelStateSummary {
+  scenario: ModelScenario;
+  currentModelId: string | null;
+  configuredModelIds: string[];
+}
+
+export interface ScenarioModelSwitchOverview {
+  models: ScenarioModelCatalogSummary[];
+  scenarios: ScenarioModelStateSummary[];
+}
+
+export interface SwitchScenarioModelInput {
+  scenario: ModelScenario;
+  modelId: string;
+}
+
+export interface SwitchScenarioModelResult {
+  scenario: ModelScenario;
+  previousModelId: string | null;
+  nextModelId: string;
+  configuredModelIds: string[];
+  reloaded: boolean;
+  version: number;
+  warnings: string[];
+}
+
+export class ScenarioModelSwitchService {
+  constructor(
+    private readonly config: Pick<
+      LiveConfigManager,
+      "getSnapshot" | "getFilePaths" | "reloadFromDisk"
+    >,
+  ) {}
+
+  getOverview(): ScenarioModelSwitchOverview {
+    const snapshot = this.config.getSnapshot();
+    return {
+      models: snapshot.models.catalog.map((model, index) =>
+        summarizeCatalogModel(model, index + 1),
+      ),
+      scenarios: listScenarioStates(snapshot),
+    };
+  }
+
+  getScenarioOptions(scenario: ModelScenario): {
+    scenario: ModelScenario;
+    currentModelId: string | null;
+    models: ScenarioModelCatalogSummary[];
+  } {
+    const snapshot = this.config.getSnapshot();
+    const configuredModelIds = snapshot.models.scenarios[scenario];
+    return {
+      scenario,
+      currentModelId: configuredModelIds[0] ?? null,
+      models: snapshot.models.catalog.map((model, index) =>
+        summarizeCatalogModel(model, index + 1),
+      ),
+    };
+  }
+
+  async switchScenarioModel(input: SwitchScenarioModelInput): Promise<SwitchScenarioModelResult> {
+    const filePaths = this.config.getFilePaths();
+    if (filePaths == null) {
+      throw new Error(
+        "Scenario model switching is unavailable because config file paths are not configured.",
+      );
+    }
+
+    const snapshot = this.config.getSnapshot();
+    assertScenarioExists(snapshot, input.scenario);
+    const catalogModel =
+      snapshot.models.catalog.find((candidate) => candidate.id === input.modelId) ?? null;
+    if (catalogModel == null) {
+      throw new Error(`Unknown model id: ${input.modelId}`);
+    }
+
+    const configuredModelIds = moveModelToFront(
+      snapshot.models.scenarios[input.scenario],
+      input.modelId,
+    );
+    const originalText = await readConfigTomlText(filePaths.configTomlPath);
+    const candidateText = patchScenarioModelListInToml({
+      tomlText: originalText,
+      scenario: input.scenario,
+      modelIds: configuredModelIds,
+    });
+    await validateCandidateConfig({
+      candidateTomlText: candidateText,
+      secretsTomlPath: filePaths.secretsTomlPath,
+    });
+    await writeFileAtomically(filePaths.configTomlPath, candidateText);
+    const reload = await this.config.reloadFromDisk(
+      `scenario_model_switch:${input.scenario}:${input.modelId}`,
+    );
+
+    return {
+      scenario: input.scenario,
+      previousModelId: snapshot.models.scenarios[input.scenario][0] ?? null,
+      nextModelId: input.modelId,
+      configuredModelIds,
+      reloaded: reload.reloaded,
+      version: reload.version,
+      warnings: buildScenarioSwitchWarnings(catalogModel),
+    };
+  }
+}
+
+function summarizeCatalogModel(
+  model: ModelCatalogEntry,
+  index: number,
+): ScenarioModelCatalogSummary {
+  return {
+    index,
+    modelId: model.id,
+    providerId: model.provider,
+    upstreamModelId: model.upstreamId,
+    supportsTools: model.supportsTools,
+    supportsVision: model.supportsVision,
+    supportsReasoning: model.reasoning?.enabled === true,
+  };
+}
+
+function listScenarioStates(snapshot: AppConfig): ScenarioModelStateSummary[] {
+  return (Object.keys(snapshot.models.scenarios) as ModelScenario[]).map((scenario) => ({
+    scenario,
+    currentModelId: snapshot.models.scenarios[scenario][0] ?? null,
+    configuredModelIds: [...snapshot.models.scenarios[scenario]],
+  }));
+}
+
+function assertScenarioExists(snapshot: AppConfig, scenario: ModelScenario): void {
+  if (!(scenario in snapshot.models.scenarios)) {
+    throw new Error(`Unknown model scenario: ${scenario}`);
+  }
+}
+
+function moveModelToFront(modelIds: string[], targetModelId: string): string[] {
+  const remaining = modelIds.filter((modelId) => modelId !== targetModelId);
+  return [targetModelId, ...remaining];
+}
+
+async function readConfigTomlText(configTomlPath: string): Promise<string> {
+  try {
+    return await readFile(configTomlPath, "utf8");
+  } catch (error: unknown) {
+    if (isMissingFileError(error)) {
+      return "";
+    }
+    throw error;
+  }
+}
+
+async function validateCandidateConfig(input: {
+  candidateTomlText: string;
+  secretsTomlPath: string;
+}): Promise<void> {
+  const rawConfigInput =
+    input.candidateTomlText.trim().length === 0 ? undefined : parse(input.candidateTomlText);
+  const rawSecretsInput = await readOptionalTomlFile(input.secretsTomlPath);
+  buildAppConfigFromInputs(rawConfigInput, rawSecretsInput);
+}
+
+async function writeFileAtomically(targetPath: string, content: string): Promise<void> {
+  const tempPath = path.join(
+    path.dirname(targetPath),
+    `.${path.basename(targetPath)}.tmp-${process.pid}-${Date.now()}`,
+  );
+  await writeFile(tempPath, content, "utf8");
+  await rename(tempPath, targetPath);
+}
+
+function buildScenarioSwitchWarnings(model: ModelCatalogEntry): string[] {
+  const warnings: string[] = [];
+  if (!model.supportsTools) {
+    warnings.push("该模型不支持 tools，某些依赖工具调用的场景可能受影响。");
+  }
+  return warnings;
+}
+
+function isMissingFileError(error: unknown): error is NodeJS.ErrnoException {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -44,8 +44,7 @@ export interface ModelCatalogEntry {
 export interface ModelScenarioConfig {
   chat: string[];
   compaction: string[];
-  subagent: string[];
-  cron: string[];
+  task: string[];
   meditationBucket: string[];
   meditationConsolidation: string[];
 }
@@ -188,10 +187,11 @@ interface ModelCatalogEntryInput {
 interface ModelScenarioConfigInput {
   chat?: unknown;
   compaction?: unknown;
-  subagent?: unknown;
-  cron?: unknown;
+  task?: unknown;
   meditationBucket?: unknown;
   meditationConsolidation?: unknown;
+  subagent?: unknown;
+  cron?: unknown;
 }
 
 interface ModelsConfigInput {
@@ -285,11 +285,11 @@ const LOG_LEVELS: readonly LogLevel[] = ["debug", "info", "warn", "error"];
 const MODEL_SCENARIOS = [
   "chat",
   "compaction",
-  "subagent",
-  "cron",
+  "task",
   "meditationBucket",
   "meditationConsolidation",
 ] as const;
+const LEGACY_MODEL_SCENARIOS = ["subagent", "cron"] as const;
 const LARK_CONNECTION_MODES: readonly LarkConnectionMode[] = ["websocket", "webhook"];
 const PROVIDER_AUTH_SOURCES: readonly ProviderAuthSource[] = ["config", "codex-local"];
 const REASONING_EFFORTS: readonly ReasoningEffort[] = ["minimal", "low", "medium", "high", "xhigh"];
@@ -366,8 +366,7 @@ function cloneRawConfig(config: RawConfig): RawConfig {
       scenarios: {
         chat: [...config.models.scenarios.chat],
         compaction: [...config.models.scenarios.compaction],
-        subagent: [...config.models.scenarios.subagent],
-        cron: [...config.models.scenarios.cron],
+        task: [...config.models.scenarios.task],
         meditationBucket: [...config.models.scenarios.meditationBucket],
         meditationConsolidation: [...config.models.scenarios.meditationConsolidation],
       },
@@ -531,8 +530,7 @@ function validateModelsConfig(
       scenarios: {
         chat: [...defaults.scenarios.chat],
         compaction: [...defaults.scenarios.compaction],
-        subagent: [...defaults.scenarios.subagent],
-        cron: [...defaults.scenarios.cron],
+        task: [...defaults.scenarios.task],
         meditationBucket: [...defaults.scenarios.meditationBucket],
         meditationConsolidation: [...defaults.scenarios.meditationConsolidation],
       },
@@ -683,8 +681,7 @@ function validateModelScenarios(
     return {
       chat: [...defaults.chat],
       compaction: [...defaults.compaction],
-      subagent: [...defaults.subagent],
-      cron: [...defaults.cron],
+      task: [...defaults.task],
       meditationBucket: [...defaults.meditationBucket],
       meditationConsolidation: [...defaults.meditationConsolidation],
     };
@@ -695,7 +692,16 @@ function validateModelScenarios(
   }
 
   const scenarios = input as ModelScenarioConfigInput;
-  assertAllowedKeys(scenarios, new Set(MODEL_SCENARIOS), "config.toml models.scenarios");
+  assertAllowedKeys(
+    scenarios,
+    new Set([...MODEL_SCENARIOS, ...LEGACY_MODEL_SCENARIOS]),
+    "config.toml models.scenarios",
+  );
+
+  const legacyTaskDefaults = mergeLegacyTaskScenarioLists({
+    subagent: validateScenarioList(scenarios.subagent, [], catalogIds, "subagent"),
+    cron: validateScenarioList(scenarios.cron, [], catalogIds, "cron"),
+  });
 
   return {
     chat: validateScenarioList(scenarios.chat, defaults.chat, catalogIds, "chat"),
@@ -705,8 +711,12 @@ function validateModelScenarios(
       catalogIds,
       "compaction",
     ),
-    subagent: validateScenarioList(scenarios.subagent, defaults.subagent, catalogIds, "subagent"),
-    cron: validateScenarioList(scenarios.cron, defaults.cron, catalogIds, "cron"),
+    task: validateScenarioList(
+      scenarios.task,
+      legacyTaskDefaults.length > 0 ? legacyTaskDefaults : defaults.task,
+      catalogIds,
+      "task",
+    ),
     meditationBucket: validateScenarioList(
       scenarios.meditationBucket,
       defaults.meditationBucket,
@@ -720,6 +730,10 @@ function validateModelScenarios(
       "meditationConsolidation",
     ),
   };
+}
+
+function mergeLegacyTaskScenarioLists(input: { subagent: string[]; cron: string[] }): string[] {
+  return Array.from(new Set([...input.subagent, ...input.cron]));
 }
 
 function validateScenarioList(

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@
  * start runtime bootstrap, listen for shutdown signals, and perform graceful
  * teardown. Business logic lives in runtime/orchestration/channel modules.
  */
-import { loadConfig } from "@/src/config/load.js";
+import { getDefaultConfigPaths, loadConfig } from "@/src/config/load.js";
 import { createRuntimeBootstrap } from "@/src/runtime/bootstrap.js";
 import { readLastRuntimeLogTimestamp } from "@/src/runtime/runtime-log.js";
 import {
@@ -27,7 +27,8 @@ export async function main(): Promise<void> {
   let runtime: ReturnType<typeof createRuntimeBootstrap> | null = null;
 
   try {
-    const config = await loadConfig();
+    const configPaths = getDefaultConfigPaths();
+    const config = await loadConfig(configPaths);
     const previousLastSeenAt = await readLastRuntimeLogTimestamp(POKECLAW_RUNTIME_LOG_PATH);
     configureRuntimeLogging(config.logging);
     logger.info("application config loaded", {
@@ -40,6 +41,7 @@ export async function main(): Promise<void> {
       config,
       storage: storage.db,
       previousLastSeenAt,
+      configPaths,
     });
 
     runtime.start();

--- a/src/meditation/runner.ts
+++ b/src/meditation/runner.ts
@@ -11,6 +11,10 @@ import { randomUUID } from "node:crypto";
 import path from "node:path";
 
 import type { ProviderRegistry } from "@/src/agent/llm/provider-registry.js";
+import {
+  type ProviderRegistrySource,
+  resolveProviderRegistry,
+} from "@/src/agent/llm/provider-registry-source.js";
 import type { SecurityConfig, SelfHarnessConfig } from "@/src/config/schema.js";
 import {
   runMeditationBucketAgent,
@@ -61,7 +65,7 @@ interface MeditationPipelineRunnerDependencies {
   storage: StorageDb;
   state: MeditationStateRepo;
   config: SelfHarnessConfig;
-  models: ProviderRegistry;
+  models: ProviderRegistry | ProviderRegistrySource;
   bridge: MeditationTurnBridge;
   securityConfig: SecurityConfig;
   workspaceDir?: string;
@@ -138,8 +142,9 @@ export class MeditationPipelineRunner implements MeditationRunner {
         readModel: this.readModel,
       }),
     );
+    const registry = resolveProviderRegistry(this.deps.models);
     const configuredModels = maybeResolveMeditationModels({
-      registry: this.deps.models,
+      registry,
     });
     const executedBucketInputs =
       configuredModels == null ? [] : bucketInputs.slice(0, MAX_BUCKETS_PER_RUN);
@@ -196,7 +201,7 @@ export class MeditationPipelineRunner implements MeditationRunner {
       }
 
       const resolvedModels = resolveMeditationModels({
-        registry: this.deps.models,
+        registry,
       });
 
       logger.info("meditation pipeline run started", {

--- a/src/orchestration/subagents.ts
+++ b/src/orchestration/subagents.ts
@@ -118,7 +118,7 @@ export interface SubagentConversationSurfaceProvisioner {
 export interface SubagentManagerIngress {
   submitMessage(input: {
     sessionId: string;
-    scenario: "subagent";
+    scenario: "chat";
     content: string;
     messageType: string;
     visibility: string;
@@ -391,7 +391,7 @@ export class SubagentManager {
     void this.deps.ingress
       .submitMessage({
         sessionId: created.session.id,
-        scenario: "subagent",
+        scenario: "chat",
         content: kickoffMessage,
         messageType: "subagent_kickoff",
         visibility: "hidden_system",

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -6,7 +6,6 @@
  * module to keep process entry thin and business assembly centralized.
  */
 import { PiAgentModelRunner, PiBridge } from "@/src/agent/llm/pi-bridge.js";
-import { ProviderRegistry } from "@/src/agent/llm/provider-registry.js";
 import { LiveProviderRegistrySource } from "@/src/agent/llm/provider-registry-source.js";
 import { CodexProviderApiKeyResolver } from "@/src/agent/llm/providers/codex/resolver.js";
 import { AgentLoop } from "@/src/agent/loop.js";
@@ -94,7 +93,6 @@ export function createRuntimeBootstrap(input: CreateRuntimeBootstrapInput): Runt
     sessions,
     taskRuns: new TaskRunsRepo(input.storage),
   });
-  const models = new ProviderRegistry(input.config);
   const scenarioModelSwitch = new ScenarioModelSwitchService(liveConfig);
   const providerApiKeyResolver = new CodexProviderApiKeyResolver();
   const llmBridge = new PiBridge(providerApiKeyResolver);
@@ -152,7 +150,7 @@ export function createRuntimeBootstrap(input: CreateRuntimeBootstrapInput): Runt
       storage: input.storage,
       state: meditationState,
       config: input.config.selfHarness,
-      models,
+      models: liveModels,
       bridge: llmBridge,
       securityConfig: input.config.security,
     }),

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -7,6 +7,7 @@
  */
 import { PiAgentModelRunner, PiBridge } from "@/src/agent/llm/pi-bridge.js";
 import { ProviderRegistry } from "@/src/agent/llm/provider-registry.js";
+import { LiveProviderRegistrySource } from "@/src/agent/llm/provider-registry-source.js";
 import { CodexProviderApiKeyResolver } from "@/src/agent/llm/providers/codex/resolver.js";
 import { AgentLoop } from "@/src/agent/loop.js";
 import { AgentSessionService } from "@/src/agent/session.js";
@@ -14,6 +15,9 @@ import { createLarkChannelRuntime, type LarkChannelRuntime } from "@/src/channel
 import { LarkClientRegistry } from "@/src/channels/lark/client.js";
 import { createLarkSubagentConversationSurfaceProvisioner } from "@/src/channels/lark/subagent-provisioner.js";
 import { listConfiguredLarkInstallations } from "@/src/channels/lark/types.js";
+import { LiveConfigManager } from "@/src/config/live-manager.js";
+import type { LoadConfigOptions } from "@/src/config/load.js";
+import { ScenarioModelSwitchService } from "@/src/config/scenario-model-switch.js";
 import type { AppConfig } from "@/src/config/schema.js";
 import { CronService } from "@/src/cron/service.js";
 import { MeditationPipelineRunner } from "@/src/meditation/runner.js";
@@ -50,6 +54,7 @@ export interface RuntimeBootstrap {
   readonly bridge: RuntimeOrchestrationBridge;
   readonly ingress: SessionRuntimeIngress;
   readonly manager: AgentManager;
+  readonly liveConfig: LiveConfigManager;
   readonly heartbeat: MinuteHeartbeat;
   readonly cron: CronService;
   readonly meditation: MeditationScheduler;
@@ -66,9 +71,15 @@ export interface CreateRuntimeBootstrapInput {
   storage: StorageDb;
   subagentProvisioner?: AgentManagerDependencies["subagentProvisioner"];
   previousLastSeenAt?: Date | null;
+  configPaths?: Required<LoadConfigOptions>;
 }
 
 export function createRuntimeBootstrap(input: CreateRuntimeBootstrapInput): RuntimeBootstrap {
+  const liveConfig = new LiveConfigManager({
+    initialSnapshot: input.config,
+    ...(input.configPaths == null ? {} : { filePaths: input.configPaths }),
+  });
+  const liveModels = new LiveProviderRegistrySource(liveConfig);
   const messages = new MessagesRepo(input.storage);
   const sessions = new SessionsRepo(input.storage);
   const tools = createBuiltinToolRegistry({
@@ -84,17 +95,18 @@ export function createRuntimeBootstrap(input: CreateRuntimeBootstrapInput): Runt
     taskRuns: new TaskRunsRepo(input.storage),
   });
   const models = new ProviderRegistry(input.config);
+  const scenarioModelSwitch = new ScenarioModelSwitchService(liveConfig);
   const providerApiKeyResolver = new CodexProviderApiKeyResolver();
   const llmBridge = new PiBridge(providerApiKeyResolver);
   const status = new RuntimeStatusService({
     storage: input.storage,
     control,
-    models,
+    models: liveModels,
   });
   const loop = new AgentLoop({
     sessions: new AgentSessionService(sessions, messages),
     messages,
-    models,
+    models: liveModels,
     tools,
     cancel,
     modelRunner: new PiAgentModelRunner(llmBridge, tools),
@@ -153,6 +165,7 @@ export function createRuntimeBootstrap(input: CreateRuntimeBootstrapInput): Runt
     ingress,
     control,
     status,
+    modelSwitch: scenarioModelSwitch,
     outboundEventBus,
     clients: larkClients,
     subagentRequests: {
@@ -175,6 +188,7 @@ export function createRuntimeBootstrap(input: CreateRuntimeBootstrapInput): Runt
     bridge,
     ingress,
     manager,
+    liveConfig,
     heartbeat,
     cron,
     meditation,
@@ -205,6 +219,7 @@ export function createRuntimeBootstrap(input: CreateRuntimeBootstrapInput): Runt
         });
       }
 
+      liveConfig.startWatching();
       lark.start();
       cron.start();
       meditation.start();
@@ -249,6 +264,7 @@ export function createRuntimeBootstrap(input: CreateRuntimeBootstrapInput): Runt
         cron.stop();
         await meditation.drain();
         await cron.drain();
+        await liveConfig.shutdown();
         started = false;
         logger.info("runtime bootstrap shutdown complete");
       })().finally(() => {

--- a/src/runtime/status.ts
+++ b/src/runtime/status.ts
@@ -33,7 +33,7 @@ const NO_RECENT_SESSION_USAGE_TEXT = "- 最近 3 天还没有可用 usage。";
 export interface ConversationStatusInput {
   conversationId: string;
   sessionId: string;
-  scenario: "chat" | "cron" | "subagent";
+  scenario: "chat" | "task";
 }
 
 export interface StatusModelSnapshot {
@@ -303,7 +303,7 @@ function resolveStatusModel(input: {
   session: Session;
   agentsRepo: AgentsRepo;
   models: ProviderRegistry;
-  scenario: "chat" | "cron" | "subagent";
+  scenario: "chat" | "task";
 }): StatusModelSnapshot {
   const latestAssistantModel = resolveCatalogModelFromStoredAssistant({
     latestAssistant: input.latestAssistant,

--- a/src/runtime/status.ts
+++ b/src/runtime/status.ts
@@ -8,6 +8,10 @@
 import { readFileSync } from "node:fs";
 import type { ResolvedModel } from "@/src/agent/llm/models.js";
 import type { ProviderRegistry } from "@/src/agent/llm/provider-registry.js";
+import {
+  type ProviderRegistrySource,
+  resolveProviderRegistry,
+} from "@/src/agent/llm/provider-registry-source.js";
 import type { RuntimeControlService } from "@/src/runtime/control.js";
 import { resolveSessionLiveState } from "@/src/runtime/live-state.js";
 import { toCanonicalUtcIsoTimestamp } from "@/src/shared/time.js";
@@ -84,7 +88,7 @@ export class RuntimeStatusService {
     private readonly deps: {
       storage: StorageDb;
       control: RuntimeControlService;
-      models: ProviderRegistry;
+      models: ProviderRegistry | ProviderRegistrySource;
     },
   ) {}
 
@@ -100,11 +104,12 @@ export class RuntimeStatusService {
     }
 
     const latestAssistant = messagesRepo.getLatestAssistantBySession(session.id);
+    const currentModels = resolveProviderRegistry(this.deps.models);
     const model = resolveStatusModel({
       latestAssistant,
       session,
       agentsRepo,
-      models: this.deps.models,
+      models: currentModels,
       scenario: input.scenario,
     });
 

--- a/src/tasks/task-session.ts
+++ b/src/tasks/task-session.ts
@@ -74,8 +74,8 @@ const GROUP_CRON_TRANSCRIPT_GUIDANCE_LINES = [
   "Complete the scheduled objective for this run, then end the task instead of continuing broader conversation.",
 ];
 
-export function resolveTaskExecutionScenario(runType: string): ModelScenario {
-  return runType === "cron" ? "cron" : "subagent";
+export function resolveTaskExecutionScenario(_runType: string): ModelScenario {
+  return "task";
 }
 
 export function buildTaskExecutionKickoffEnvelope(

--- a/tests/agent/bash-approval.test.ts
+++ b/tests/agent/bash-approval.test.ts
@@ -58,8 +58,7 @@ function createModelConfig(): Pick<AppConfig, "providers" | "models"> {
       scenarios: {
         chat: ["anthropic_main/claude-sonnet-4-5"],
         compaction: ["anthropic_main/claude-sonnet-4-5"],
-        subagent: ["anthropic_main/claude-sonnet-4-5"],
-        cron: ["anthropic_main/claude-sonnet-4-5"],
+        task: ["anthropic_main/claude-sonnet-4-5"],
         meditationBucket: [],
         meditationConsolidation: [],
       },

--- a/tests/agent/compaction.test.ts
+++ b/tests/agent/compaction.test.ts
@@ -43,8 +43,7 @@ function createModelConfig(): Pick<AppConfig, "providers" | "models"> {
       scenarios: {
         chat: ["anthropic_main/claude-sonnet-4-5"],
         compaction: ["anthropic_main/claude-sonnet-4-5"],
-        subagent: ["anthropic_main/claude-sonnet-4-5"],
-        cron: ["anthropic_main/claude-sonnet-4-5"],
+        task: ["anthropic_main/claude-sonnet-4-5"],
         meditationBucket: [],
         meditationConsolidation: [],
       },

--- a/tests/agent/llm/models.test.ts
+++ b/tests/agent/llm/models.test.ts
@@ -90,6 +90,7 @@ describe("llm models helpers", () => {
   test("recognizes configured model scenarios", () => {
     expect(isModelScenario("chat")).toBe(true);
     expect(isModelScenario("compaction")).toBe(true);
+    expect(isModelScenario("task")).toBe(true);
     expect(isModelScenario("meditationBucket")).toBe(true);
     expect(isModelScenario("agent")).toBe(false);
   });

--- a/tests/agent/llm/provider-registry.test.ts
+++ b/tests/agent/llm/provider-registry.test.ts
@@ -46,8 +46,7 @@ function createConfig(): Pick<AppConfig, "providers" | "models"> {
       scenarios: {
         chat: ["anthropic_main/claude-sonnet-4-5", "openai_main/gpt-5-mini"],
         compaction: ["openai_main/gpt-5-mini"],
-        subagent: ["anthropic_main/claude-sonnet-4-5"],
-        cron: ["anthropic_main/claude-sonnet-4-5"],
+        task: ["anthropic_main/claude-sonnet-4-5"],
         meditationBucket: ["openai_main/gpt-5-mini"],
         meditationConsolidation: ["anthropic_main/claude-sonnet-4-5"],
       },
@@ -78,12 +77,12 @@ describe("provider registry", () => {
 
   test("returns null for missing scenario selection when the list is empty", () => {
     const config = createConfig();
-    config.models.scenarios.cron = [];
+    config.models.scenarios.task = [];
 
     const registry = new ProviderRegistry(config);
-    expect(registry.getScenarioModel("cron")).toBeNull();
-    expect(() => registry.getRequiredScenarioModel("cron")).toThrow(
-      "No model configured for scenario: cron",
+    expect(registry.getScenarioModel("task")).toBeNull();
+    expect(() => registry.getRequiredScenarioModel("task")).toThrow(
+      "No model configured for scenario: task",
     );
   });
 

--- a/tests/agent/loop.test.ts
+++ b/tests/agent/loop.test.ts
@@ -69,8 +69,7 @@ function createModelConfig(
       scenarios: {
         chat: ["anthropic_main/claude-sonnet-4-5"],
         compaction: ["anthropic_main/claude-sonnet-4-5"],
-        subagent: ["anthropic_main/claude-sonnet-4-5"],
-        cron: ["anthropic_main/claude-sonnet-4-5"],
+        task: ["anthropic_main/claude-sonnet-4-5"],
         meditationBucket: [],
         meditationConsolidation: [],
       },
@@ -1272,7 +1271,7 @@ describe("agent loop", () => {
     expect(seenSystemPrompts[0]).not.toContain("<name>repo-review</name>");
   });
 
-  test("filters non-readable skills out of the injected catalog for subagent sessions", async () => {
+  test("filters non-readable skills out of the injected catalog for task sessions", async () => {
     handle = await createTestDatabase(import.meta.url);
     seedConversationAndAgentFixture(handle);
 
@@ -1408,7 +1407,7 @@ describe("agent loop", () => {
       compaction: DEFAULT_CONFIG.compaction,
     });
 
-    await expect(loop.run({ sessionId: "sess_task", scenario: "cron" })).rejects.toThrow(
+    await expect(loop.run({ sessionId: "sess_task", scenario: "task" })).rejects.toThrow(
       'Session purpose "task" requires a tool-capable model',
     );
   });
@@ -2612,7 +2611,7 @@ describe("agent loop", () => {
       },
     });
 
-    const runPromise = loop.run({ sessionId: "sess_task", scenario: "chat" });
+    const runPromise = loop.run({ sessionId: "sess_task", scenario: "task" });
     const approvalId = Number(await waitForApprovalRequested(emittedEvents));
     const approvalRecord = approvalsRepo.getById(approvalId);
 

--- a/tests/agent/pi-agent-model-runner.test.ts
+++ b/tests/agent/pi-agent-model-runner.test.ts
@@ -54,8 +54,7 @@ function createModelConfig(): Pick<AppConfig, "providers" | "models"> {
       scenarios: {
         chat: ["anthropic_main/claude-sonnet-4-5"],
         compaction: ["anthropic_main/claude-sonnet-4-5"],
-        subagent: ["anthropic_main/claude-sonnet-4-5"],
-        cron: ["anthropic_main/claude-sonnet-4-5"],
+        task: ["anthropic_main/claude-sonnet-4-5"],
         meditationBucket: [],
         meditationConsolidation: [],
       },

--- a/tests/agent/runtime.test.ts
+++ b/tests/agent/runtime.test.ts
@@ -47,8 +47,7 @@ function createModelConfig(): Pick<AppConfig, "providers" | "models"> {
       scenarios: {
         chat: ["anthropic_main/claude-sonnet-4-5"],
         compaction: ["anthropic_main/claude-sonnet-4-5"],
-        subagent: ["anthropic_main/claude-sonnet-4-5"],
-        cron: ["anthropic_main/claude-sonnet-4-5"],
+        task: ["anthropic_main/claude-sonnet-4-5"],
         meditationBucket: [],
         meditationConsolidation: [],
       },

--- a/tests/channels/lark/inbound.test.ts
+++ b/tests/channels/lark/inbound.test.ts
@@ -817,7 +817,7 @@ describe("lark inbound message handling", () => {
 
       expect(submitMessage).toHaveBeenCalledExactlyOnceWith({
         sessionId: "sess_task_1",
-        scenario: "cron",
+        scenario: "task",
         content: "Please prioritize this error.",
         channelMessageId: "om_task_thread_msg_1",
         channelParentMessageId: "om_task_card_1",
@@ -888,7 +888,7 @@ describe("lark inbound message handling", () => {
 
       expect(submitMessage).toHaveBeenCalledExactlyOnceWith({
         sessionId: "sess_task_1",
-        scenario: "cron",
+        scenario: "task",
         content: "Continue, but prioritize fixing the previous error.",
         channelMessageId: "om_task_thread_msg_2",
         channelParentMessageId: "om_user_reply_1",
@@ -965,7 +965,7 @@ describe("lark inbound message handling", () => {
 
       expect(submitMessage).toHaveBeenCalledExactlyOnceWith({
         sessionId: "sess_task_1",
-        scenario: "cron",
+        scenario: "task",
         content: "Use the stack trace above and fix the failing step.",
         channelMessageId: "om_task_thread_msg_child_1",
         channelParentMessageId: "om_task_thread_card_1",
@@ -2551,9 +2551,12 @@ describe("lark card actions", () => {
     expect(modelSwitch.getOverview).toHaveBeenCalledTimes(1);
     expect(result).toMatchObject({
       card: {
-        header: {
-          title: {
-            content: "模型切换",
+        type: "raw",
+        data: {
+          header: {
+            title: {
+              content: "模型切换",
+            },
           },
         },
       },
@@ -2625,9 +2628,12 @@ describe("lark card actions", () => {
         content: "已切换 chat → gpt5",
       },
       card: {
-        header: {
-          title: {
-            content: "模型切换",
+        type: "raw",
+        data: {
+          header: {
+            title: {
+              content: "模型切换",
+            },
           },
         },
       },

--- a/tests/channels/lark/inbound.test.ts
+++ b/tests/channels/lark/inbound.test.ts
@@ -6,6 +6,7 @@ import {
   buildLarkChatSurfaceKey,
   buildLarkThreadSurfaceKey,
   createLarkCardActionHandler,
+  createLarkInboundRuntime,
   createLarkMessageReceiveHandler,
   createLarkQuoteMessageFetcher,
   normalizeLarkTextMessage,
@@ -2427,6 +2428,104 @@ describe("lark card actions", () => {
         type: "info",
         content: "该授权请求已结束或无法处理",
       },
+    });
+  });
+
+  test("forwards modelSwitch through lark inbound runtime so /model works end-to-end", async () => {
+    await withHandle(async (handle) => {
+      seedFixture(handle);
+      type InboundDispatcher = {
+        invoke(data: unknown, params?: { needCheck?: boolean }): Promise<unknown>;
+      };
+      const dispatchers: InboundDispatcher[] = [];
+      const wsClose = vi.fn();
+      const messageCreate = vi.fn(async () => ({}));
+      const modelSwitch = {
+        getOverview: vi.fn(() => ({
+          models: [
+            {
+              index: 1,
+              modelId: "gpt5",
+              providerId: "main",
+              upstreamModelId: "openai/gpt-5",
+              supportsTools: true,
+              supportsVision: false,
+              supportsReasoning: true,
+            },
+          ],
+          scenarios: [
+            {
+              scenario: "chat",
+              currentModelId: "gpt5",
+              configuredModelIds: ["gpt5"],
+            },
+          ],
+        })),
+      };
+      const runtime = createLarkInboundRuntime({
+        installations: [
+          {
+            installationId: "default",
+            appId: "cli_123",
+            appSecret: "secret_123",
+            config: {
+              enabled: true,
+              appId: "cli_123",
+              appSecret: "secret_123",
+              connectionMode: "websocket",
+            },
+          },
+        ],
+        storage: handle.storage.db,
+        ingress: {
+          submitMessage: vi.fn(async () => ({ status: "started" as const })),
+          submitApprovalDecision: vi.fn(() => false),
+        },
+        control: new RuntimeControlService(new SessionRunAbortRegistry()),
+        modelSwitch: modelSwitch as never,
+        clients: {
+          getOrCreate: () =>
+            ({
+              sdk: {
+                im: {
+                  message: {
+                    create: messageCreate,
+                    reply: vi.fn(async () => ({})),
+                  },
+                },
+              },
+            }) as unknown as LarkSdkClient,
+        },
+        wsClientFactory: () =>
+          ({
+            start: ({ eventDispatcher }: { eventDispatcher: InboundDispatcher }) => {
+              dispatchers.push(eventDispatcher);
+            },
+            close: wsClose,
+          }) as never,
+      });
+
+      runtime.start();
+      const activeDispatcher = dispatchers.at(0);
+      if (activeDispatcher == null) {
+        throw new Error("expected lark inbound runtime to install an event dispatcher");
+      }
+      await activeDispatcher.invoke(
+        {
+          schema: "2.0",
+          header: {
+            event_type: "im.message.receive_v1",
+          },
+          event: makeTextEvent("/model"),
+        },
+        { needCheck: false },
+      );
+
+      expect(modelSwitch.getOverview).toHaveBeenCalledTimes(1);
+      expect(messageCreate).toHaveBeenCalledTimes(1);
+
+      await runtime.shutdown();
+      expect(wsClose).toHaveBeenCalledOnce();
     });
   });
 

--- a/tests/channels/lark/inbound.test.ts
+++ b/tests/channels/lark/inbound.test.ts
@@ -2429,4 +2429,208 @@ describe("lark card actions", () => {
       },
     });
   });
+
+  test("routes /model to the model switch service and sends an interactive card", async () => {
+    await withHandle(async (handle) => {
+      seedFixture(handle);
+      const submitMessage = vi.fn(async () => ({ status: "started" as const }));
+      const messageCreate = vi.fn(async () => ({}));
+      const modelSwitch = {
+        getOverview: vi.fn(() => ({
+          models: [
+            {
+              index: 1,
+              modelId: "gpt5",
+              providerId: "main",
+              upstreamModelId: "openai/gpt-5",
+              supportsTools: true,
+              supportsVision: false,
+              supportsReasoning: true,
+            },
+          ],
+          scenarios: [
+            {
+              scenario: "chat",
+              currentModelId: "gpt5",
+              configuredModelIds: ["gpt5"],
+            },
+          ],
+        })),
+      };
+      const handler = createLarkMessageReceiveHandler({
+        installationId: "default",
+        storage: handle.storage.db,
+        ingress: { submitMessage, submitApprovalDecision: vi.fn(() => false) },
+        control: new RuntimeControlService(new SessionRunAbortRegistry()),
+        modelSwitch: modelSwitch as never,
+        clients: {
+          getOrCreate: () =>
+            ({
+              sdk: {
+                im: {
+                  message: {
+                    create: messageCreate,
+                    reply: vi.fn(async () => ({})),
+                  },
+                },
+              },
+            }) as unknown as LarkSdkClient,
+        },
+      });
+
+      await handler(makeTextEvent("/model"));
+
+      expect(submitMessage).not.toHaveBeenCalled();
+      expect(modelSwitch.getOverview).toHaveBeenCalledTimes(1);
+      expect(messageCreate).toHaveBeenCalledTimes(1);
+      const firstCall = messageCreate.mock.calls.at(0) as
+        | [
+            {
+              data?: {
+                msg_type?: string;
+                content?: string;
+              };
+            },
+          ]
+        | undefined;
+      const payload = firstCall?.[0];
+      expect(payload?.data?.msg_type).toBe("interactive");
+      const content = JSON.parse(String(payload?.data?.content)) as {
+        header?: { title?: { content?: string } };
+      };
+      expect(content.header?.title?.content).toBe("模型切换");
+    });
+  });
+
+  test("returns an updated card when selecting a scenario from the model switch card", async () => {
+    const modelSwitch = {
+      getOverview: vi.fn(() => ({
+        models: [
+          {
+            index: 1,
+            modelId: "gpt5",
+            providerId: "main",
+            upstreamModelId: "openai/gpt-5",
+            supportsTools: true,
+            supportsVision: false,
+            supportsReasoning: true,
+          },
+        ],
+        scenarios: [
+          {
+            scenario: "chat",
+            currentModelId: "gpt5",
+            configuredModelIds: ["gpt5"],
+          },
+        ],
+      })),
+      switchScenarioModel: vi.fn(),
+    };
+    const handler = createLarkCardActionHandler({
+      installationId: "default",
+      ingress: {
+        submitMessage: vi.fn(async () => ({ status: "started" as const })),
+        submitApprovalDecision: vi.fn(() => false),
+      },
+      control: {} as RuntimeControlService,
+      modelSwitch: modelSwitch as never,
+    });
+
+    const result = await handler({
+      action: {
+        value: {
+          action: "model_switch_select_scenario",
+          scenario: "chat",
+        },
+      },
+      operator: {
+        open_id: "ou_sender",
+      },
+    });
+
+    expect(modelSwitch.getOverview).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      card: {
+        header: {
+          title: {
+            content: "模型切换",
+          },
+        },
+      },
+    });
+  });
+
+  test("applies a model switch from card action and returns toast plus refreshed card", async () => {
+    const modelSwitch = {
+      getOverview: vi.fn(() => ({
+        models: [
+          {
+            index: 1,
+            modelId: "gpt5",
+            providerId: "main",
+            upstreamModelId: "openai/gpt-5",
+            supportsTools: true,
+            supportsVision: false,
+            supportsReasoning: true,
+          },
+        ],
+        scenarios: [
+          {
+            scenario: "chat",
+            currentModelId: "gpt5",
+            configuredModelIds: ["gpt5"],
+          },
+        ],
+      })),
+      switchScenarioModel: vi.fn(async () => ({
+        scenario: "chat",
+        previousModelId: "deepseek",
+        nextModelId: "gpt5",
+        configuredModelIds: ["gpt5", "deepseek"],
+        reloaded: true,
+        version: 2,
+        warnings: [],
+      })),
+    };
+    const handler = createLarkCardActionHandler({
+      installationId: "default",
+      ingress: {
+        submitMessage: vi.fn(async () => ({ status: "started" as const })),
+        submitApprovalDecision: vi.fn(() => false),
+      },
+      control: {} as RuntimeControlService,
+      modelSwitch: modelSwitch as never,
+    });
+
+    const result = await handler({
+      action: {
+        value: {
+          action: "model_switch_apply",
+          scenario: "chat",
+          modelId: "gpt5",
+        },
+      },
+      operator: {
+        open_id: "ou_sender",
+      },
+    });
+
+    expect(modelSwitch.switchScenarioModel).toHaveBeenCalledExactlyOnceWith({
+      scenario: "chat",
+      modelId: "gpt5",
+    });
+    expect(result).toMatchObject({
+      toast: {
+        type: "success",
+        content: "已切换 chat → gpt5",
+      },
+      card: {
+        header: {
+          title: {
+            content: "模型切换",
+          },
+        },
+      },
+    });
+  });
 });

--- a/tests/config/live-manager.test.ts
+++ b/tests/config/live-manager.test.ts
@@ -1,0 +1,124 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { LiveConfigManager } from "@/src/config/live-manager.js";
+import { loadConfig } from "@/src/config/load.js";
+
+function buildConfigToml(chatModelId: string): string {
+  return [
+    "[logging]",
+    'level = "info"',
+    "useColors = false",
+    "",
+    "[providers.main]",
+    'api = "openai-responses"',
+    'apiKey = "test-key"',
+    "",
+    "[[models.catalog]]",
+    'id = "gpt5"',
+    'provider = "main"',
+    'upstreamId = "openai/gpt-5"',
+    "contextWindow = 200000",
+    "maxOutputTokens = 8192",
+    "supportsTools = true",
+    "supportsVision = false",
+    "",
+    "[[models.catalog]]",
+    'id = "deepseek"',
+    'provider = "main"',
+    'upstreamId = "deepseek/chat"',
+    "contextWindow = 128000",
+    "maxOutputTokens = 8192",
+    "supportsTools = true",
+    "supportsVision = false",
+    "",
+    "[models.scenarios]",
+    `chat = ["${chatModelId}"]`,
+    'compaction = ["gpt5"]',
+    'subagent = ["gpt5"]',
+    'cron = ["deepseek"]',
+    'meditationBucket = ["gpt5"]',
+    'meditationConsolidation = ["gpt5"]',
+    "",
+  ].join("\n");
+}
+
+describe("LiveConfigManager", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+    tempDirs.length = 0;
+  });
+
+  test("reloadFromDisk replaces the active snapshot and notifies subscribers", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "pokeclaw-live-config-"));
+    tempDirs.push(dir);
+    const configTomlPath = path.join(dir, "config.toml");
+    const secretsTomlPath = path.join(dir, "secrets.toml");
+    await writeFile(configTomlPath, buildConfigToml("deepseek"), "utf8");
+    await writeFile(secretsTomlPath, "", "utf8");
+
+    const initialSnapshot = await loadConfig({
+      configTomlPath,
+      secretsTomlPath,
+    });
+    const manager = new LiveConfigManager({
+      initialSnapshot,
+      filePaths: {
+        configTomlPath,
+        secretsTomlPath,
+      },
+    });
+    const listener = vi.fn();
+    manager.subscribe(listener);
+
+    await writeFile(configTomlPath, buildConfigToml("gpt5"), "utf8");
+    const result = await manager.reloadFromDisk("test_reload");
+
+    expect(result).toEqual({
+      reloaded: true,
+      version: 2,
+      reason: "test_reload",
+    });
+    expect(manager.getVersion()).toBe(2);
+    expect(manager.getSnapshot().models.scenarios.chat).toEqual(["gpt5"]);
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0]?.[0]).toMatchObject({
+      version: 2,
+      reason: "test_reload",
+    });
+  });
+
+  test("reloadFromDisk keeps the previous version when the snapshot is unchanged", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "pokeclaw-live-config-"));
+    tempDirs.push(dir);
+    const configTomlPath = path.join(dir, "config.toml");
+    const secretsTomlPath = path.join(dir, "secrets.toml");
+    await writeFile(configTomlPath, buildConfigToml("deepseek"), "utf8");
+    await writeFile(secretsTomlPath, "", "utf8");
+
+    const initialSnapshot = await loadConfig({
+      configTomlPath,
+      secretsTomlPath,
+    });
+    const manager = new LiveConfigManager({
+      initialSnapshot,
+      filePaths: {
+        configTomlPath,
+        secretsTomlPath,
+      },
+    });
+
+    const result = await manager.reloadFromDisk("no_change");
+
+    expect(result).toEqual({
+      reloaded: false,
+      version: 1,
+      reason: "no_change",
+    });
+    expect(manager.getVersion()).toBe(1);
+  });
+});

--- a/tests/config/load.test.ts
+++ b/tests/config/load.test.ts
@@ -130,8 +130,7 @@ describe("config loader", () => {
     expect(config.models.scenarios).toEqual({
       chat: [],
       compaction: [],
-      subagent: [],
-      cron: [],
+      task: [],
       meditationBucket: [],
       meditationConsolidation: [],
     });
@@ -244,8 +243,7 @@ describe("config loader", () => {
         "[models.scenarios]",
         'chat = ["anthropic_main/claude-sonnet-4-5", "openai_main/gpt-5-mini"]',
         'compaction = ["openai_main/gpt-5-mini"]',
-        'subagent = ["anthropic_main/claude-sonnet-4-5"]',
-        'cron = ["anthropic_main/claude-sonnet-4-5"]',
+        'task = ["anthropic_main/claude-sonnet-4-5"]',
         'meditationBucket = ["openai_main/gpt-5-mini"]',
         'meditationConsolidation = ["anthropic_main/claude-sonnet-4-5"]',
         "",
@@ -305,6 +303,7 @@ describe("config loader", () => {
       "openai_main/gpt-5-mini",
     ]);
     expect(config.models.scenarios.compaction).toEqual(["openai_main/gpt-5-mini"]);
+    expect(config.models.scenarios.task).toEqual(["anthropic_main/claude-sonnet-4-5"]);
     expect(config.models.scenarios.meditationBucket).toEqual(["openai_main/gpt-5-mini"]);
     expect(config.models.scenarios.meditationConsolidation).toEqual([
       "anthropic_main/claude-sonnet-4-5",

--- a/tests/config/model-scenario-patch.test.ts
+++ b/tests/config/model-scenario-patch.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "vitest";
+import { patchScenarioModelListInToml } from "@/src/config/model-scenario-patch.js";
+
+describe("patchScenarioModelListInToml", () => {
+  test("replaces an existing single-line scenario array without rewriting other config", () => {
+    const original = [
+      "# keep me",
+      "[logging]",
+      'level = "info"',
+      "useColors = false",
+      "",
+      "[models.scenarios]",
+      'chat = ["deepseek"] # current chat model',
+      'cron = ["deepseek"]',
+      "",
+      "[runtime]",
+      "maxTurns = 60",
+      "",
+    ].join("\n");
+
+    const patched = patchScenarioModelListInToml({
+      tomlText: original,
+      scenario: "chat",
+      modelIds: ["gpt5", "deepseek"],
+    });
+
+    expect(patched).toContain("# keep me");
+    expect(patched).toContain('chat = ["gpt5", "deepseek"] # current chat model');
+    expect(patched).toContain('cron = ["deepseek"]');
+    expect(patched).toContain("[runtime]");
+  });
+
+  test("replaces an existing multiline scenario array", () => {
+    const original = [
+      "[models.scenarios]",
+      "chat = [",
+      '  "deepseek",',
+      '  "gpt5",',
+      "]",
+      'cron = ["deepseek"]',
+      "",
+    ].join("\n");
+
+    const patched = patchScenarioModelListInToml({
+      tomlText: original,
+      scenario: "chat",
+      modelIds: ["minimax", "gpt5", "deepseek"],
+    });
+
+    expect(patched).toContain('  "minimax",');
+    expect(patched).toContain('  "gpt5",');
+    expect(patched).toContain('  "deepseek",');
+    expect(patched).toContain('cron = ["deepseek"]');
+  });
+
+  test("inserts a new scenario key into an existing models.scenarios section", () => {
+    const original = [
+      "[models.scenarios]",
+      'chat = ["deepseek"]',
+      "",
+      "[runtime]",
+      "maxTurns = 60",
+      "",
+    ].join("\n");
+
+    const patched = patchScenarioModelListInToml({
+      tomlText: original,
+      scenario: "cron",
+      modelIds: ["gpt5"],
+    });
+
+    expect(patched).toContain('chat = ["deepseek"]');
+    expect(patched).toContain('cron = ["gpt5"]');
+    expect(patched.indexOf("[runtime]")).toBeGreaterThan(patched.indexOf('cron = ["gpt5"]'));
+  });
+
+  test("appends a models.scenarios section when the file does not define one", () => {
+    const original = ["[logging]", 'level = "info"', "useColors = false", ""].join("\n");
+
+    const patched = patchScenarioModelListInToml({
+      tomlText: original,
+      scenario: "chat",
+      modelIds: ["gpt5"],
+    });
+
+    expect(patched).toContain("[models.scenarios]");
+    expect(patched).toContain('chat = ["gpt5"]');
+  });
+});

--- a/tests/config/model-scenario-patch.test.ts
+++ b/tests/config/model-scenario-patch.test.ts
@@ -11,7 +11,7 @@ describe("patchScenarioModelListInToml", () => {
       "",
       "[models.scenarios]",
       'chat = ["deepseek"] # current chat model',
-      'cron = ["deepseek"]',
+      'task = ["deepseek"]',
       "",
       "[runtime]",
       "maxTurns = 60",
@@ -26,7 +26,7 @@ describe("patchScenarioModelListInToml", () => {
 
     expect(patched).toContain("# keep me");
     expect(patched).toContain('chat = ["gpt5", "deepseek"] # current chat model');
-    expect(patched).toContain('cron = ["deepseek"]');
+    expect(patched).toContain('task = ["deepseek"]');
     expect(patched).toContain("[runtime]");
   });
 
@@ -37,7 +37,7 @@ describe("patchScenarioModelListInToml", () => {
       '  "deepseek",',
       '  "gpt5",',
       "]",
-      'cron = ["deepseek"]',
+      'task = ["deepseek"]',
       "",
     ].join("\n");
 
@@ -50,7 +50,7 @@ describe("patchScenarioModelListInToml", () => {
     expect(patched).toContain('  "minimax",');
     expect(patched).toContain('  "gpt5",');
     expect(patched).toContain('  "deepseek",');
-    expect(patched).toContain('cron = ["deepseek"]');
+    expect(patched).toContain('task = ["deepseek"]');
   });
 
   test("inserts a new scenario key into an existing models.scenarios section", () => {
@@ -65,13 +65,13 @@ describe("patchScenarioModelListInToml", () => {
 
     const patched = patchScenarioModelListInToml({
       tomlText: original,
-      scenario: "cron",
+      scenario: "task",
       modelIds: ["gpt5"],
     });
 
     expect(patched).toContain('chat = ["deepseek"]');
-    expect(patched).toContain('cron = ["gpt5"]');
-    expect(patched.indexOf("[runtime]")).toBeGreaterThan(patched.indexOf('cron = ["gpt5"]'));
+    expect(patched).toContain('task = ["gpt5"]');
+    expect(patched.indexOf("[runtime]")).toBeGreaterThan(patched.indexOf('task = ["gpt5"]'));
   });
 
   test("appends a models.scenarios section when the file does not define one", () => {

--- a/tests/config/scenario-model-switch.test.ts
+++ b/tests/config/scenario-model-switch.test.ts
@@ -65,8 +65,7 @@ function buildConfigToml(): string {
     "# keep this section comment",
     'chat = ["deepseek"] # keep this inline comment',
     'compaction = ["gpt5"]',
-    'subagent = ["gpt5"]',
-    'cron = ["deepseek"]',
+    'task = ["deepseek"]',
     'meditationBucket = ["gpt5"]',
     'meditationConsolidation = ["gpt5"]',
     "",
@@ -123,15 +122,15 @@ describe("ScenarioModelSwitchService", () => {
     const service = new ScenarioModelSwitchService(liveConfig);
 
     const result = await service.switchScenarioModel({
-      scenario: "cron",
+      scenario: "task",
       modelId: "minimax",
     });
 
     expect(result.configuredModelIds).toEqual(["minimax", "deepseek"]);
     expect(result.warnings).toEqual(["该模型不支持 tools，某些依赖工具调用的场景可能受影响。"]);
-    expect(liveConfig.getSnapshot().models.scenarios.cron).toEqual(["minimax", "deepseek"]);
+    expect(liveConfig.getSnapshot().models.scenarios.task).toEqual(["minimax", "deepseek"]);
 
     const nextToml = await readFile(workspace.configTomlPath, "utf8");
-    expect(nextToml).toContain('cron = ["minimax", "deepseek"]');
+    expect(nextToml).toContain('task = ["minimax", "deepseek"]');
   });
 });

--- a/tests/config/scenario-model-switch.test.ts
+++ b/tests/config/scenario-model-switch.test.ts
@@ -1,0 +1,137 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { LiveConfigManager } from "@/src/config/live-manager.js";
+import { loadConfig } from "@/src/config/load.js";
+import { ScenarioModelSwitchService } from "@/src/config/scenario-model-switch.js";
+
+async function createConfigWorkspace(): Promise<{
+  dir: string;
+  configTomlPath: string;
+  secretsTomlPath: string;
+}> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "pokeclaw-model-switch-"));
+  const configTomlPath = path.join(dir, "config.toml");
+  const secretsTomlPath = path.join(dir, "secrets.toml");
+  await writeFile(configTomlPath, buildConfigToml(), "utf8");
+  await writeFile(secretsTomlPath, "", "utf8");
+  return {
+    dir,
+    configTomlPath,
+    secretsTomlPath,
+  };
+}
+
+function buildConfigToml(): string {
+  return [
+    "# top comment should stay",
+    "[logging]",
+    'level = "info"',
+    "useColors = false",
+    "",
+    "[providers.main]",
+    'api = "openai-responses"',
+    'apiKey = "test-key"',
+    "",
+    "[[models.catalog]]",
+    'id = "gpt5"',
+    'provider = "main"',
+    'upstreamId = "openai/gpt-5"',
+    "contextWindow = 200000",
+    "maxOutputTokens = 8192",
+    "supportsTools = true",
+    "supportsVision = false",
+    "",
+    "[[models.catalog]]",
+    'id = "deepseek"',
+    'provider = "main"',
+    'upstreamId = "deepseek/chat"',
+    "contextWindow = 128000",
+    "maxOutputTokens = 8192",
+    "supportsTools = true",
+    "supportsVision = false",
+    "",
+    "[[models.catalog]]",
+    'id = "minimax"',
+    'provider = "main"',
+    'upstreamId = "minimax/m1"',
+    "contextWindow = 128000",
+    "maxOutputTokens = 8192",
+    "supportsTools = false",
+    "supportsVision = false",
+    "",
+    "[models.scenarios]",
+    "# keep this section comment",
+    'chat = ["deepseek"] # keep this inline comment',
+    'compaction = ["gpt5"]',
+    'subagent = ["gpt5"]',
+    'cron = ["deepseek"]',
+    'meditationBucket = ["gpt5"]',
+    'meditationConsolidation = ["gpt5"]',
+    "",
+  ].join("\n");
+}
+
+describe("ScenarioModelSwitchService", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+    tempDirs.length = 0;
+  });
+
+  test("moves an already-configured model to the front and reloads the live snapshot", async () => {
+    const workspace = await createConfigWorkspace();
+    tempDirs.push(workspace.dir);
+    const initialSnapshot = await loadConfig(workspace);
+    const liveConfig = new LiveConfigManager({
+      initialSnapshot,
+      filePaths: workspace,
+    });
+    const service = new ScenarioModelSwitchService(liveConfig);
+
+    const result = await service.switchScenarioModel({
+      scenario: "chat",
+      modelId: "gpt5",
+    });
+
+    expect(result).toMatchObject({
+      scenario: "chat",
+      previousModelId: "deepseek",
+      nextModelId: "gpt5",
+      configuredModelIds: ["gpt5", "deepseek"],
+      reloaded: true,
+      version: 2,
+    });
+    expect(liveConfig.getSnapshot().models.scenarios.chat).toEqual(["gpt5", "deepseek"]);
+
+    const nextToml = await readFile(workspace.configTomlPath, "utf8");
+    expect(nextToml).toContain("# top comment should stay");
+    expect(nextToml).toContain("# keep this section comment");
+    expect(nextToml).toContain('chat = ["gpt5", "deepseek"] # keep this inline comment');
+  });
+
+  test("inserts a catalog model that was not previously configured for the scenario", async () => {
+    const workspace = await createConfigWorkspace();
+    tempDirs.push(workspace.dir);
+    const initialSnapshot = await loadConfig(workspace);
+    const liveConfig = new LiveConfigManager({
+      initialSnapshot,
+      filePaths: workspace,
+    });
+    const service = new ScenarioModelSwitchService(liveConfig);
+
+    const result = await service.switchScenarioModel({
+      scenario: "cron",
+      modelId: "minimax",
+    });
+
+    expect(result.configuredModelIds).toEqual(["minimax", "deepseek"]);
+    expect(result.warnings).toEqual(["该模型不支持 tools，某些依赖工具调用的场景可能受影响。"]);
+    expect(liveConfig.getSnapshot().models.scenarios.cron).toEqual(["minimax", "deepseek"]);
+
+    const nextToml = await readFile(workspace.configTomlPath, "utf8");
+    expect(nextToml).toContain('cron = ["minimax", "deepseek"]');
+  });
+});

--- a/tests/cron/service.test.ts
+++ b/tests/cron/service.test.ts
@@ -50,7 +50,7 @@ function createCompletedRunResult(taskRunId: string): TaskExecutionRunResult {
       run: {
         runId: "loop_run_1",
         sessionId: "sess_task_1",
-        scenario: "cron",
+        scenario: "task",
         modelId: "test-model",
         appendedMessageIds: [],
         toolExecutions: 0,
@@ -101,7 +101,7 @@ function createCompletedRunResult(taskRunId: string): TaskExecutionRunResult {
     run: {
       runId: "loop_run_1",
       sessionId: "sess_task_1",
-      scenario: "cron",
+      scenario: "task",
       modelId: "test-model",
       appendedMessageIds: [],
       toolExecutions: 0,
@@ -138,7 +138,7 @@ function createStartedIngressResult(sessionId: string): SubmitMessageResult {
     run: {
       runId: "loop_run_1",
       sessionId,
-      scenario: "cron",
+      scenario: "task",
       modelId: "test-model",
       appendedMessageIds: [],
       toolExecutions: 0,

--- a/tests/integration/llm/delegated-approval.test.ts
+++ b/tests/integration/llm/delegated-approval.test.ts
@@ -280,7 +280,7 @@ describe("real llm delegated approval integration", () => {
 
     const result = await harness.ingress.submitMessage({
       sessionId: harness.created.executionSession.id,
-      scenario: "subagent",
+      scenario: "task",
       content: [
         "This is a permission-flow integration test. If the tool returns a requestable <permission_block>, you should request that permission instead of refusing on your own.",
         "Follow these steps exactly:",
@@ -390,7 +390,7 @@ describe("real llm delegated approval integration", () => {
 
     const result = await harness.ingress.submitMessage({
       sessionId: harness.created.executionSession.id,
-      scenario: "subagent",
+      scenario: "task",
       content: [
         "This is a permission-flow integration test. The path is intentionally sensitive so the approval layer can deny it. If the tool returns a requestable <permission_block>, you should still request it instead of refusing on your own.",
         "Follow these steps exactly:",

--- a/tests/meditation/models.test.ts
+++ b/tests/meditation/models.test.ts
@@ -45,8 +45,7 @@ function createRegistry(options?: {
       scenarios: {
         chat: ["anthropic_main/claude-sonnet-4-5"],
         compaction: ["anthropic_main/claude-sonnet-4-5"],
-        subagent: ["anthropic_main/claude-sonnet-4-5"],
-        cron: ["openai_main/gpt-5-mini"],
+        task: ["anthropic_main/claude-sonnet-4-5", "openai_main/gpt-5-mini"],
         meditationBucket: options?.bucketScenarioIds ?? ["openai_main/gpt-5-mini"],
         meditationConsolidation: options?.consolidationScenarioIds ?? [
           "anthropic_main/claude-sonnet-4-5",

--- a/tests/meditation/runner.test.ts
+++ b/tests/meditation/runner.test.ts
@@ -19,7 +19,10 @@ import {
   type TestDatabaseHandle,
 } from "@/tests/storage/helpers/test-db.js";
 
-function createRegistry(): ProviderRegistry {
+function createRegistry(options?: {
+  meditationBucket?: string[];
+  meditationConsolidation?: string[];
+}): ProviderRegistry {
   const config: Pick<AppConfig, "providers" | "models"> = {
     providers: {
       anthropic_main: {
@@ -58,8 +61,8 @@ function createRegistry(): ProviderRegistry {
         chat: ["anthropic_main/claude-sonnet-4-5"],
         compaction: ["anthropic_main/claude-sonnet-4-5"],
         task: ["anthropic_main/claude-sonnet-4-5", "openai_main/gpt-5-mini"],
-        meditationBucket: ["anthropic_main/claude-sonnet-4-5"],
-        meditationConsolidation: ["openai_main/gpt-5-mini"],
+        meditationBucket: options?.meditationBucket ?? ["anthropic_main/claude-sonnet-4-5"],
+        meditationConsolidation: options?.meditationConsolidation ?? ["openai_main/gpt-5-mini"],
       },
     },
   };
@@ -349,6 +352,83 @@ describe("MeditationPipelineRunner", () => {
     expect(privateMemory).toBe(
       "# Scope\n\n- atlas-web frontend.\n\n# Repeat-Use Lessons\n\n- Lead with diagnosis before explanation during atlas-web frontend debugging.\n",
     );
+  });
+
+  test("re-resolves meditation models from a provider registry source on each run", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedFixture(handle);
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "pokeclaw-meditation-live-models-"));
+    const workspaceDir = path.join(tempDir, "workspace");
+    const state = new MeditationStateRepo(handle.storage.db);
+    state.markFinished({
+      status: "completed",
+      finishedAt: new Date("2026-03-20T00:00:00.000Z"),
+      markSuccess: true,
+    });
+
+    let currentRegistry = createRegistry();
+    const registrySource = {
+      current: () => currentRegistry,
+    };
+    const seenModels: string[] = [];
+    let bridgeCall = 0;
+    let runIdCounter = 0;
+    const runner = new MeditationPipelineRunner({
+      storage: handle.storage.db,
+      state,
+      config: {
+        meditation: {
+          enabled: true,
+          cron: "0 0 * * *",
+        },
+      },
+      models: registrySource as never,
+      bridge: {
+        async completeTurn(input) {
+          bridgeCall += 1;
+          seenModels.push(input.model.id);
+          if (bridgeCall % 2 === 1) {
+            return createSubmitTurnResult({
+              note: `bucket note ${bridgeCall}`,
+              memory_candidates: [],
+            });
+          }
+
+          return createSubmitTurnResult({
+            shared_memory_rewrite: "# Shared\n",
+            private_memory_rewrites: [],
+          });
+        },
+      },
+      securityConfig: DEFAULT_CONFIG.security,
+      workspaceDir,
+      logsDir: tempDir,
+      createRunId: () => `run_${++runIdCounter}`,
+      resolveCalendarContext: () => ({
+        currentDate: "2026-04-08",
+        timezone: "UTC",
+      }),
+    });
+
+    await runner.runOnce({
+      tickAt: new Date("2026-04-08T00:00:00.000Z"),
+    });
+
+    currentRegistry = createRegistry({
+      meditationBucket: ["openai_main/gpt-5-mini"],
+      meditationConsolidation: ["anthropic_main/claude-sonnet-4-5"],
+    });
+
+    await runner.runOnce({
+      tickAt: new Date("2026-04-09T00:00:00.000Z"),
+    });
+
+    expect(seenModels).toEqual([
+      "anthropic_main/claude-sonnet-4-5",
+      "openai_main/gpt-5-mini",
+      "openai_main/gpt-5-mini",
+      "anthropic_main/claude-sonnet-4-5",
+    ]);
   });
 
   test("skips safely when meditation models are not configured", async () => {

--- a/tests/meditation/runner.test.ts
+++ b/tests/meditation/runner.test.ts
@@ -57,8 +57,7 @@ function createRegistry(): ProviderRegistry {
       scenarios: {
         chat: ["anthropic_main/claude-sonnet-4-5"],
         compaction: ["anthropic_main/claude-sonnet-4-5"],
-        subagent: ["anthropic_main/claude-sonnet-4-5"],
-        cron: ["openai_main/gpt-5-mini"],
+        task: ["anthropic_main/claude-sonnet-4-5", "openai_main/gpt-5-mini"],
         meditationBucket: ["anthropic_main/claude-sonnet-4-5"],
         meditationConsolidation: ["openai_main/gpt-5-mini"],
       },
@@ -388,8 +387,7 @@ describe("MeditationPipelineRunner", () => {
         scenarios: {
           chat: ["anthropic_main/claude-sonnet-4-5"],
           compaction: ["anthropic_main/claude-sonnet-4-5"],
-          subagent: ["anthropic_main/claude-sonnet-4-5"],
-          cron: ["anthropic_main/claude-sonnet-4-5"],
+          task: ["anthropic_main/claude-sonnet-4-5"],
           meditationBucket: [],
           meditationConsolidation: [],
         },

--- a/tests/orchestration/agent-manager.test.ts
+++ b/tests/orchestration/agent-manager.test.ts
@@ -17,7 +17,7 @@ import {
 
 function createStartedTaskRunResult(input: {
   sessionId: string;
-  scenario: "subagent" | "cron";
+  scenario: "task";
   completionStatus?: "completed" | "blocked" | "failed";
   summary?: string;
   finalMessage?: string;
@@ -27,7 +27,7 @@ function createStartedTaskRunResult(input: {
     status: "started",
     messageId: "msg_task_1",
     run: {
-      runId: input.scenario === "cron" ? "run_loop_cron_1" : "run_loop_1",
+      runId: "run_loop_task_1",
       sessionId: input.sessionId,
       scenario: input.scenario,
       modelId: "test-model",
@@ -586,7 +586,7 @@ describe("AgentManager", () => {
       const submitMessage = vi.fn(
         async (input: SubmitMessageInput): Promise<SubmitMessageResult> => {
           expect(input).toMatchObject({
-            scenario: "subagent",
+            scenario: "task",
             messageType: "task_kickoff",
             visibility: "hidden_system",
           });
@@ -595,7 +595,7 @@ describe("AgentManager", () => {
           expect(input.afterToolResultHook).toBeDefined();
           return createStartedTaskRunResult({
             sessionId: input.sessionId,
-            scenario: "subagent",
+            scenario: "task",
             summary: "Reviewed the repository changes.",
             finalMessage: "Reviewed the repository changes.",
           });
@@ -884,7 +884,7 @@ describe("AgentManager", () => {
       const submitMessage = vi.fn(
         async (input: SubmitMessageInput): Promise<SubmitMessageResult> => {
           expect(input).toMatchObject({
-            scenario: "cron",
+            scenario: "task",
             messageType: "cron_kickoff",
             visibility: "hidden_system",
           });
@@ -897,7 +897,7 @@ describe("AgentManager", () => {
           expect(input.afterToolResultHook).toBeDefined();
           return createStartedTaskRunResult({
             sessionId: input.sessionId,
-            scenario: "cron",
+            scenario: "task",
             summary: "Cron reconciliation finished.",
             finalMessage: "Cron reconciliation finished.",
           });
@@ -1034,7 +1034,7 @@ describe("AgentManager", () => {
           expect(input.afterToolResultHook).toBeDefined();
           return createStartedTaskRunResult({
             sessionId: input.sessionId,
-            scenario: "cron",
+            scenario: "task",
             summary: "Manual cron run finished.",
             finalMessage: "Manual cron run finished.",
           });

--- a/tests/orchestration/delegated-approval-orchestration.test.ts
+++ b/tests/orchestration/delegated-approval-orchestration.test.ts
@@ -55,8 +55,7 @@ function createModelConfig(): Pick<AppConfig, "providers" | "models"> {
       scenarios: {
         chat: ["anthropic_main/claude-sonnet-4-5"],
         compaction: ["anthropic_main/claude-sonnet-4-5"],
-        subagent: ["anthropic_main/claude-sonnet-4-5"],
-        cron: ["anthropic_main/claude-sonnet-4-5"],
+        task: ["anthropic_main/claude-sonnet-4-5"],
         meditationBucket: [],
         meditationConsolidation: [],
       },
@@ -367,7 +366,7 @@ describe("delegated approval end-to-end", () => {
 
     const result = await ingress.submitMessage({
       sessionId: created.executionSession.id,
-      scenario: "subagent",
+      scenario: "task",
       content: "Run the unattended task.",
     });
 
@@ -502,7 +501,7 @@ describe("delegated approval end-to-end", () => {
 
     const result = await ingress.submitMessage({
       sessionId: created.executionSession.id,
-      scenario: "subagent",
+      scenario: "task",
       content: "Run the unattended task.",
     });
 
@@ -615,7 +614,7 @@ describe("delegated approval end-to-end", () => {
 
     const result = await ingress.submitMessage({
       sessionId: created.executionSession.id,
-      scenario: "subagent",
+      scenario: "task",
       content: "Run the unattended task.",
     });
 

--- a/tests/orchestration/subagents.test.ts
+++ b/tests/orchestration/subagents.test.ts
@@ -226,7 +226,7 @@ describe("subagent orchestration", () => {
 
     expect(submitMessage).toHaveBeenCalledExactlyOnceWith({
       sessionId: created.session.id,
-      scenario: "subagent",
+      scenario: "chat",
       content: buildSubagentKickoffMessage(
         "Review the current PR and report concrete issues to the user.",
       ),

--- a/tests/orchestration/task-runner.test.ts
+++ b/tests/orchestration/task-runner.test.ts
@@ -58,7 +58,7 @@ function requireHandle(handle: TestDatabaseHandle | null): TestDatabaseHandle {
 
 function makeStartedRun(input: {
   sessionId: string;
-  scenario: "subagent" | "cron";
+  scenario: "task";
   stopSignal?: { reason: string; payload?: unknown } | null;
 }) {
   return {
@@ -106,8 +106,7 @@ function createModelConfig(): Pick<AppConfig, "providers" | "models"> {
       scenarios: {
         chat: ["anthropic_main/claude-sonnet-4-5"],
         compaction: ["anthropic_main/claude-sonnet-4-5"],
-        subagent: ["anthropic_main/claude-sonnet-4-5"],
-        cron: ["anthropic_main/claude-sonnet-4-5"],
+        task: ["anthropic_main/claude-sonnet-4-5"],
         meditationBucket: [],
         meditationConsolidation: [],
       },
@@ -191,7 +190,7 @@ describe("TaskExecutionRunner", () => {
         submitMessage: vi.fn(async (input) => {
           expect(input).toMatchObject({
             sessionId: created.executionSession.id,
-            scenario: "subagent",
+            scenario: "task",
             messageType: "task_kickoff",
             visibility: "hidden_system",
           });
@@ -199,7 +198,7 @@ describe("TaskExecutionRunner", () => {
           expect(input.content).toContain("<task_execution>");
           return makeStartedRun({
             sessionId: created.executionSession.id,
-            scenario: "subagent",
+            scenario: "task",
             stopSignal: {
               reason: "task_completion",
               payload: {
@@ -341,7 +340,7 @@ describe("TaskExecutionRunner", () => {
         expect(input.messageType).toBe("task_kickoff");
         return makeStartedRun({
           sessionId: created.executionSession.id,
-          scenario: "subagent",
+          scenario: "task",
         });
       })
       .mockImplementationOnce(async (input) => {
@@ -349,7 +348,7 @@ describe("TaskExecutionRunner", () => {
         expect(input.content).toContain("ended without calling finish_task");
         return makeStartedRun({
           sessionId: created.executionSession.id,
-          scenario: "subagent",
+          scenario: "task",
           stopSignal: {
             reason: "task_completion",
             payload: {
@@ -400,7 +399,7 @@ describe("TaskExecutionRunner", () => {
         submitMessage: vi.fn(async () =>
           makeStartedRun({
             sessionId: created.executionSession.id,
-            scenario: "cron",
+            scenario: "task",
             stopSignal: {
               reason: "task_completion",
               payload: {
@@ -445,7 +444,7 @@ describe("TaskExecutionRunner", () => {
     const submitMessage = vi.fn(async (input) =>
       makeStartedRun({
         sessionId: created.executionSession.id,
-        scenario: input.scenario as "subagent",
+        scenario: input.scenario as "task",
       }),
     );
 
@@ -580,7 +579,7 @@ describe("TaskExecutionRunner", () => {
         submitMessage: vi.fn(async (input) => {
           expect(input).toMatchObject({
             sessionId: created.executionSession.id,
-            scenario: "cron",
+            scenario: "task",
             messageType: "cron_kickoff",
             visibility: "hidden_system",
           });
@@ -605,7 +604,7 @@ describe("TaskExecutionRunner", () => {
           expect(input.content).toContain("Do not tell the user to look at them");
           return makeStartedRun({
             sessionId: created.executionSession.id,
-            scenario: "cron",
+            scenario: "task",
             stopSignal: {
               reason: "task_completion",
               payload: {

--- a/tests/runtime/bootstrap.test.ts
+++ b/tests/runtime/bootstrap.test.ts
@@ -19,8 +19,7 @@ function createConfig(): AppConfig {
       scenarios: {
         chat: [],
         compaction: [],
-        subagent: [],
-        cron: [],
+        task: [],
         meditationBucket: [],
         meditationConsolidation: [],
       },

--- a/tests/runtime/control.test.ts
+++ b/tests/runtime/control.test.ts
@@ -258,7 +258,7 @@ describe("RuntimeControlService", () => {
         sessionId: "sess_1",
         conversationId: "conv_1",
         branchId: "branch_1",
-        scenario: "cron",
+        scenario: "task",
       });
 
       control.stopRun({

--- a/tests/runtime/orchestration-bridge.test.ts
+++ b/tests/runtime/orchestration-bridge.test.ts
@@ -43,8 +43,7 @@ function createModelConfig(): Pick<AppConfig, "providers" | "models"> {
       scenarios: {
         chat: ["anthropic_main/claude-sonnet-4-5"],
         compaction: ["anthropic_main/claude-sonnet-4-5"],
-        subagent: ["anthropic_main/claude-sonnet-4-5"],
-        cron: ["anthropic_main/claude-sonnet-4-5"],
+        task: ["anthropic_main/claude-sonnet-4-5"],
         meditationBucket: [],
         meditationConsolidation: [],
       },

--- a/tests/runtime/status.test.ts
+++ b/tests/runtime/status.test.ts
@@ -64,8 +64,7 @@ function createConfig(): AppConfig {
       scenarios: {
         chat: ["openrouter-gpt5.4"],
         compaction: ["openrouter-gpt5.4"],
-        subagent: ["openrouter-gpt5.4"],
-        cron: ["openrouter-gpt5.4"],
+        task: ["openrouter-gpt5.4"],
         meditationBucket: [],
         meditationConsolidation: [],
       },

--- a/tests/tasks/task-session.test.ts
+++ b/tests/tasks/task-session.test.ts
@@ -14,7 +14,7 @@ describe("buildTaskExecutionKickoffEnvelope", () => {
         "Seeing this message means the daily report task should run now. Organize what was completed yesterday and produce a complete daily report.",
     });
 
-    expect(envelope.scenario).toBe("cron");
+    expect(envelope.scenario).toBe("task");
     expect(envelope.messageType).toBe("cron_kickoff");
     expect(envelope.content).toContain("<task_definition>");
     expect(envelope.content).toContain(
@@ -121,7 +121,7 @@ describe("buildTaskExecutionKickoffEnvelope", () => {
       maxPasses: 3,
     });
 
-    expect(envelope.scenario).toBe("cron");
+    expect(envelope.scenario).toBe("task");
     expect(envelope.messageType).toBe("task_supervisor_followup");
     expect(envelope.visibility).toBe("hidden_system");
     expect(envelope.content).toContain("<task_supervisor_followup>");


### PR DESCRIPTION
## Summary
- add live config hot-reload infrastructure with versioned snapshots
- add scenario-based model switching that patches config.toml and reloads runtime state
- add Lark /model interactive card flow and tests for config + inbound behavior

## Validation
- pnpm preflight

by Pokeclaw