### PR TITLE
feat: refine slash help command (by pokoclaw)

### DIFF
--- a/src/channels/help.ts
+++ b/src/channels/help.ts
@@ -11,29 +11,24 @@ export interface SlashCommandHelpPresentation {
 interface SlashCommandHelpEntry {
   command: string;
   description: string;
-  suggestedUse: string;
 }
 
 const SLASH_COMMANDS: SlashCommandHelpEntry[] = [
   {
     command: "/help",
     description: "Show this help message.",
-    suggestedUse: "Use it when you want a quick reminder of what the assistant can do.",
   },
   {
     command: "/status",
     description: "Show the current conversation status, model, usage, and active runs.",
-    suggestedUse: "Use it when you want to check progress before continuing work.",
   },
   {
     command: "/model",
     description: "Open the model switch card for the current conversation.",
-    suggestedUse: "Use it when you want to inspect or change the active model.",
   },
   {
     command: "/stop",
     description: "Stop the current conversation or session.",
-    suggestedUse: "Use it when the current run is off track or should be interrupted immediately.",
   },
 ];
 
@@ -44,53 +39,29 @@ export function buildSlashCommandHelpPresentation(
   const renderMode: SlashCommandHelpRenderMode =
     normalizedChannelType === "lark" ? "markdown" : "plain_text";
   const title = "Slash Commands";
-  const summary = "Available slash commands and suggested usage";
-  const markdownSections = [
-    buildCommandsMarkdownSection(),
-    buildSuggestedUsageMarkdownSection(),
-    buildRenderingMarkdownSection(channelType, renderMode),
-  ];
+  const summary = "Slash commands";
+  const markdownSections = [buildCommandsMarkdownSection()];
 
   return {
     title,
     summary,
     renderMode,
     markdownSections,
-    plainText: buildPlainTextHelp(channelType, renderMode),
+    plainText: buildPlainTextHelp(channelType),
   };
 }
 
 function buildCommandsMarkdownSection(): string {
-  const lines = SLASH_COMMANDS.map((entry) => `- **${entry.command}** — ${entry.description}`);
+  const lines = SLASH_COMMANDS.map((entry) => `- ${entry.command} — ${entry.description}`);
   return ["### Slash Commands", ...lines].join("\n");
 }
 
-function buildSuggestedUsageMarkdownSection(): string {
-  const lines = SLASH_COMMANDS.map((entry) => `- **${entry.command}** — ${entry.suggestedUse}`);
-  return ["### Suggested Usage", ...lines].join("\n");
-}
-
-function buildRenderingMarkdownSection(
-  channelType: string,
-  renderMode: SlashCommandHelpRenderMode,
-): string {
-  const channelLabel = formatChannelLabel(channelType);
-  return [
-    "### Rendering",
-    `- Channel: **${channelLabel}**`,
-    `- Mode: **${renderMode === "markdown" ? "Markdown" : "Plain text"}**`,
-  ].join("\n");
-}
-
-function buildPlainTextHelp(channelType: string, renderMode: SlashCommandHelpRenderMode): string {
+function buildPlainTextHelp(channelType: string): string {
   const lines = [
     "Slash Commands",
     ...SLASH_COMMANDS.map((entry) => `${entry.command} — ${entry.description}`),
     "",
-    "Suggested Usage",
-    ...SLASH_COMMANDS.map((entry) => `${entry.command} — ${entry.suggestedUse}`),
-    "",
-    `Rendering: ${formatChannelLabel(channelType)} / ${renderMode === "markdown" ? "Markdown" : "Plain text"}`,
+    `Channel: ${formatChannelLabel(channelType)}`,
   ];
   return lines.join("\n");
 }

--- a/src/channels/help.ts
+++ b/src/channels/help.ts
@@ -1,0 +1,104 @@
+export type SlashCommandHelpRenderMode = "markdown" | "plain_text";
+
+export interface SlashCommandHelpPresentation {
+  title: string;
+  summary: string;
+  renderMode: SlashCommandHelpRenderMode;
+  markdownSections: string[];
+  plainText: string;
+}
+
+interface SlashCommandHelpEntry {
+  command: string;
+  description: string;
+  suggestedUse: string;
+}
+
+const SLASH_COMMANDS: SlashCommandHelpEntry[] = [
+  {
+    command: "/help",
+    description: "Show this help message.",
+    suggestedUse: "Use it when you want a quick reminder of what the assistant can do.",
+  },
+  {
+    command: "/status",
+    description: "Show the current conversation status, model, usage, and active runs.",
+    suggestedUse: "Use it when you want to check progress before continuing work.",
+  },
+  {
+    command: "/model",
+    description: "Open the model switch card for the current conversation.",
+    suggestedUse: "Use it when you want to inspect or change the active model.",
+  },
+  {
+    command: "/stop",
+    description: "Stop the current conversation or session.",
+    suggestedUse: "Use it when the current run is off track or should be interrupted immediately.",
+  },
+];
+
+export function buildSlashCommandHelpPresentation(
+  channelType: string,
+): SlashCommandHelpPresentation {
+  const normalizedChannelType = channelType.trim().toLowerCase();
+  const renderMode: SlashCommandHelpRenderMode =
+    normalizedChannelType === "lark" ? "markdown" : "plain_text";
+  const title = "Slash Commands";
+  const summary = "Available slash commands and suggested usage";
+  const markdownSections = [
+    buildCommandsMarkdownSection(),
+    buildSuggestedUsageMarkdownSection(),
+    buildRenderingMarkdownSection(channelType, renderMode),
+  ];
+
+  return {
+    title,
+    summary,
+    renderMode,
+    markdownSections,
+    plainText: buildPlainTextHelp(channelType, renderMode),
+  };
+}
+
+function buildCommandsMarkdownSection(): string {
+  const lines = SLASH_COMMANDS.map((entry) => `- **${entry.command}** — ${entry.description}`);
+  return ["### Slash Commands", ...lines].join("\n");
+}
+
+function buildSuggestedUsageMarkdownSection(): string {
+  const lines = SLASH_COMMANDS.map((entry) => `- **${entry.command}** — ${entry.suggestedUse}`);
+  return ["### Suggested Usage", ...lines].join("\n");
+}
+
+function buildRenderingMarkdownSection(
+  channelType: string,
+  renderMode: SlashCommandHelpRenderMode,
+): string {
+  const channelLabel = formatChannelLabel(channelType);
+  return [
+    "### Rendering",
+    `- Channel: **${channelLabel}**`,
+    `- Mode: **${renderMode === "markdown" ? "Markdown" : "Plain text"}**`,
+  ].join("\n");
+}
+
+function buildPlainTextHelp(channelType: string, renderMode: SlashCommandHelpRenderMode): string {
+  const lines = [
+    "Slash Commands",
+    ...SLASH_COMMANDS.map((entry) => `${entry.command} — ${entry.description}`),
+    "",
+    "Suggested Usage",
+    ...SLASH_COMMANDS.map((entry) => `${entry.command} — ${entry.suggestedUse}`),
+    "",
+    `Rendering: ${formatChannelLabel(channelType)} / ${renderMode === "markdown" ? "Markdown" : "Plain text"}`,
+  ];
+  return lines.join("\n");
+}
+
+function formatChannelLabel(channelType: string): string {
+  const trimmed = channelType.trim();
+  if (trimmed.length === 0) {
+    return "Unknown";
+  }
+  return trimmed.slice(0, 1).toUpperCase() + trimmed.slice(1);
+}

--- a/src/channels/lark/inbound.ts
+++ b/src/channels/lark/inbound.ts
@@ -17,6 +17,7 @@ import {
 } from "@/src/agent/llm/messages.js";
 import type { ModelScenario } from "@/src/agent/llm/models.js";
 import type { AgentLoopAfterToolResultHook } from "@/src/agent/loop.js";
+import { buildSlashCommandHelpPresentation } from "@/src/channels/help.js";
 import type { LarkSdkClient } from "@/src/channels/lark/client.js";
 import {
   buildLarkRenderedModelSwitchCard,
@@ -490,6 +491,25 @@ export function createLarkMessageReceiveHandler(input: {
         ...(input.clients == null ? {} : { clients: input.clients }),
       });
       logger.info("processed lark model command", {
+        installationId: input.installationId,
+        chatId: hydrated.chatId,
+        messageId: hydrated.messageId,
+        conversationId: route.conversationId,
+        sessionId: route.sessionId,
+        routeKind: route.kind,
+      });
+      return;
+    }
+
+    if (hydrated.text === "/help") {
+      await sendLarkHelpMessage({
+        installationId: input.installationId,
+        chatId: route.chatId,
+        replyToMessageId: route.replyToMessageId,
+        channelType: "lark",
+        ...(input.clients == null ? {} : { clients: input.clients }),
+      });
+      logger.info("processed lark help command", {
         installationId: input.installationId,
         chatId: hydrated.chatId,
         messageId: hydrated.messageId,
@@ -2142,7 +2162,7 @@ function extractStartedSubmitMessageResult(
 }
 
 function isLarkThreadControlCommand(text: string): boolean {
-  return text === "/stop" || text === "/status" || text === "/model";
+  return text === "/stop" || text === "/status" || text === "/model" || text === "/help";
 }
 
 function buildTaskRunCardObjectId(taskRunId: string): string {
@@ -3088,6 +3108,81 @@ async function sendLarkStatusCard(input: {
     ...(input.replyToMessageId === undefined ? {} : { replyToMessageId: input.replyToMessageId }),
     card,
     ...(input.clients == null ? {} : { clients: input.clients }),
+  });
+}
+
+async function sendLarkHelpMessage(input: {
+  installationId: string;
+  chatId: string;
+  replyToMessageId?: string | null;
+  channelType: string;
+  clients?: {
+    getOrCreate(installationId: string): LarkSdkClient;
+  };
+}): Promise<void> {
+  const presentation = buildSlashCommandHelpPresentation(input.channelType);
+  if (presentation.renderMode === "markdown") {
+    await sendLarkStatusCard({
+      installationId: input.installationId,
+      chatId: input.chatId,
+      ...(input.replyToMessageId == null ? {} : { replyToMessageId: input.replyToMessageId }),
+      presentation: {
+        title: presentation.title,
+        summary: presentation.summary,
+        markdownSections: presentation.markdownSections,
+      },
+      ...(input.clients == null ? {} : { clients: input.clients }),
+    });
+    return;
+  }
+
+  await sendLarkTextMessage({
+    installationId: input.installationId,
+    chatId: input.chatId,
+    ...(input.replyToMessageId == null ? {} : { replyToMessageId: input.replyToMessageId }),
+    text: presentation.plainText,
+    ...(input.clients == null ? {} : { clients: input.clients }),
+  });
+}
+
+async function sendLarkTextMessage(input: {
+  installationId: string;
+  chatId: string;
+  replyToMessageId?: string | null;
+  text: string;
+  clients?: {
+    getOrCreate(installationId: string): LarkSdkClient;
+  };
+}): Promise<void> {
+  if (input.clients == null) {
+    logger.warn("cannot send lark text message because no sdk clients are configured", {
+      installationId: input.installationId,
+      chatId: input.chatId,
+    });
+    return;
+  }
+
+  const client = input.clients.getOrCreate(input.installationId);
+  const content = JSON.stringify({ text: input.text });
+  if (input.replyToMessageId != null && input.replyToMessageId.length > 0) {
+    await client.sdk.im.message.reply({
+      path: { message_id: input.replyToMessageId },
+      data: {
+        msg_type: "text",
+        content,
+        reply_in_thread: true,
+      },
+    });
+    return;
+  }
+
+  await client.sdk.im.message.create({
+    params: { receive_id_type: "chat_id" },
+    data: {
+      receive_id: input.chatId,
+      msg_type: "text",
+      content,
+    },
   });
 }
 

--- a/tests/channels/help.test.ts
+++ b/tests/channels/help.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import { buildSlashCommandHelpPresentation } from "@/src/channels/help.js";
+
+describe("slash command help presentation", () => {
+  test("renders Lark as markdown with command and usage sections", () => {
+    const presentation = buildSlashCommandHelpPresentation("lark");
+
+    expect(presentation.renderMode).toBe("markdown");
+    expect(presentation.title).toBe("Slash Commands");
+    expect(presentation.summary).toContain("Available slash commands");
+    expect(presentation.markdownSections.join("\n")).toContain("/help");
+    expect(presentation.markdownSections.join("\n")).toContain("Suggested Usage");
+  });
+
+  test("falls back to plain text for non-Lark channels", () => {
+    const presentation = buildSlashCommandHelpPresentation("slack");
+
+    expect(presentation.renderMode).toBe("plain_text");
+    expect(presentation.plainText).toContain("Slash Commands");
+    expect(presentation.plainText).toContain("Rendering: Slack / Plain text");
+  });
+});

--- a/tests/channels/help.test.ts
+++ b/tests/channels/help.test.ts
@@ -2,14 +2,20 @@ import { describe, expect, test } from "vitest";
 import { buildSlashCommandHelpPresentation } from "@/src/channels/help.js";
 
 describe("slash command help presentation", () => {
-  test("renders Lark as markdown with command and usage sections", () => {
+  test("renders Lark as markdown with the requested command list", () => {
     const presentation = buildSlashCommandHelpPresentation("lark");
 
     expect(presentation.renderMode).toBe("markdown");
     expect(presentation.title).toBe("Slash Commands");
-    expect(presentation.summary).toContain("Available slash commands");
-    expect(presentation.markdownSections.join("\n")).toContain("/help");
-    expect(presentation.markdownSections.join("\n")).toContain("Suggested Usage");
+    expect(presentation.markdownSections.join("\n")).toBe(
+      [
+        "### Slash Commands",
+        "- /help — Show this help message.",
+        "- /status — Show the current conversation status, model, usage, and active runs.",
+        "- /model — Open the model switch card for the current conversation.",
+        "- /stop — Stop the current conversation or session.",
+      ].join("\n"),
+    );
   });
 
   test("falls back to plain text for non-Lark channels", () => {
@@ -17,6 +23,7 @@ describe("slash command help presentation", () => {
 
     expect(presentation.renderMode).toBe("plain_text");
     expect(presentation.plainText).toContain("Slash Commands");
-    expect(presentation.plainText).toContain("Rendering: Slack / Plain text");
+    expect(presentation.plainText).toContain("/status");
+    expect(presentation.plainText).toContain("Channel: Slack");
   });
 });

--- a/tests/channels/lark/inbound.test.ts
+++ b/tests/channels/lark/inbound.test.ts
@@ -2463,8 +2463,15 @@ describe("lark inbound message handling", () => {
         .filter((element) => element.tag === "markdown")
         .map((element) => element.content ?? "")
         .join("\n");
-      expect(markdown).toContain("/status");
-      expect(markdown).toContain("Suggested Usage");
+      expect(markdown).toBe(
+        [
+          "### Slash Commands",
+          "- /help — Show this help message.",
+          "- /status — Show the current conversation status, model, usage, and active runs.",
+          "- /model — Open the model switch card for the current conversation.",
+          "- /stop — Stop the current conversation or session.",
+        ].join("\n"),
+      );
     });
   });
 });

--- a/tests/channels/lark/inbound.test.ts
+++ b/tests/channels/lark/inbound.test.ts
@@ -2404,6 +2404,69 @@ describe("lark inbound message handling", () => {
       expect(markdown).toContain("**版本**");
     });
   });
+
+  test("routes /help to a markdown help card with slash command guidance", async () => {
+    await withHandle(async (handle) => {
+      seedFixture(handle);
+      const surfacesRepo = new ChannelSurfacesRepo(handle.storage.db);
+      surfacesRepo.upsert({
+        id: "surface_help_1",
+        channelType: "lark",
+        channelInstallationId: "default",
+        conversationId: "conv_main",
+        branchId: "branch_main",
+        surfaceKey: buildLarkChatSurfaceKey("oc_chat_1"),
+        surfaceObjectJson: JSON.stringify({ chat_id: "oc_chat_1" }),
+      });
+
+      const submitMessage = vi.fn(async () => ({ status: "started" as const }));
+      const create = vi.fn(async () => ({ data: { message_id: "om_help_1" } }));
+      const handler = createLarkMessageReceiveHandler({
+        installationId: "default",
+        storage: handle.storage.db,
+        ingress: { submitMessage, submitApprovalDecision: vi.fn(() => false) },
+        control: new RuntimeControlService(new SessionRunAbortRegistry()),
+        clients: {
+          getOrCreate: vi.fn(() => ({
+            sdk: {
+              im: {
+                message: {
+                  create,
+                  reply: vi.fn(),
+                },
+              },
+            },
+          })) as unknown as (installationId: string) => LarkSdkClient,
+        },
+      });
+
+      await handler(makeTextEvent("/help"));
+
+      expect(submitMessage).not.toHaveBeenCalled();
+      expect(create).toHaveBeenCalledTimes(1);
+      const firstCall = create.mock.calls[0] as [Record<string, unknown>] | undefined;
+      expect(firstCall?.[0]).toMatchObject({
+        params: { receive_id_type: "chat_id" },
+        data: {
+          receive_id: "oc_chat_1",
+          msg_type: "interactive",
+        },
+      });
+      const content = JSON.parse(
+        String((firstCall?.[0] as { data?: { content?: string } } | undefined)?.data?.content),
+      ) as {
+        header?: { title?: { content?: string } };
+        body?: { elements?: Array<{ tag?: string; content?: string }> };
+      };
+      expect(content.header?.title?.content).toBe("Slash Commands");
+      const markdown = (content.body?.elements ?? [])
+        .filter((element) => element.tag === "markdown")
+        .map((element) => element.content ?? "")
+        .join("\n");
+      expect(markdown).toContain("/status");
+      expect(markdown).toContain("Suggested Usage");
+    });
+  });
 });
 
 describe("lark card actions", () => {


### PR DESCRIPTION
## Summary
- Add /help command for Lark
- Render the help message as Markdown in Lark
- Keep the help output to the requested minimal slash-command list

## Validation
- pnpm preflight
