### PR TITLE
Add Claude session observe skill

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "vitest": "^4.1.0"
   },
   "dependencies": {
-    "@anthropic-ai/sandbox-runtime": "link:../sandbox-runtime",
+    "@danielwpz/sandbox-runtime": "0.0.43-pokeclaw.0",
     "@larksuiteoapi/node-sdk": "^1.60.0",
     "@mariozechner/pi-agent-core": "0.58.0",
     "@mariozechner/pi-ai": "0.58.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      '@anthropic-ai/sandbox-runtime':
-        specifier: link:../sandbox-runtime
-        version: link:../sandbox-runtime
+      '@danielwpz/sandbox-runtime':
+        specifier: 0.0.43-pokeclaw.0
+        version: 0.0.43-pokeclaw.0
       '@larksuiteoapi/node-sdk':
         specifier: ^1.60.0
         version: 1.60.0
@@ -270,6 +270,11 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@danielwpz/sandbox-runtime@0.0.43-pokeclaw.0':
+    resolution: {integrity: sha512-U1bZo9YibCuMcOF7Vd6Dsl8t05tz1T8taAtVsZ+dVZ6zPjPhtbfVN0qhZ6z0F9B2GrZFlvbPCb4DYfRBMxxqwg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -768,6 +773,9 @@ packages:
   '@oxc-project/types@0.120.0':
     resolution: {integrity: sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==}
 
+  '@pondwader/socks5-server@1.0.10':
+    resolution: {integrity: sha512-bQY06wzzR8D2+vVCUoBsr5QS2U6UgPUQRmErNwtsuI6vLcyRKkafjkr3KxbtGFf9aBBIV2mcvlsKD1UYaIV+sg==}
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -1109,6 +1117,12 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/lodash-es@4.17.12':
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
+
+  '@types/lodash@4.17.24':
+    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
+
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
@@ -1250,6 +1264,10 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -1720,6 +1738,9 @@ packages:
     resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
     engines: {node: '>=20.0.0'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.identity@3.0.0:
     resolution: {integrity: sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q==}
 
@@ -1918,6 +1939,10 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -2180,6 +2205,9 @@ packages:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
     peerDependencies:
       zod: ^3.25 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -2605,6 +2633,15 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.8':
     optional: true
 
+  '@danielwpz/sandbox-runtime@0.0.43-pokeclaw.0':
+    dependencies:
+      '@pondwader/socks5-server': 1.0.10
+      '@types/lodash-es': 4.17.12
+      commander: 12.1.0
+      lodash-es: 4.18.1
+      shell-quote: 1.8.3
+      zod: 3.25.76
+
   '@drizzle-team/brocli@0.10.2': {}
 
   '@emnapi/core@1.9.1':
@@ -2935,6 +2972,8 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.120.0': {}
+
+  '@pondwader/socks5-server@1.0.10': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -3346,6 +3385,12 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/lodash-es@4.17.12':
+    dependencies:
+      '@types/lodash': 4.17.24
+
+  '@types/lodash@4.17.24': {}
+
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
@@ -3492,6 +3537,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  commander@12.1.0: {}
 
   commander@14.0.3: {}
 
@@ -3921,6 +3968,8 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
 
+  lodash-es@4.18.1: {}
+
   lodash.identity@3.0.0: {}
 
   lodash.merge@4.6.2: {}
@@ -4140,6 +4189,8 @@ snapshots:
 
   semver@7.7.4: {}
 
+  shell-quote@1.8.3: {}
+
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -4357,5 +4408,7 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:
       zod: 4.3.6
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}

--- a/skills/claude-session-observe/SKILL.md
+++ b/skills/claude-session-observe/SKILL.md
@@ -8,7 +8,7 @@ skillKey: pokeclaw/claude-session-observe
 
 Use this skill to inspect Claude Code's local session artifacts under `~/.claude`.
 
-The goal of this skill is **not** to teach the agent to trust a magic script. The goal is to teach the agent how to:
+The goal of this skill is **not** to teach you to trust a magic script. The goal is to teach you how to:
 
 - find which Claude Code sessions exist for a project
 - inspect what happened in a session
@@ -26,15 +26,15 @@ There are three layers here:
 2. **Query helpers**
    - optional scripts under `scripts/`
    - ordinary file reads, `ls`, `grep`, `tail`-style inspection
-3. **Agent judgment**
+3. **Your judgment**
    - "what sessions exist"
    - "what this session was doing"
    - "what was completed"
    - "what should happen next"
 
-The scripts are only layer 2. They are read-only retrieval helpers, similar to `ls`, `tail`, or `select ... from ... limit ...`. They do **not** decide the final answer.
+The scripts are only layer 2. They are read-only retrieval helpers, similar to `ls`, `tail`, or `select ... from ... limit ...`. **You** decide the final answer.
 
-If the scripts do not exist, the skill should still work. The real contract of this skill is the investigation workflow.
+If the scripts do not exist, you should still be able to use this skill. The real contract of this skill is the investigation workflow.
 
 ## Channels
 

--- a/skills/claude-session-observe/SKILL.md
+++ b/skills/claude-session-observe/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: claude-session-observe
+description: Use this skill to inspect Claude Code session history under ~/.claude, recover what sessions exist, and manually determine what a session was doing from transcript evidence.
+skillKey: pokeclaw/claude-session-observe
+---
+
+# Claude Session Observe
+
+Use this skill to inspect Claude Code's local session artifacts under `~/.claude`.
+
+The goal of this skill is **not** to teach the agent to trust a magic script. The goal is to teach the agent how to:
+
+- find which Claude Code sessions exist for a project
+- inspect what happened in a session
+- understand what a session was doing from transcript evidence
+- check whether work was completed, interrupted, delegated, or still needs follow-up
+- compare the session story with the **current repo state** when the user wants to continue or verify work
+
+## Core principle
+
+There are three layers here:
+
+1. **Artifacts**
+   - `~/.claude` transcript and sidecar files
+   - current repo/worktree state for the recovered `cwd`
+2. **Query helpers**
+   - optional scripts under `scripts/`
+   - ordinary file reads, `ls`, `grep`, `tail`-style inspection
+3. **Agent judgment**
+   - "what sessions exist"
+   - "what this session was doing"
+   - "what was completed"
+   - "what should happen next"
+
+The scripts are only layer 2. They are read-only retrieval helpers, similar to `ls`, `tail`, or `select ... from ... limit ...`. They do **not** decide the final answer.
+
+If the scripts do not exist, the skill should still work. The real contract of this skill is the investigation workflow.
+
+## Channels
+
+- Active session map: `~/.claude/sessions/*.json`
+- Project session transcripts: `~/.claude/projects/<encoded-project>/<session-id>.jsonl`
+- Session sidecar directory: `~/.claude/projects/<encoded-project>/<session-id>/`
+- Subagent transcripts: `subagents/*.jsonl`
+- Subagent metadata: `subagents/*.meta.json`
+- Tool output captures: `tool-results/*.txt`
+- Global history: `~/.claude/history.jsonl`
+- Current repo/worktree for the recovered `cwd`
+
+Choose channels based on the question. Do not force every question through the same path.
+
+## Required first reads
+
+- If the task is about `~/.claude` layout, path encoding, or where files live:
+  - read `references/layout-overview.md`
+- If the task is about finding which session to inspect:
+  - read `references/session-discovery-recipes.md`
+- If the task is about how to read transcript JSONL records:
+  - read `references/transcript-records.md`
+- If the task is about interpreting recent work or takeover / continuation:
+  - read `references/activity-heuristics.md`
+  - then read `references/continuation-handoff.md`
+
+## Default posture
+
+Start **manually** unless a helper script will obviously save repetitive work.
+
+In many cases you do not need Python at all. The job can often be done with:
+
+- path resolution
+- directory listing
+- reading one or more transcript files
+- checking the tail of the transcript
+- checking the current repo state
+
+Use scripts only when they make repetitive retrieval faster or safer.
+
+## Core workflows
+
+### 1. User asks: what Claude Code sessions exist for this project?
+
+1. Resolve the project to an absolute path.
+2. Map it to the encoded project directory under `~/.claude/projects/`.
+3. Check `~/.claude/sessions/*.json` for active-session matches by `cwd`.
+4. List the project's `*.jsonl` files.
+5. Rank candidates by evidence:
+   - active-session match
+   - transcript timestamps
+   - nearby `progress` / `last-prompt`
+   - file mtime only as fallback
+6. Present the candidate sessions and your ranking evidence.
+
+### 2. User asks: what was this session doing?
+
+1. Read the transcript tail.
+2. Inspect the latest useful evidence:
+   - `last-prompt`
+   - recent `user` records
+   - recent `assistant` records
+   - recent `progress` records
+3. If the parent transcript suggests delegated work, inspect `subagents/`.
+4. If a tool result is needed, inspect `tool-results/`.
+5. Then **you** explain:
+   - what the user wanted
+   - what Claude already did
+   - whether the flow looks finished, interrupted, or still in flight
+
+Do not ask the scripts to produce that explanation for you.
+
+### 3. User asks: continue the latest Claude Code session / finish what it did not finish
+
+1. Choose the best candidate session for the target project.
+2. Recover the session story from transcript evidence.
+3. Then inspect the **current repo/worktree** for that session's `cwd`.
+4. Compare transcript evidence with disk state.
+5. Answer with a continuation brief:
+   - recovered objective
+   - artifacts touched
+   - completed so far
+   - current repo/worktree state
+   - what remains
+   - immediate next action
+
+Important: for continuation, transcript evidence alone is not enough.
+
+### 4. User asks: check whether Claude's work actually landed
+
+1. Recover the claimed work from the transcript.
+2. Check the relevant repo directly:
+   - `git status --short --branch`
+   - `git diff --stat`
+   - relevant file diffs or file reads
+   - recent commits if needed
+3. Compare the claim with the actual repo state.
+4. Report agreement or mismatch explicitly.
+
+## Working rules
+
+- Prefer direct evidence over guesswork.
+- Prefer project-local transcript evidence over global history for project continuation.
+- Scripts are optional helpers, not answer generators.
+- If you use a script, treat its output as evidence to inspect.
+- Do not let a script decide the goal, stopping point, completion state, or next step.
+- Inspect `progress` before assuming the latest assistant text tells the whole story.
+- Inspect sidecar artifacts only when the transcript suggests they matter or when more detail is needed.
+- If the user wants continuation or verification, compare the session story with the current repo/worktree state.
+- If evidence is ambiguous, present ranked interpretations instead of pretending certainty.
+- If the trailing transcript line is malformed, ignore that line and continue with earlier valid records.
+
+## Optional helper scripts
+
+These are convenience tools only.
+
+- `scripts/find_project_sessions.py`
+  - read-only helper to list project-local candidate sessions
+- `scripts/read_session_records.py`
+  - read-only helper to slice one session transcript and optionally list sidecar artifacts
+
+Use them the same way you would use `ls`, `tail`, or a small `select ... from ... limit ...` query.
+
+## Available references
+
+- `references/layout-overview.md`
+- `references/session-discovery-recipes.md`
+- `references/transcript-records.md`
+- `references/activity-heuristics.md`
+- `references/continuation-handoff.md`
+
+## Anti-patterns
+
+- Do not treat helper scripts as semantic summarizers.
+- Do not expect a Python script to tell you what a session "means".
+- Do not stop at transcript reading when the user asked you to continue or verify work.
+- Do not ignore the current repo state for the recovered `cwd`.
+- Do not rely only on file mtime when transcript timestamps exist.
+- Do not assume tool results are top-level transcript records.
+- Do not assume interruptions have a dedicated top-level schema.
+- Do not require the scripts when direct file inspection is enough.

--- a/skills/claude-session-observe/references/activity-heuristics.md
+++ b/skills/claude-session-observe/references/activity-heuristics.md
@@ -1,0 +1,128 @@
+# Activity and continuation heuristics
+
+Use this file when the task is to answer questions like:
+
+- what was Claude Code doing lately
+- what was this session trying to do
+- can I continue from the latest session
+- is the work finished or still pending
+
+## Core rule
+
+The heuristics in this file are for the **agent**, not for the helper scripts.
+
+Scripts may retrieve evidence slices. They should not be treated as the entity that understands the meaning of the session.
+
+## What a good answer requires
+
+A good answer usually combines two evidence planes:
+
+1. **Session evidence** from `~/.claude`
+2. **Current repo/worktree evidence** from the recovered `cwd`
+
+For many continuation tasks, transcript evidence tells you the direction, but the repo state tells you whether the work actually landed.
+
+## Recommended evidence order
+
+### 1. Active-session map
+
+Check `~/.claude/sessions/*.json` for a matching `cwd`.
+
+If there is a match, that session is a strong candidate for "currently open".
+
+This is only a liveness hint, not proof that the work is complete or healthy.
+
+### 2. Main transcript tail
+
+Read the latest valid records in `<session-id>.jsonl`.
+
+Use timestamps to establish recency. If needed, `file-history-snapshot.snapshot.timestamp` can help when a nearby top-level timestamp is missing.
+
+### 3. `progress`
+
+Inspect recent `progress` records before trusting the latest assistant text alone.
+
+`progress` often reveals:
+
+- delegated work
+- subagent activity
+- in-flight actions
+- more current operational state than a nearby assistant reply
+
+### 4. `last-prompt`
+
+Use `last-prompt` to quickly recover the latest direct user intent.
+
+### 5. Recent `user` and `assistant`
+
+Use nearby `user` and `assistant` turns to understand:
+
+- what the user wanted
+- what Claude said it did
+- whether the flow stopped mid-tool-use
+- whether the user interrupted it
+
+### 6. Sidecar artifacts when relevant
+
+If the parent transcript suggests delegated work or compressed tool output, inspect:
+
+- `subagents/*.jsonl`
+- `subagents/*.meta.json`
+- `tool-results/*.txt`
+
+Do this when needed, not by default for every session.
+
+### 7. Current repo/worktree state
+
+When the user wants continuation, verification, or completion:
+
+- inspect the recovered `cwd`
+- check `git status --short --branch`
+- check `git diff --stat`
+- inspect specific files or diffs that the transcript suggests matter
+- inspect recent commits when commit state matters
+
+This is often the difference between "Claude said it was done" and "the work is actually on disk and landed".
+
+## Reasoning pattern
+
+After collecting evidence, reason in this order:
+
+1. Which session is the best candidate?
+2. What was the user trying to get done?
+3. What did Claude already do?
+4. Did the flow stop cleanly, get interrupted, or stay in flight?
+5. What does the current repo/worktree state confirm or contradict?
+6. What should happen next?
+
+That final reasoning step belongs to the agent.
+
+## Suggested answer shape
+
+When asked to explain or continue a session, answer in this order:
+
+1. **Recovered objective**
+2. **Completed so far**
+3. **Current stopping point**
+4. **Current repo/worktree state**
+5. **What remains**
+6. **Immediate next action**
+
+If confidence is low, include ranked alternatives and explain the uncertainty.
+
+## Important interpretation rules
+
+- Prefer direct evidence over guesswork.
+- Prefer project-local transcript evidence over global history.
+- Prefer `progress` and sidecar evidence over assumptions from the last assistant text alone.
+- If the last assistant action is a `tool_use` with no later resolution, consider unfinished work as a possibility.
+- If multiple candidate sessions are plausible, show them instead of silently picking one.
+- Do not stop at `~/.claude` if the user asked whether the work was finished.
+- Do not ask the helper scripts to explain the semantics for you.
+
+## Optional helper scripts
+
+- `scripts/find_project_sessions.py --project /abs/path/to/project`
+- `scripts/read_session_records.py --session-file /path/to/session.jsonl`
+
+Use them to retrieve data more quickly. The judgment still belongs to the agent.

--- a/skills/claude-session-observe/references/activity-heuristics.md
+++ b/skills/claude-session-observe/references/activity-heuristics.md
@@ -9,7 +9,7 @@ Use this file when the task is to answer questions like:
 
 ## Core rule
 
-The heuristics in this file are for the **agent**, not for the helper scripts.
+The heuristics in this file are for **you**, not for the helper scripts.
 
 Scripts may retrieve evidence slices. They should not be treated as the entity that understands the meaning of the session.
 
@@ -95,7 +95,7 @@ After collecting evidence, reason in this order:
 5. What does the current repo/worktree state confirm or contradict?
 6. What should happen next?
 
-That final reasoning step belongs to the agent.
+That final reasoning step belongs to you.
 
 ## Suggested answer shape
 
@@ -125,4 +125,4 @@ If confidence is low, include ranked alternatives and explain the uncertainty.
 - `scripts/find_project_sessions.py --project /abs/path/to/project`
 - `scripts/read_session_records.py --session-file /path/to/session.jsonl`
 
-Use them to retrieve data more quickly. The judgment still belongs to the agent.
+Use them to retrieve data more quickly. The judgment still belongs to you.

--- a/skills/claude-session-observe/references/continuation-handoff.md
+++ b/skills/claude-session-observe/references/continuation-handoff.md
@@ -4,7 +4,7 @@ Use this file when the task is not just to observe a session, but to **take it o
 
 ## Core idea
 
-Continuation is not a script feature. Continuation is an **agent workflow**.
+Continuation is not a script feature. Continuation is **your workflow**.
 
 A good continuation answer needs at least two evidence planes:
 

--- a/skills/claude-session-observe/references/continuation-handoff.md
+++ b/skills/claude-session-observe/references/continuation-handoff.md
@@ -1,0 +1,128 @@
+# Continuation and handoff workflow
+
+Use this file when the task is not just to observe a session, but to **take it over, verify it, or finish the unfinished work**.
+
+## Core idea
+
+Continuation is not a script feature. Continuation is an **agent workflow**.
+
+A good continuation answer needs at least two evidence planes:
+
+1. **Session evidence** from `~/.claude`
+2. **Current repo/worktree evidence** from the recovered `cwd`
+
+If you only read the transcript, you often know the direction but not the current execution state.
+
+## Phase 1: recover the session story
+
+1. Choose the best candidate session.
+2. Read the transcript tail.
+3. Recover:
+   - what the user wanted
+   - what Claude already did
+   - where the flow seems to have stopped
+4. Inspect `subagents/` and `tool-results/` only when the transcript suggests they matter.
+
+Useful evidence:
+
+- `last-prompt`
+- recent `user`
+- recent `assistant`
+- recent `progress`
+- `subagents/*.jsonl`
+- `subagents/*.meta.json`
+- `tool-results/*.txt`
+
+## Phase 2: inspect the current repo/worktree
+
+Inspect the recovered `cwd` directly.
+
+Typical read-only checks:
+
+- `git status --short --branch`
+- `git diff --stat`
+- `git diff -- <relevant-file>`
+- `git log --oneline --decorate -n 5`
+- file reads for touched artifacts when needed
+
+This phase answers questions the transcript cannot settle by itself.
+
+## Phase 3: reconcile transcript with repo state
+
+Ask these questions explicitly:
+
+1. Does the work described in the transcript actually exist on disk?
+2. Is it uncommitted, committed, or absent?
+3. Does the repo state match Claude's claims?
+4. Is the task actually finished, or only apparently finished inside the transcript?
+
+## Common continuation states
+
+### A. Implemented locally, not landed
+
+Signals:
+
+- transcript says work was done
+- relevant files are modified or untracked
+
+Likely next action:
+
+- review files
+- run the minimum validation needed
+- commit / PR / report
+
+### B. Partially implemented
+
+Signals:
+
+- transcript shows active coding or tool use
+- repo has some relevant edits
+- obvious work remains
+
+Likely next action:
+
+- continue implementation from the touched files
+
+### C. Finished and landed
+
+Signals:
+
+- transcript says done
+- repo state is clean or recent commits already contain the work
+
+Likely next action:
+
+- report completion or move to the next task
+
+### D. Ambiguous or divergent
+
+Signals:
+
+- transcript and repo state do not line up
+- multiple sessions are plausible
+- workspace includes unrelated changes
+
+Likely next action:
+
+- report the ambiguity explicitly
+- present ranked possibilities
+
+## Continuation brief template
+
+When you answer a continuation / takeover request, prefer this structure:
+
+1. **Recovered objective**
+2. **Artifacts touched**
+3. **Completed so far**
+4. **Current repo/worktree state**
+5. **What remains**
+6. **Immediate next action**
+
+## Optional helper scripts
+
+If they help with retrieval, you may use:
+
+- `scripts/find_project_sessions.py`
+- `scripts/read_session_records.py`
+
+But continuation itself is not delegated to the scripts.

--- a/skills/claude-session-observe/references/layout-overview.md
+++ b/skills/claude-session-observe/references/layout-overview.md
@@ -23,18 +23,20 @@ For "continue recent work on project X", start with `projects/` and `sessions/`,
 
 Project session data is keyed by an encoded absolute path under `~/.claude/projects/`.
 
-Observed pattern:
+Observed practical lookup rule:
 
 - start from the absolute project path
-- replace `/` with `-`
-- keep the leading slash as a leading `-`
+- normalize path separators before encoding
+- expect Claude's directory name to be lossy rather than perfectly reversible
+- on observed installations, path separators, spaces, and other unsupported characters often collapse to `-`
+- on POSIX paths, the leading slash usually appears as a leading `-`
 
-Example:
+POSIX example:
 
 - project path: `/absolute/path/to/project`
 - project dir: `~/.claude/projects/-absolute-path-to-project/`
 
-Treat this as the practical lookup rule, but still verify the resulting directory exists.
+Do not treat this as an exact universal encoding contract. Use it as a first lookup guess, then verify the resulting directory exists. If it does not, inspect candidate project directories and confirm matches from transcript `cwd` values.
 
 ## Project directory layout
 

--- a/skills/claude-session-observe/references/layout-overview.md
+++ b/skills/claude-session-observe/references/layout-overview.md
@@ -1,0 +1,92 @@
+# Claude Code local storage layout
+
+Use this file when the task is about where Claude Code stores local state under `~/.claude` and which directories matter for session inspection.
+
+## Top-level locations to know
+
+Important paths under `~/.claude`:
+
+- `history.jsonl` - global cross-project input/history hints
+- `projects/` - per-project session transcripts and sidecar artifacts
+- `sessions/` - active-session PID map files
+- `session-env/` - per-session environment snapshots
+- `file-history/` - per-session file history snapshots
+- `plans/` - plan-mode files
+- `tasks/` - task list storage
+- `teams/` - team inboxes and shared coordination files
+- `skills/` - installed user/global skills
+- `settings.json` - Claude Code settings
+
+For "continue recent work on project X", start with `projects/` and `sessions/`, not `history.jsonl`.
+
+## Project path encoding
+
+Project session data is keyed by an encoded absolute path under `~/.claude/projects/`.
+
+Observed pattern:
+
+- start from the absolute project path
+- replace `/` with `-`
+- keep the leading slash as a leading `-`
+
+Example:
+
+- project path: `/absolute/path/to/project`
+- project dir: `~/.claude/projects/-absolute-path-to-project/`
+
+Treat this as the practical lookup rule, but still verify the resulting directory exists.
+
+## Project directory layout
+
+Inside one encoded project directory you may see:
+
+- `<session-id>.jsonl` - main transcript for one Claude Code session
+- `<session-id>/` - sidecar directory for that session
+
+Inside the sidecar directory you may see:
+
+- `subagents/*.jsonl` - subagent transcripts
+- `subagents/*.meta.json` - subagent labels/types/descriptions
+- `tool-results/*.txt` - captured tool outputs or spill files
+
+This means a full reconstruction may need both:
+
+- the main transcript file
+- the sidecar session directory
+
+## Active session map
+
+`~/.claude/sessions/*.json` is the best place to detect a likely live session.
+
+Observed fields include:
+
+- `pid`
+- `sessionId`
+- `cwd`
+- `startedAt`
+
+For a project-specific question, match `cwd` to the real project path.
+
+If there is a match, inspect that `sessionId` first.
+
+Important: this is strong evidence of a currently open session, but not proof that the work is healthy, complete, or still making progress.
+
+## What `history.jsonl` is for
+
+`~/.claude/history.jsonl` is useful for broad cross-project recall and prompt history.
+
+It is **not** the primary source for:
+
+- latest session for one project
+- latest progress for one project
+- continuation state for one project
+
+For those tasks, use the project transcript directory first.
+
+## Other useful but secondary directories
+
+- `session-env/` - useful when environment context matters
+- `file-history/` - useful when you need file-tracking snapshots
+- `plans/`, `tasks/`, `teams/` - useful when recent work involved plan mode, task lists, or teammate coordination
+
+These are secondary to the main project transcript for most continuation tasks.

--- a/skills/claude-session-observe/references/session-discovery-recipes.md
+++ b/skills/claude-session-observe/references/session-discovery-recipes.md
@@ -1,0 +1,92 @@
+# Session discovery recipes
+
+Use this file when the task is to locate Claude Code sessions for a project, or to decide which recent session is the best candidate to inspect.
+
+## Core idea
+
+Finding the right session is mostly a file-discovery problem:
+
+- resolve the project path
+- map it to the encoded project directory
+- inspect active-session PID files
+- inspect project-local transcript files
+- rank candidates using timestamps and nearby evidence
+
+You do not need a magic script to do this. A script can help, but the workflow should still make sense manually.
+
+## Manual recipe: find sessions for project X
+
+### 1. Resolve the project path
+
+Turn the user-facing project name into a concrete absolute path.
+
+Do not skip this step. The encoded Claude directory depends on the exact path.
+
+### 2. Map the path to the encoded project directory
+
+Compute the expected directory under `~/.claude/projects/` using the path-encoding rule from `layout-overview.md`.
+
+Then verify that directory exists.
+
+### 3. Check active sessions first
+
+Inspect `~/.claude/sessions/*.json` and match by `cwd`.
+
+If one or more entries match the project path:
+
+- treat them as strong candidates for the current active session
+- inspect them first
+- if multiple active entries match, rank them using transcript evidence instead of guessing
+
+### 4. Enumerate transcript candidates
+
+Within the project directory, inspect:
+
+- `*.jsonl`
+
+Each file is a candidate main session transcript.
+
+Session IDs are not time-ordered. Do not rank by filename.
+
+### 5. Rank candidates using evidence
+
+Preferred ranking order:
+
+1. active-session match
+2. latest valid transcript timestamp
+3. latest `file-history-snapshot.snapshot.timestamp` if needed
+4. nearby `progress` / `last-prompt` evidence near the tail
+5. file mtime only as fallback
+
+### 6. Handle ambiguity explicitly
+
+If two or more candidates are close:
+
+- inspect the tail of each transcript
+- compare evidence such as:
+  - `last-prompt`
+  - latest progress timestamp
+  - latest assistant activity
+  - interruption markers
+- present the ranked candidates and your reasoning
+
+## Manual recipe: continue the recent work
+
+Once you choose the best candidate session:
+
+1. read the transcript tail
+2. inspect `last-prompt`
+3. inspect recent `user`, `assistant`, and `progress` records
+4. inspect sidecar artifacts if the transcript suggests they matter
+5. inspect the current repo/worktree for that session's `cwd`
+6. only then decide what the session was doing and what remains
+
+This workflow is the real contract. Scripts only accelerate the retrieval parts.
+
+## Optional helper script
+
+If repetitive candidate listing is useful, you may use:
+
+- `scripts/find_project_sessions.py --project /abs/path/to/project`
+
+Treat it as a query helper, not as a final answer engine.

--- a/skills/claude-session-observe/references/session-discovery-recipes.md
+++ b/skills/claude-session-observe/references/session-discovery-recipes.md
@@ -24,9 +24,11 @@ Do not skip this step. The encoded Claude directory depends on the exact path.
 
 ### 2. Map the path to the encoded project directory
 
-Compute the expected directory under `~/.claude/projects/` using the path-encoding rule from `layout-overview.md`.
+Compute the expected directory under `~/.claude/projects/` using the practical encoding rule from `layout-overview.md`.
 
 Then verify that directory exists.
+
+If it does not exist, do not stop there. The encoding is lossy and may vary across platforms or path contents. Fall back to inspecting candidate transcript files under `~/.claude/projects/*/` and match them by transcript `cwd`.
 
 ### 3. Check active sessions first
 

--- a/skills/claude-session-observe/references/transcript-records.md
+++ b/skills/claude-session-observe/references/transcript-records.md
@@ -1,0 +1,175 @@
+# Transcript record guide
+
+Use this file when the task is to interpret Claude Code session JSONL records.
+
+## Core idea
+
+Transcript reading is mostly a structured file-reading task.
+
+You are looking at JSONL records and asking:
+
+- which records matter for this question
+- what order they happened in
+- what fixed fields they expose
+- what additional sidecar files might matter
+
+The interpretation still belongs to the agent.
+
+## Main record types observed in project transcripts
+
+Observed top-level `type` values include:
+
+- `file-history-snapshot`
+- `user`
+- `assistant`
+- `progress`
+- `system`
+- `custom-title`
+- `agent-name`
+- `last-prompt`
+
+Do not assume this list is exhaustive.
+
+## What each record type is useful for
+
+### `file-history-snapshot`
+
+Useful for:
+
+- snapshot timestamps
+- file-history state changes
+
+Important note:
+
+- metadata, not a conversational turn
+- `snapshot.timestamp` can help when a nearby top-level timestamp is missing
+
+### `user`
+
+Useful for:
+
+- direct user intent
+- interruption markers
+- tool results nested back into the transcript
+
+Important note:
+
+- not every `user` record is direct human text
+- some `user` records mainly carry tool result payloads
+
+### `assistant`
+
+Useful for:
+
+- assistant text output
+- assistant tool-use intent
+- whether the assistant appears to have stopped mid-action
+
+Important note:
+
+- `tool_use` items often live inside `message.content[]`
+- a trailing tool-use record with no later resolution may indicate unfinished work
+
+### `progress`
+
+Useful for:
+
+- recent operational state
+- delegated work
+- subagent activity
+- in-flight actions near the tail
+
+Important note:
+
+- `progress` can be more informative than nearby assistant text
+- useful clues may be nested, not always exposed at the top level
+
+### `system`
+
+Useful for:
+
+- metadata like turn timing
+
+Observed subtype:
+
+- `turn_duration`
+
+### `custom-title`
+
+Useful for:
+
+- user/session title hints
+
+### `agent-name`
+
+Useful for:
+
+- named agent labels
+
+### `last-prompt`
+
+Useful for:
+
+- quick recovery of the latest direct user request
+
+This is often one of the fastest ways to recover intent.
+
+## Important parsing caveats
+
+### Tool results are often nested
+
+Do not expect a dedicated top-level `tool` record.
+
+Tool results may appear:
+
+- inside top-level `user.message.content[]`
+- mirrored in helper fields like `toolUseResult`
+- nested under `progress` payloads
+
+### Interruptions may be plain text markers
+
+Common examples:
+
+- `[Request interrupted by user]`
+- `[Request interrupted by user for tool use]`
+
+Do not assume a special interruption schema exists.
+
+### Unknown future record types should not break the analysis
+
+If a new record type appears:
+
+- keep it as unknown metadata
+- do not crash
+- rely on known record types first
+
+### Large lines and partial writes are normal hazards
+
+Practical handling:
+
+- tolerate very large JSONL lines
+- if the trailing line is malformed, ignore it and continue with earlier valid records
+
+## Minimal fields worth extracting
+
+For most session-reading tasks, these fields matter most:
+
+- top-level `type`
+- top-level `timestamp`
+- `sessionId`
+- `cwd`
+- `gitBranch`
+- `message.role`
+- `message.content`
+- `lastPrompt`
+- `subtype` and `durationMs` on `system`
+
+These are good fields for a query helper to expose.
+
+## Optional helper script
+
+For repeated transcript slicing you may use:
+
+- `scripts/read_session_records.py`
+
+Treat it as a transcript query helper, not as an interpretation engine.

--- a/skills/claude-session-observe/references/transcript-records.md
+++ b/skills/claude-session-observe/references/transcript-records.md
@@ -13,7 +13,7 @@ You are looking at JSONL records and asking:
 - what fixed fields they expose
 - what additional sidecar files might matter
 
-The interpretation still belongs to the agent.
+The interpretation still belongs to you.
 
 ## Main record types observed in project transcripts
 

--- a/skills/claude-session-observe/scripts/find_project_sessions.py
+++ b/skills/claude-session-observe/scripts/find_project_sessions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import re
 import sys
 from collections import Counter
 from pathlib import Path
@@ -16,7 +17,8 @@ def resolve_claude_dir(raw: str | None) -> Path:
 
 def encode_project_path(project_path: Path) -> str:
     resolved = project_path.expanduser().resolve()
-    return str(resolved).replace("/", "-")
+    normalized = resolved.as_posix().replace("\\", "/")
+    return re.sub(r"[^A-Za-z0-9._-]", "-", normalized)
 
 
 def safe_read_json(path: Path) -> dict[str, Any] | None:
@@ -57,6 +59,25 @@ def iter_active_sessions(project_path: Path, sessions_dir: Path) -> list[dict[st
             }
         )
     return matches
+
+
+def transcript_matches_project(path: Path, project_path: Path) -> bool:
+    wanted = str(project_path)
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(record, dict) and record.get("cwd") == wanted:
+                    return True
+    except OSError:
+        return False
+    return False
 
 
 def summarize_session_file(path: Path, active_session_ids: set[str]) -> dict[str, Any]:
@@ -180,10 +201,17 @@ def main() -> int:
         item["session_id"] for item in active_sessions if isinstance(item.get("session_id"), str)
     }
 
-    sessions: list[dict[str, Any]] = []
+    transcript_paths: list[Path] = []
+    discovery_mode = "encoded-project-dir"
     if project_dir.exists():
-        for transcript in sorted(project_dir.glob("*.jsonl")):
-            sessions.append(summarize_session_file(transcript, active_session_ids))
+        transcript_paths = sorted(project_dir.glob("*.jsonl"))
+    if not transcript_paths:
+        discovery_mode = "cwd-fallback-scan"
+        for transcript in sorted(projects_dir.glob("*/*.jsonl")):
+            if transcript_matches_project(transcript, project_path):
+                transcript_paths.append(transcript)
+
+    sessions = [summarize_session_file(transcript, active_session_ids) for transcript in transcript_paths]
     sessions.sort(key=sort_key, reverse=True)
     sessions = sessions[: max(args.limit, 0)]
 
@@ -192,6 +220,7 @@ def main() -> int:
         "project_path": str(project_path),
         "encoded_project_dir": str(project_dir),
         "project_dir_exists": project_dir.exists(),
+        "discovery_mode": discovery_mode,
         "active_sessions": active_sessions,
         "sessions": sessions,
     }
@@ -205,6 +234,7 @@ def main() -> int:
     print(f"project_path: {payload['project_path']}")
     print(f"encoded_project_dir: {payload['encoded_project_dir']}")
     print(f"project_dir_exists: {payload['project_dir_exists']}")
+    print(f"discovery_mode: {payload['discovery_mode']}")
     if args.include_active:
         print("active_sessions:")
         if active_sessions:

--- a/skills/claude-session-observe/scripts/find_project_sessions.py
+++ b/skills/claude-session-observe/scripts/find_project_sessions.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+def resolve_claude_dir(raw: str | None) -> Path:
+    return Path(raw).expanduser().resolve() if raw else (Path.home() / ".claude")
+
+
+def encode_project_path(project_path: Path) -> str:
+    resolved = project_path.expanduser().resolve()
+    return str(resolved).replace("/", "-")
+
+
+def safe_read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def parse_iso_timestamp(value: Any) -> dt.datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        if value.endswith("Z"):
+            return dt.datetime.fromisoformat(value[:-1] + "+00:00")
+        return dt.datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def iter_active_sessions(project_path: Path, sessions_dir: Path) -> list[dict[str, Any]]:
+    matches: list[dict[str, Any]] = []
+    wanted = str(project_path)
+    if not sessions_dir.exists():
+        return matches
+    for session_file in sorted(sessions_dir.glob("*.json")):
+        data = safe_read_json(session_file)
+        if data is None or data.get("cwd") != wanted:
+            continue
+        matches.append(
+            {
+                "pid_file": str(session_file),
+                "pid": data.get("pid"),
+                "session_id": data.get("sessionId"),
+                "cwd": data.get("cwd"),
+                "started_at": data.get("startedAt"),
+            }
+        )
+    return matches
+
+
+def summarize_session_file(path: Path, active_session_ids: set[str]) -> dict[str, Any]:
+    latest_timestamp: dt.datetime | None = None
+    latest_timestamp_raw: str | None = None
+    last_prompt_record: str | None = None
+    last_user_timestamp: str | None = None
+    last_assistant_timestamp: str | None = None
+    last_progress_timestamp: str | None = None
+    session_id = path.stem
+    cwd: str | None = None
+    git_branch: str | None = None
+    parsed_lines = 0
+    malformed_lines = 0
+    record_counts: Counter[str] = Counter()
+    user_assistant_count = 0
+
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                malformed_lines += 1
+                continue
+            parsed_lines += 1
+            if not isinstance(record, dict):
+                continue
+
+            record_type = record.get("type")
+            if isinstance(record_type, str):
+                record_counts[record_type] += 1
+                if record_type in {"user", "assistant"}:
+                    user_assistant_count += 1
+
+            if cwd is None and isinstance(record.get("cwd"), str):
+                cwd = record["cwd"]
+            if git_branch is None and isinstance(record.get("gitBranch"), str):
+                git_branch = record["gitBranch"]
+            if isinstance(record.get("sessionId"), str):
+                session_id = record["sessionId"]
+
+            timestamp_candidates: list[str] = []
+            if isinstance(record.get("timestamp"), str):
+                timestamp_candidates.append(record["timestamp"])
+            snapshot = record.get("snapshot")
+            if isinstance(snapshot, dict) and isinstance(snapshot.get("timestamp"), str):
+                timestamp_candidates.append(snapshot["timestamp"])
+            for raw in timestamp_candidates:
+                parsed = parse_iso_timestamp(raw)
+                if parsed is not None and (latest_timestamp is None or parsed > latest_timestamp):
+                    latest_timestamp = parsed
+                    latest_timestamp_raw = raw
+
+            if record_type == "user" and isinstance(record.get("timestamp"), str):
+                last_user_timestamp = record["timestamp"]
+            if record_type == "assistant" and isinstance(record.get("timestamp"), str):
+                last_assistant_timestamp = record["timestamp"]
+            if record_type == "progress" and isinstance(record.get("timestamp"), str):
+                last_progress_timestamp = record["timestamp"]
+            if record_type == "last-prompt" and isinstance(record.get("lastPrompt"), str):
+                last_prompt_record = record["lastPrompt"]
+
+    session_dir = path.with_suffix("")
+    subagents_dir = session_dir / "subagents"
+    tool_results_dir = session_dir / "tool-results"
+    stat = path.stat()
+    return {
+        "session_id": session_id,
+        "transcript_path": str(path),
+        "cwd": cwd,
+        "git_branch": git_branch,
+        "is_active_match": session_id in active_session_ids,
+        "last_timestamp": latest_timestamp_raw,
+        "last_user_timestamp": last_user_timestamp,
+        "last_assistant_timestamp": last_assistant_timestamp,
+        "last_progress_timestamp": last_progress_timestamp,
+        "last_prompt_record": last_prompt_record,
+        "file_mtime": dt.datetime.fromtimestamp(stat.st_mtime, tz=dt.timezone.utc).isoformat(),
+        "parsed_lines": parsed_lines,
+        "malformed_lines": malformed_lines,
+        "record_counts": dict(record_counts),
+        "user_assistant_count": user_assistant_count,
+        "has_sidecar_dir": session_dir.exists(),
+        "subagent_count": len(list(subagents_dir.glob("*.jsonl"))) if subagents_dir.exists() else 0,
+        "tool_result_file_count": len(list(tool_results_dir.glob("*.txt"))) if tool_results_dir.exists() else 0,
+    }
+
+
+def sort_key(item: dict[str, Any]) -> tuple[int, str, str]:
+    return (
+        1 if item.get("is_active_match") else 0,
+        item.get("last_timestamp") or "",
+        item.get("file_mtime") or "",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="List candidate Claude Code sessions for a project")
+    parser.add_argument("--project", required=True, help="Absolute or user-relative project path")
+    parser.add_argument("--claude-dir", help="Override Claude data dir (defaults to ~/.claude)")
+    parser.add_argument("--limit", type=int, default=10, help="Max sessions to print")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    parser.add_argument("--include-active", action="store_true", help="Include active-session PID entries in text output")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    claude_dir = resolve_claude_dir(args.claude_dir)
+    projects_dir = claude_dir / "projects"
+    sessions_dir = claude_dir / "sessions"
+
+    project_path = Path(args.project).expanduser().resolve()
+    project_dir = projects_dir / encode_project_path(project_path)
+
+    active_sessions = iter_active_sessions(project_path, sessions_dir)
+    active_session_ids = {
+        item["session_id"] for item in active_sessions if isinstance(item.get("session_id"), str)
+    }
+
+    sessions: list[dict[str, Any]] = []
+    if project_dir.exists():
+        for transcript in sorted(project_dir.glob("*.jsonl")):
+            sessions.append(summarize_session_file(transcript, active_session_ids))
+    sessions.sort(key=sort_key, reverse=True)
+    sessions = sessions[: max(args.limit, 0)]
+
+    payload = {
+        "claude_dir": str(claude_dir),
+        "project_path": str(project_path),
+        "encoded_project_dir": str(project_dir),
+        "project_dir_exists": project_dir.exists(),
+        "active_sessions": active_sessions,
+        "sessions": sessions,
+    }
+
+    if args.json:
+        json.dump(payload, sys.stdout, ensure_ascii=False, indent=2)
+        sys.stdout.write("\n")
+        return 0
+
+    print(f"claude_dir: {payload['claude_dir']}")
+    print(f"project_path: {payload['project_path']}")
+    print(f"encoded_project_dir: {payload['encoded_project_dir']}")
+    print(f"project_dir_exists: {payload['project_dir_exists']}")
+    if args.include_active:
+        print("active_sessions:")
+        if active_sessions:
+            for item in active_sessions:
+                print(f"  - session_id={item.get('session_id')} pid={item.get('pid')} pid_file={item.get('pid_file')}")
+        else:
+            print("  - none")
+    print("sessions:")
+    if not sessions:
+        print("  - none")
+        return 0
+    for item in sessions:
+        print(
+            f"  - session_id={item['session_id']} active={item['is_active_match']} last_timestamp={item['last_timestamp']} user_assistant_count={item['user_assistant_count']} malformed_lines={item['malformed_lines']}"
+        )
+        print(f"    transcript_path={item['transcript_path']}")
+        print(f"    subagent_count={item['subagent_count']} tool_result_file_count={item['tool_result_file_count']}")
+        if item.get("last_prompt_record"):
+            print(f"    last_prompt_record={item['last_prompt_record']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/claude-session-observe/scripts/read_session_records.py
+++ b/skills/claude-session-observe/scripts/read_session_records.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+INTERRUPTION_MARKERS = {
+    "[Request interrupted by user]",
+    "[Request interrupted by user for tool use]",
+}
+
+
+def truncate_text(text: str | None, limit: int = 400) -> str | None:
+    if text is None:
+        return None
+    text = text.strip()
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}..."
+
+
+def is_interruption_marker_text(text: str) -> bool:
+    stripped = text.strip()
+    if stripped in INTERRUPTION_MARKERS:
+        return True
+    return any(line.strip() in INTERRUPTION_MARKERS for line in stripped.splitlines())
+
+
+def extract_message_text_parts(content: Any) -> list[str]:
+    if isinstance(content, str):
+        stripped = content.strip()
+        return [stripped] if stripped else []
+    if not isinstance(content, list):
+        return []
+    parts: list[str] = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") == "text" and isinstance(item.get("text"), str):
+            stripped = item["text"].strip()
+            if stripped:
+                parts.append(stripped)
+    return parts
+
+
+def extract_tool_use_names(content: Any) -> list[str]:
+    if not isinstance(content, list):
+        return []
+    names: list[str] = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") == "tool_use" and isinstance(item.get("name"), str):
+            names.append(item["name"])
+    return names
+
+
+def has_tool_result(content: Any) -> bool:
+    if not isinstance(content, list):
+        return False
+    return any(isinstance(item, dict) and item.get("type") == "tool_result" for item in content)
+
+
+def summarize_message_payload(message: dict[str, Any]) -> dict[str, Any]:
+    summary: dict[str, Any] = {}
+    if isinstance(message.get("role"), str):
+        summary["role"] = message["role"]
+    text_parts = extract_message_text_parts(message.get("content"))
+    if text_parts:
+        merged = "\n".join(text_parts)
+        summary["text_preview"] = truncate_text(merged)
+        summary["has_interruption_marker"] = is_interruption_marker_text(merged)
+    tool_use_names = extract_tool_use_names(message.get("content"))
+    if tool_use_names:
+        summary["tool_use_names"] = tool_use_names
+    if has_tool_result(message.get("content")):
+        summary["has_tool_result"] = True
+    return summary
+
+
+def summarize_progress_payload(data: Any) -> dict[str, Any]:
+    summary: dict[str, Any] = {}
+    if not isinstance(data, dict):
+        return summary
+    if isinstance(data.get("type"), str):
+        summary["progress_type"] = data["type"]
+    if isinstance(data.get("agentId"), str):
+        summary["progress_agent_id"] = data["agentId"]
+
+    raw_message = data.get("message")
+    if isinstance(raw_message, dict):
+        if isinstance(raw_message.get("type"), str):
+            summary["progress_message_type"] = raw_message["type"]
+        if isinstance(raw_message.get("timestamp"), str):
+            summary["progress_message_timestamp"] = raw_message["timestamp"]
+        nested_message = raw_message.get("message")
+        if isinstance(nested_message, dict):
+            nested_summary = summarize_message_payload(nested_message)
+            if isinstance(nested_summary.get("role"), str):
+                summary["nested_role"] = nested_summary["role"]
+            if isinstance(nested_summary.get("text_preview"), str):
+                summary["text_preview"] = nested_summary["text_preview"]
+            if isinstance(nested_summary.get("tool_use_names"), list):
+                summary["tool_use_names"] = nested_summary["tool_use_names"]
+            if nested_summary.get("has_tool_result"):
+                summary["has_tool_result"] = True
+            if nested_summary.get("has_interruption_marker"):
+                summary["has_interruption_marker"] = True
+    return summary
+
+
+def parse_jsonl(path: Path) -> tuple[list[dict[str, Any]], int]:
+    records: list[dict[str, Any]] = []
+    malformed_lines = 0
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                malformed_lines += 1
+                continue
+            if isinstance(record, dict):
+                records.append(record)
+    return records, malformed_lines
+
+
+def summarize_subagents(session_dir: Path) -> list[dict[str, Any]]:
+    subagents_dir = session_dir / "subagents"
+    if not subagents_dir.exists():
+        return []
+    summaries: list[dict[str, Any]] = []
+    for transcript in sorted(subagents_dir.glob("*.jsonl")):
+        record_count = 0
+        malformed_lines = 0
+        last_timestamp: str | None = None
+        with transcript.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    malformed_lines += 1
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                record_count += 1
+                if isinstance(record.get("timestamp"), str):
+                    last_timestamp = record["timestamp"]
+        meta_path = transcript.with_suffix(".meta.json")
+        meta: dict[str, Any] | None = None
+        if meta_path.exists():
+            try:
+                loaded = json.loads(meta_path.read_text(encoding="utf-8"))
+                if isinstance(loaded, dict):
+                    meta = loaded
+            except Exception:
+                meta = None
+        summaries.append(
+            {
+                "transcript_path": str(transcript),
+                "record_count": record_count,
+                "malformed_lines": malformed_lines,
+                "last_timestamp": last_timestamp,
+                "meta": meta,
+            }
+        )
+    return summaries
+
+
+def summarize_tool_results(session_dir: Path) -> list[dict[str, Any]]:
+    tool_results_dir = session_dir / "tool-results"
+    if not tool_results_dir.exists():
+        return []
+    results: list[dict[str, Any]] = []
+    for path in sorted(tool_results_dir.glob("*.txt")):
+        try:
+            preview = truncate_text(path.read_text(encoding="utf-8"), 300)
+        except Exception:
+            preview = None
+        results.append({"path": str(path), "preview": preview})
+    return results
+
+
+def summarize_record(record: dict[str, Any], index: int) -> dict[str, Any]:
+    summary: dict[str, Any] = {
+        "index": index,
+        "type": record.get("type"),
+        "timestamp": record.get("timestamp"),
+    }
+
+    if isinstance(record.get("sessionId"), str):
+        summary["session_id"] = record["sessionId"]
+    if isinstance(record.get("cwd"), str):
+        summary["cwd"] = record["cwd"]
+
+    message = record.get("message")
+    if isinstance(message, dict):
+        summary.update(summarize_message_payload(message))
+
+    if record.get("type") == "last-prompt" and isinstance(record.get("lastPrompt"), str):
+        summary["last_prompt"] = truncate_text(record["lastPrompt"])
+    if record.get("type") == "system":
+        if isinstance(record.get("subtype"), str):
+            summary["subtype"] = record["subtype"]
+        if isinstance(record.get("durationMs"), int):
+            summary["duration_ms"] = record["durationMs"]
+    if record.get("type") == "progress":
+        summary.update(summarize_progress_payload(record.get("data")))
+        if isinstance(record.get("toolUseID"), str):
+            summary["tool_use_id"] = record["toolUseID"]
+        if isinstance(record.get("parentToolUseID"), str):
+            summary["parent_tool_use_id"] = record["parentToolUseID"]
+    if record.get("type") == "file-history-snapshot":
+        snapshot = record.get("snapshot")
+        if isinstance(snapshot, dict) and isinstance(snapshot.get("timestamp"), str):
+            summary["snapshot_timestamp"] = snapshot["timestamp"]
+
+    return summary
+
+
+def collect_records(records: list[dict[str, Any]], record_type: str, limit: int) -> list[dict[str, Any]]:
+    if limit <= 0:
+        return []
+    matches: list[tuple[int, dict[str, Any]]] = []
+    for index, record in enumerate(records, start=1):
+        if record.get("type") == record_type:
+            matches.append((index, record))
+    matches = matches[-limit:]
+    return [summarize_record(record, index) for index, record in matches]
+
+
+def collect_message_role_records(records: list[dict[str, Any]], role: str, limit: int) -> list[dict[str, Any]]:
+    if limit <= 0:
+        return []
+    matches: list[tuple[int, dict[str, Any]]] = []
+    for index, record in enumerate(records, start=1):
+        if record.get("type") not in {"user", "assistant"}:
+            continue
+        message = record.get("message")
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") != role:
+            continue
+        matches.append((index, record))
+    matches = matches[-limit:]
+    return [summarize_record(record, index) for index, record in matches]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Read one Claude Code session transcript and return structured evidence slices")
+    parser.add_argument("--session-file", required=True, help="Path to a session JSONL file")
+    parser.add_argument("--tail-records", type=int, default=25, help="How many trailing records to include")
+    parser.add_argument("--user-records", type=int, default=5, help="How many recent user records to include")
+    parser.add_argument("--assistant-records", type=int, default=5, help="How many recent assistant records to include")
+    parser.add_argument("--progress-records", type=int, default=5, help="How many recent progress records to include")
+    parser.add_argument("--last-prompt-records", type=int, default=3, help="How many recent last-prompt records to include")
+    parser.add_argument("--include-subagents", action="store_true", help="List subagent sidecar files")
+    parser.add_argument("--include-tool-results", action="store_true", help="List tool result text files")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    session_file = Path(args.session_file).expanduser().resolve()
+    records, malformed_lines = parse_jsonl(session_file)
+
+    record_counts: Counter[str] = Counter()
+    interruption_count = 0
+    first_timestamp: str | None = None
+    last_timestamp: str | None = None
+    session_id = session_file.stem
+    cwd: str | None = None
+    git_branch: str | None = None
+    last_prompt_record: str | None = None
+
+    for record in records:
+        record_type = record.get("type")
+        if isinstance(record_type, str):
+            record_counts[record_type] += 1
+        if first_timestamp is None and isinstance(record.get("timestamp"), str):
+            first_timestamp = record["timestamp"]
+        if isinstance(record.get("timestamp"), str):
+            last_timestamp = record["timestamp"]
+        if isinstance(record.get("sessionId"), str):
+            session_id = record["sessionId"]
+        if cwd is None and isinstance(record.get("cwd"), str):
+            cwd = record["cwd"]
+        if git_branch is None and isinstance(record.get("gitBranch"), str):
+            git_branch = record["gitBranch"]
+        if record_type == "last-prompt" and isinstance(record.get("lastPrompt"), str):
+            last_prompt_record = record["lastPrompt"]
+        message = record.get("message")
+        if isinstance(message, dict):
+            merged = "\n".join(extract_message_text_parts(message.get("content")))
+            if merged and is_interruption_marker_text(merged):
+                interruption_count += 1
+
+    tail_count = max(args.tail_records, 0)
+    tail_records = records[-tail_count:] if tail_count > 0 else []
+    tail_summaries = [
+        summarize_record(record, len(records) - len(tail_records) + offset + 1)
+        for offset, record in enumerate(tail_records)
+    ]
+
+    session_dir = session_file.with_suffix("")
+    payload: dict[str, Any] = {
+        "session_file": str(session_file),
+        "session_id": session_id,
+        "cwd": cwd,
+        "git_branch": git_branch,
+        "record_count": len(records),
+        "record_counts": dict(record_counts),
+        "malformed_lines": malformed_lines,
+        "interruption_count": interruption_count,
+        "first_timestamp": first_timestamp,
+        "last_timestamp": last_timestamp,
+        "last_prompt_record": last_prompt_record,
+        "tail_records_requested": tail_count,
+        "tail_records": tail_summaries,
+        "user_records": collect_message_role_records(records, "user", max(args.user_records, 0)),
+        "assistant_records": collect_message_role_records(records, "assistant", max(args.assistant_records, 0)),
+        "progress_records": collect_records(records, "progress", max(args.progress_records, 0)),
+        "last_prompt_records": collect_records(records, "last-prompt", max(args.last_prompt_records, 0)),
+    }
+    if args.include_subagents:
+        payload["subagents"] = summarize_subagents(session_dir)
+    if args.include_tool_results:
+        payload["tool_results"] = summarize_tool_results(session_dir)
+
+    if args.json:
+        json.dump(payload, sys.stdout, ensure_ascii=False, indent=2)
+        sys.stdout.write("\n")
+        return 0
+
+    print(f"session_file: {payload['session_file']}")
+    print(f"session_id: {payload['session_id']}")
+    print(f"cwd: {payload['cwd']}")
+    print(f"git_branch: {payload['git_branch']}")
+    print(f"record_count: {payload['record_count']}")
+    print(f"record_counts: {payload['record_counts']}")
+    print(f"malformed_lines: {payload['malformed_lines']}")
+    print(f"interruption_count: {payload['interruption_count']}")
+    print(f"first_timestamp: {payload['first_timestamp']}")
+    print(f"last_timestamp: {payload['last_timestamp']}")
+    print(f"last_prompt_record: {payload['last_prompt_record']}")
+    print(f"tail_records_requested: {payload['tail_records_requested']}")
+    print("tail_records:")
+    for item in payload["tail_records"]:
+        print(json.dumps(item, ensure_ascii=False))
+    print("user_records:")
+    for item in payload["user_records"]:
+        print(json.dumps(item, ensure_ascii=False))
+    print("assistant_records:")
+    for item in payload["assistant_records"]:
+        print(json.dumps(item, ensure_ascii=False))
+    print("progress_records:")
+    for item in payload["progress_records"]:
+        print(json.dumps(item, ensure_ascii=False))
+    print("last_prompt_records:")
+    for item in payload["last_prompt_records"]:
+        print(json.dumps(item, ensure_ascii=False))
+    if args.include_subagents:
+        print("subagents:")
+        for item in payload["subagents"]:
+            print(json.dumps(item, ensure_ascii=False))
+    if args.include_tool_results:
+        print("tool_results:")
+        for item in payload["tool_results"]:
+            print(json.dumps(item, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/security/sandbox.ts
+++ b/src/security/sandbox.ts
@@ -8,7 +8,7 @@ import {
   type SandboxExecResult,
   type SandboxPermissionIssue,
   type SandboxRuntimeConfig,
-} from "@anthropic-ai/sandbox-runtime";
+} from "@danielwpz/sandbox-runtime";
 
 import {
   checkFilesystemPermission,

--- a/tests/agent/skills.test.ts
+++ b/tests/agent/skills.test.ts
@@ -199,6 +199,7 @@ describe("agent skills catalog", () => {
     });
 
     expect(snapshot.entries.some((entry) => entry.name === "system-observe")).toBe(true);
+    expect(snapshot.entries.some((entry) => entry.name === "claude-session-observe")).toBe(true);
   });
 
   async function createTempDir(): Promise<string> {

--- a/tests/security/sandbox.test.ts
+++ b/tests/security/sandbox.test.ts
@@ -8,7 +8,7 @@ const { executeSandboxedCommandMock } = vi.hoisted(() => ({
   executeSandboxedCommandMock: vi.fn(),
 }));
 
-import { SandboxPermissionError } from "@anthropic-ai/sandbox-runtime";
+import { SandboxPermissionError } from "@danielwpz/sandbox-runtime";
 
 import { DEFAULT_CONFIG } from "@/src/config/defaults.js";
 import { normalizeFilesystemTargetPath } from "@/src/security/permissions.js";
@@ -27,9 +27,9 @@ import {
   type TestDatabaseHandle,
 } from "@/tests/storage/helpers/test-db.js";
 
-vi.mock("@anthropic-ai/sandbox-runtime", async () => {
-  const actual = await vi.importActual<typeof import("@anthropic-ai/sandbox-runtime")>(
-    "@anthropic-ai/sandbox-runtime",
+vi.mock("@danielwpz/sandbox-runtime", async () => {
+  const actual = await vi.importActual<typeof import("@danielwpz/sandbox-runtime")>(
+    "@danielwpz/sandbox-runtime",
   );
 
   return {


### PR DESCRIPTION
## Summary
- add a builtin claude-session-observe skill for inspecting Claude Code sessions under ~/.claude
- document the manual investigation workflow, including session discovery, transcript reading, sidecar inspection, and repo-state verification
- add read-only helper scripts for project session discovery and session record slicing

## Notes
- helper scripts are intentionally positioned as query helpers, not semantic answer generators
- examples and docs use generic paths and do not hardcode local machine details

## Validation
- committed via repo hooks with preflight passing
- manually validated against real local Claude sessions for multiple projects
