### PR TITLE
Handle Lark CardKit non-zero responses

### DIFF
--- a/src/channels/lark/cardkit-mutations.ts
+++ b/src/channels/lark/cardkit-mutations.ts
@@ -1,0 +1,311 @@
+export interface LarkCardOperationResponse {
+  code?: number;
+  msg?: string;
+  data?: Record<string, unknown>;
+}
+
+export interface LarkCardCreateResponse extends LarkCardOperationResponse {
+  data?: {
+    card_id?: string;
+  };
+  card_id?: string;
+}
+
+export type LarkSequencedCardMutationOperation = "card.update" | "cardElement.content";
+
+export type LarkSequencedCardMutationOutcome<T extends LarkCardOperationResponse> =
+  | {
+      kind: "applied";
+      response: T;
+    }
+  | {
+      kind: "reconcile";
+      nextSequenceFloor: number;
+      reason: "ambiguous_transport_failure" | "sequence_compare_failed";
+    };
+
+export interface LarkCardkitLogger {
+  warn(message: string, fields?: Record<string, unknown>): void;
+  error(message: string, fields?: Record<string, unknown>): void;
+}
+
+const LARK_CARD_LOG_PREVIEW_MAX_LENGTH = 600;
+const LARK_CARDKIT_NONZERO_CODE_RETRY_LIMIT = 1;
+const LARK_CARDKIT_SEQUENCE_COMPARE_FAILED_CODE = 300317;
+const LARK_CARDKIT_SEQUENCE_FLOOR_METADATA_KEY = "cardkitSequenceFloor";
+
+export function parseBindingMetadata(raw: string | null): Record<string, unknown> {
+  if (raw == null || raw.trim().length === 0) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed === "object" && parsed != null && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {}
+  return {};
+}
+
+export function readPositiveInteger(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    return null;
+  }
+  return value;
+}
+
+export function buildBindingMetadata(
+  base: Record<string, unknown>,
+  existingRaw: string | null | undefined,
+): string {
+  const existing = parseBindingMetadata(existingRaw ?? null);
+  const sequenceFloor = readPositiveInteger(existing[LARK_CARDKIT_SEQUENCE_FLOOR_METADATA_KEY]);
+  return JSON.stringify({
+    ...(sequenceFloor == null
+      ? {}
+      : {
+          [LARK_CARDKIT_SEQUENCE_FLOOR_METADATA_KEY]: sequenceFloor,
+        }),
+    ...base,
+  });
+}
+
+export function setCardkitSequenceFloorInMetadata(
+  raw: string | null | undefined,
+  floor: number,
+): string {
+  const metadata = parseBindingMetadata(raw ?? null);
+  const existingFloor =
+    readPositiveInteger(metadata[LARK_CARDKIT_SEQUENCE_FLOOR_METADATA_KEY]) ?? 0;
+  return JSON.stringify({
+    ...metadata,
+    [LARK_CARDKIT_SEQUENCE_FLOOR_METADATA_KEY]: Math.max(existingFloor, floor),
+  });
+}
+
+export function getNextCardkitSequence(binding: {
+  lastSequence?: number | null;
+  metadataJson?: string | null;
+}): number {
+  const lastSequence = binding.lastSequence ?? 0;
+  const metadata = parseBindingMetadata(binding.metadataJson ?? null);
+  const floor = readPositiveInteger(metadata[LARK_CARDKIT_SEQUENCE_FLOOR_METADATA_KEY]) ?? 1;
+  return Math.max(lastSequence + 1, floor);
+}
+
+export function readLarkHttpStatus(error: unknown): number | null {
+  if (typeof error !== "object" || error == null) {
+    return null;
+  }
+  const response = (error as { response?: { status?: unknown } }).response;
+  if (response == null || typeof response !== "object") {
+    return null;
+  }
+  return typeof response.status === "number" ? response.status : null;
+}
+
+export function isAmbiguousLarkCardkitTransportError(error: unknown): boolean {
+  const status = readLarkHttpStatus(error);
+  if (status != null) {
+    return status >= 500 && status < 600;
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  return /socket hang up|ETIMEDOUT|ECONNRESET|timed out|timeout|disconnected before secure TLS connection/i.test(
+    message,
+  );
+}
+
+export async function invokeLarkCardkitCallWithBusinessRetry<
+  T extends LarkCardOperationResponse,
+>(input: {
+  logger: LarkCardkitLogger;
+  operation: "card.create" | "card.update" | "cardElement.content";
+  logContext: Record<string, unknown>;
+  invoke: () => Promise<T>;
+}): Promise<T> {
+  let attempt = 0;
+  while (true) {
+    const response = await input.invoke();
+    const code = response.code;
+    if (code == null || code === 0) {
+      return response;
+    }
+
+    const responsePreview = truncateLogText(safeJson(response), LARK_CARD_LOG_PREVIEW_MAX_LENGTH);
+    if (attempt < LARK_CARDKIT_NONZERO_CODE_RETRY_LIMIT) {
+      input.logger.warn("lark cardkit call returned non-zero code; retrying once", {
+        operation: input.operation,
+        attempt: attempt + 1,
+        retryLimit: LARK_CARDKIT_NONZERO_CODE_RETRY_LIMIT,
+        code,
+        msg: response.msg ?? null,
+        responsePreview,
+        ...input.logContext,
+      });
+      attempt += 1;
+      continue;
+    }
+
+    input.logger.error(
+      "lark cardkit call kept non-zero code after retry; continuing with current logic",
+      {
+        operation: input.operation,
+        attempt: attempt + 1,
+        retryLimit: LARK_CARDKIT_NONZERO_CODE_RETRY_LIMIT,
+        code,
+        msg: response.msg ?? null,
+        responsePreview,
+        ...input.logContext,
+      },
+    );
+    return response;
+  }
+}
+
+export async function invokeSequencedLarkCardkitMutation<
+  T extends LarkCardOperationResponse,
+>(input: {
+  logger: LarkCardkitLogger;
+  operation: LarkSequencedCardMutationOperation;
+  logContext: Record<string, unknown>;
+  sequence: number;
+  invoke: () => Promise<T>;
+}): Promise<LarkSequencedCardMutationOutcome<T>> {
+  try {
+    const response = await input.invoke();
+    const code = response.code;
+    if (code == null || code === 0) {
+      return {
+        kind: "applied",
+        response,
+      };
+    }
+
+    const responsePreview = truncateLogText(safeJson(response), LARK_CARD_LOG_PREVIEW_MAX_LENGTH);
+    if (code === LARK_CARDKIT_SEQUENCE_COMPARE_FAILED_CODE) {
+      input.logger.warn("lark cardkit call reported sequence mismatch; scheduling reconcile", {
+        operation: input.operation,
+        ...input.logContext,
+        code,
+        msg: response.msg ?? null,
+        responsePreview,
+        sequence: input.sequence,
+        nextSequenceFloor: input.sequence + 1,
+      });
+      return {
+        kind: "reconcile",
+        nextSequenceFloor: input.sequence + 1,
+        reason: "sequence_compare_failed",
+      };
+    }
+
+    const attempt = 0;
+    while (attempt < LARK_CARDKIT_NONZERO_CODE_RETRY_LIMIT) {
+      input.logger.warn("lark cardkit call returned non-zero code; retrying once", {
+        operation: input.operation,
+        ...input.logContext,
+        attempt: attempt + 1,
+        retryLimit: LARK_CARDKIT_NONZERO_CODE_RETRY_LIMIT,
+        code,
+        msg: response.msg ?? null,
+        responsePreview,
+        sequence: input.sequence,
+      });
+      const retryResponse = await input.invoke();
+      const retryCode = retryResponse.code;
+      if (retryCode == null || retryCode === 0) {
+        return {
+          kind: "applied",
+          response: retryResponse,
+        };
+      }
+      const retryPreview = truncateLogText(
+        safeJson(retryResponse),
+        LARK_CARD_LOG_PREVIEW_MAX_LENGTH,
+      );
+      if (retryCode === LARK_CARDKIT_SEQUENCE_COMPARE_FAILED_CODE) {
+        input.logger.warn("lark cardkit retry reported sequence mismatch; scheduling reconcile", {
+          operation: input.operation,
+          ...input.logContext,
+          attempt: attempt + 2,
+          retryLimit: LARK_CARDKIT_NONZERO_CODE_RETRY_LIMIT,
+          code: retryCode,
+          msg: retryResponse.msg ?? null,
+          responsePreview: retryPreview,
+          sequence: input.sequence,
+          nextSequenceFloor: input.sequence + 1,
+        });
+        return {
+          kind: "reconcile",
+          nextSequenceFloor: input.sequence + 1,
+          reason: "sequence_compare_failed",
+        };
+      }
+
+      input.logger.error(
+        "lark cardkit call kept non-zero code after retry; continuing with current logic",
+        {
+          operation: input.operation,
+          ...input.logContext,
+          attempt: attempt + 2,
+          retryLimit: LARK_CARDKIT_NONZERO_CODE_RETRY_LIMIT,
+          code: retryCode,
+          msg: retryResponse.msg ?? null,
+          responsePreview: retryPreview,
+          sequence: input.sequence,
+        },
+      );
+      // Intentionally keep sequenced card mutations best-effort for explicit
+      // business-code failures other than sequence mismatch. We only schedule
+      // reconcile when remote state is ambiguous (transport failure) or when
+      // Lark explicitly reports sequence compare failure (300317). Other
+      // non-zero codes are treated as non-blocking so outbound delivery can
+      // keep progressing, while logs preserve the failure for observation.
+      return {
+        kind: "applied",
+        response: retryResponse,
+      };
+    }
+
+    return {
+      kind: "applied",
+      response,
+    };
+  } catch (error) {
+    if (!isAmbiguousLarkCardkitTransportError(error)) {
+      throw error;
+    }
+
+    input.logger.warn("lark cardkit call failed ambiguously; scheduling reconcile", {
+      operation: input.operation,
+      ...input.logContext,
+      sequence: input.sequence,
+      nextSequenceFloor: input.sequence + 1,
+      error: error instanceof Error ? error.message : String(error),
+      httpStatus: readLarkHttpStatus(error),
+    });
+    return {
+      kind: "reconcile",
+      nextSequenceFloor: input.sequence + 1,
+      reason: "ambiguous_transport_failure",
+    };
+  }
+}
+
+function truncateLogText(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return `${text.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    return JSON.stringify({
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/src/channels/lark/outbound.ts
+++ b/src/channels/lark/outbound.ts
@@ -57,14 +57,21 @@ const RUN_CARD_OBJECT_KIND = "run_card";
 const APPROVAL_CARD_OBJECT_KIND = "approval_card";
 const SUBAGENT_REQUEST_CARD_OBJECT_KIND = "subagent_creation_request_card";
 const LARK_CARD_LOG_PREVIEW_MAX_LENGTH = 600;
+const LARK_CARDKIT_NONZERO_CODE_RETRY_LIMIT = 1;
 const TASK_STATUS_DELIVERY_PREFIX = "task_status:";
 const STEER_CONFIRMED_REACTION_EMOJI = "OK";
 
-interface LarkCardCreateResponse {
+interface LarkCardCreateResponse extends LarkCardOperationResponse {
   data?: {
     card_id?: string;
   };
   card_id?: string;
+}
+
+interface LarkCardOperationResponse {
+  code?: number;
+  msg?: string;
+  data?: Record<string, unknown>;
 }
 
 interface LarkCardElementContentInput {
@@ -260,11 +267,16 @@ export function createLarkOutboundRuntime(
     }
 
     if (binding.larkCardId == null) {
-      const createResp = await bindingInput.cardkit.card.create({
-        data: {
-          type: "card_json",
-          data: bindingInput.cardJson,
-        },
+      const createResp = await invokeLarkCardkitCallWithBusinessRetry({
+        operation: "card.create",
+        logContext: bindingInput.logContext,
+        invoke: () =>
+          bindingInput.cardkit.card.create({
+            data: {
+              type: "card_json",
+              data: bindingInput.cardJson,
+            },
+          }),
       });
       const larkCardId = createResp.data?.card_id ?? createResp.card_id ?? null;
       logger.debug("created lark cardkit card response", {
@@ -542,15 +554,32 @@ export function createLarkOutboundRuntime(
             continue;
           }
           const sequence = (existing.lastSequence ?? 0) + 1;
-          await cardkit.cardElement.content({
-            path: {
-              card_id: existing.larkCardId,
-              element_id: elementId,
-            },
-            data: {
-              content: activeAssistantText,
+          const larkCardId = existing.larkCardId;
+          if (larkCardId == null) {
+            continue;
+          }
+          await invokeLarkCardkitCallWithBusinessRetry({
+            operation: "cardElement.content",
+            logContext: {
+              runId: state.runId,
+              runCardObjectId,
+              pageObjectId,
+              pageIndex: renderedPage.pageIndex,
+              channelInstallationId: target.channelInstallationId,
+              larkCardId,
               sequence,
             },
+            invoke: () =>
+              cardkit.cardElement.content({
+                path: {
+                  card_id: larkCardId,
+                  element_id: elementId,
+                },
+                data: {
+                  content: activeAssistantText,
+                  sequence,
+                },
+              }),
           });
           bindingsRepo.updateDeliveryState({
             channelInstallationId: target.channelInstallationId,
@@ -583,15 +612,32 @@ export function createLarkOutboundRuntime(
         }
 
         const sequence = (existing.lastSequence ?? 0) + 1;
-        await cardkit.card.update({
-          path: { card_id: existing.larkCardId },
-          data: {
-            card: {
-              type: "card_json",
-              data: JSON.stringify(renderedPage.card),
-            },
+        const larkCardId = existing.larkCardId;
+        if (larkCardId == null) {
+          continue;
+        }
+        await invokeLarkCardkitCallWithBusinessRetry({
+          operation: "card.update",
+          logContext: {
+            runId: state.runId,
+            runCardObjectId,
+            pageObjectId,
+            pageIndex: renderedPage.pageIndex,
+            channelInstallationId: target.channelInstallationId,
+            larkCardId,
             sequence,
           },
+          invoke: () =>
+            cardkit.card.update({
+              path: { card_id: larkCardId },
+              data: {
+                card: {
+                  type: "card_json",
+                  data: JSON.stringify(renderedPage.card),
+                },
+                sequence,
+              },
+            }),
         });
         bindingsRepo.updateDeliveryState({
           channelInstallationId: target.channelInstallationId,
@@ -628,15 +674,31 @@ export function createLarkOutboundRuntime(
 
         const staleCard = buildStaleRunCardCard();
         const sequence = (binding.lastSequence ?? 0) + 1;
-        await cardkit.card.update({
-          path: { card_id: binding.larkCardId },
-          data: {
-            card: {
-              type: "card_json",
-              data: JSON.stringify(staleCard),
-            },
+        const larkCardId = binding.larkCardId;
+        if (larkCardId == null) {
+          continue;
+        }
+        await invokeLarkCardkitCallWithBusinessRetry({
+          operation: "card.update",
+          logContext: {
+            runId: state.runId,
+            runCardObjectId,
+            stalePageObjectId: binding.internalObjectId,
+            channelInstallationId: target.channelInstallationId,
+            larkCardId,
             sequence,
           },
+          invoke: () =>
+            cardkit.card.update({
+              path: { card_id: larkCardId },
+              data: {
+                card: {
+                  type: "card_json",
+                  data: JSON.stringify(staleCard),
+                },
+                sequence,
+              },
+            }),
         });
         bindingsRepo.updateDeliveryState({
           channelInstallationId: target.channelInstallationId,
@@ -784,15 +846,30 @@ export function createLarkOutboundRuntime(
       }
 
       const sequence = (existing.lastSequence ?? 0) + 1;
-      await cardkit.card.update({
-        path: { card_id: existing.larkCardId },
-        data: {
-          card: {
-            type: "card_json",
-            data: JSON.stringify(rendered.card),
-          },
+      const larkCardId = existing.larkCardId;
+      if (larkCardId == null) {
+        continue;
+      }
+      await invokeLarkCardkitCallWithBusinessRetry({
+        operation: "card.update",
+        logContext: {
+          taskRunId,
+          cardRole: "task_status",
+          channelInstallationId: target.channelInstallationId,
+          larkCardId,
           sequence,
         },
+        invoke: () =>
+          cardkit.card.update({
+            path: { card_id: larkCardId },
+            data: {
+              card: {
+                type: "card_json",
+                data: JSON.stringify(rendered.card),
+              },
+              sequence,
+            },
+          }),
       });
       bindingsRepo.updateDeliveryState({
         channelInstallationId: target.channelInstallationId,
@@ -914,15 +991,30 @@ export function createLarkOutboundRuntime(
       }
 
       const sequence = (existing.lastSequence ?? 0) + 1;
-      await cardkit.card.update({
-        path: { card_id: existing.larkCardId },
-        data: {
-          card: {
-            type: "card_json",
-            data: JSON.stringify(rendered.card),
-          },
+      const larkCardId = existing.larkCardId;
+      if (larkCardId == null) {
+        continue;
+      }
+      await invokeLarkCardkitCallWithBusinessRetry({
+        operation: "card.update",
+        logContext: {
+          approvalId,
+          runId: state.runId,
+          channelInstallationId: target.channelInstallationId,
+          larkCardId,
           sequence,
         },
+        invoke: () =>
+          cardkit.card.update({
+            path: { card_id: larkCardId },
+            data: {
+              card: {
+                type: "card_json",
+                data: JSON.stringify(rendered.card),
+              },
+              sequence,
+            },
+          }),
       });
       bindingsRepo.updateDeliveryState({
         channelInstallationId: target.channelInstallationId,
@@ -1005,15 +1097,30 @@ export function createLarkOutboundRuntime(
       }
 
       const sequence = (existing.lastSequence ?? 0) + 1;
-      await cardkit.card.update({
-        path: { card_id: existing.larkCardId },
-        data: {
-          card: {
-            type: "card_json",
-            data: JSON.stringify(rendered.card),
-          },
+      const larkCardId = existing.larkCardId;
+      if (larkCardId == null) {
+        continue;
+      }
+      await invokeLarkCardkitCallWithBusinessRetry({
+        operation: "card.update",
+        logContext: {
+          requestId,
+          status: entry.state.status,
+          channelInstallationId: surface.channelInstallationId,
+          larkCardId,
           sequence,
         },
+        invoke: () =>
+          cardkit.card.update({
+            path: { card_id: larkCardId },
+            data: {
+              card: {
+                type: "card_json",
+                data: JSON.stringify(rendered.card),
+              },
+              sequence,
+            },
+          }),
       });
       bindingsRepo.updateDeliveryState({
         channelInstallationId: surface.channelInstallationId,
@@ -1945,6 +2052,50 @@ function truncateLogText(text: string, maxLength: number): string {
   return `${text.slice(0, Math.max(0, maxLength - 3))}...`;
 }
 
+async function invokeLarkCardkitCallWithBusinessRetry<T extends LarkCardOperationResponse>(input: {
+  operation: "card.create" | "card.update" | "cardElement.content";
+  logContext: Record<string, unknown>;
+  invoke: () => Promise<T>;
+}): Promise<T> {
+  let attempt = 0;
+  while (true) {
+    const response = await input.invoke();
+    const code = response.code;
+    if (code == null || code === 0) {
+      return response;
+    }
+
+    const responsePreview = truncateLogText(safeJson(response), LARK_CARD_LOG_PREVIEW_MAX_LENGTH);
+    if (attempt < LARK_CARDKIT_NONZERO_CODE_RETRY_LIMIT) {
+      logger.warn("lark cardkit call returned non-zero code; retrying once", {
+        operation: input.operation,
+        attempt: attempt + 1,
+        retryLimit: LARK_CARDKIT_NONZERO_CODE_RETRY_LIMIT,
+        code,
+        msg: response.msg ?? null,
+        responsePreview,
+        ...input.logContext,
+      });
+      attempt += 1;
+      continue;
+    }
+
+    logger.error(
+      "lark cardkit call kept non-zero code after retry; continuing with current logic",
+      {
+        operation: input.operation,
+        attempt: attempt + 1,
+        retryLimit: LARK_CARDKIT_NONZERO_CODE_RETRY_LIMIT,
+        code,
+        msg: response.msg ?? null,
+        responsePreview,
+        ...input.logContext,
+      },
+    );
+    return response;
+  }
+}
+
 function getCardkitSdk(client: LarkSdkClient): {
   card: {
     create(input: {
@@ -1953,10 +2104,10 @@ function getCardkitSdk(client: LarkSdkClient): {
         data: string;
       };
     }): Promise<LarkCardCreateResponse>;
-    update(input: LarkCardUpdateInput): Promise<unknown>;
+    update(input: LarkCardUpdateInput): Promise<LarkCardOperationResponse>;
   };
   cardElement: {
-    content(input: LarkCardElementContentInput): Promise<unknown>;
+    content(input: LarkCardElementContentInput): Promise<LarkCardOperationResponse>;
   };
 } {
   const sdk = client.sdk as unknown as {
@@ -1988,10 +2139,10 @@ function getCardkitSdk(client: LarkSdkClient): {
   return {
     card: {
       create,
-      update,
+      update: (input) => update(input) as Promise<LarkCardOperationResponse>,
     },
     cardElement: {
-      content,
+      content: (input) => content(input) as Promise<LarkCardOperationResponse>,
     },
   };
 }

--- a/src/channels/lark/outbound.ts
+++ b/src/channels/lark/outbound.ts
@@ -12,6 +12,16 @@ import {
   reduceLarkApprovalState,
   shouldHandleLarkApprovalRuntimeEvent,
 } from "@/src/channels/lark/approval-state.js";
+import {
+  buildBindingMetadata,
+  getNextCardkitSequence,
+  invokeLarkCardkitCallWithBusinessRetry,
+  invokeSequencedLarkCardkitMutation,
+  type LarkCardCreateResponse,
+  type LarkCardOperationResponse,
+  parseBindingMetadata,
+  setCardkitSequenceFloorInMetadata,
+} from "@/src/channels/lark/cardkit-mutations.js";
 import type { LarkSdkClient } from "@/src/channels/lark/client.js";
 import {
   addLarkMessageReaction,
@@ -57,22 +67,9 @@ const RUN_CARD_OBJECT_KIND = "run_card";
 const APPROVAL_CARD_OBJECT_KIND = "approval_card";
 const SUBAGENT_REQUEST_CARD_OBJECT_KIND = "subagent_creation_request_card";
 const LARK_CARD_LOG_PREVIEW_MAX_LENGTH = 600;
-const LARK_CARDKIT_NONZERO_CODE_RETRY_LIMIT = 1;
+const LARK_CARDKIT_RECONCILE_RETRY_DELAY_MS = 1000;
 const TASK_STATUS_DELIVERY_PREFIX = "task_status:";
 const STEER_CONFIRMED_REACTION_EMOJI = "OK";
-
-interface LarkCardCreateResponse extends LarkCardOperationResponse {
-  data?: {
-    card_id?: string;
-  };
-  card_id?: string;
-}
-
-interface LarkCardOperationResponse {
-  code?: number;
-  msg?: string;
-  data?: Record<string, unknown>;
-}
 
 interface LarkCardElementContentInput {
   path: {
@@ -157,7 +154,10 @@ export function createLarkOutboundRuntime(
   const urgentFlushes = new Set<string>();
   let unsubscribe: (() => void) | null = null;
 
-  const scheduleFlush = (deliveryId: string, options?: { immediate?: boolean }) => {
+  const scheduleFlush = (
+    deliveryId: string,
+    options?: { immediate?: boolean; delayMs?: number },
+  ) => {
     if (options?.immediate === true) {
       urgentFlushes.add(deliveryId);
       const existing = scheduled.get(deliveryId);
@@ -185,13 +185,48 @@ export function createLarkOutboundRuntime(
             error: error instanceof Error ? error.message : String(error),
           });
         });
-      }, DELIVERY_INTERVAL_MS),
+      }, options?.delayMs ?? DELIVERY_INTERVAL_MS),
     );
   };
 
-  const bumpVersionAndSchedule = (deliveryId: string, options?: { immediate?: boolean }) => {
+  const bumpVersionAndSchedule = (
+    deliveryId: string,
+    options?: { immediate?: boolean; delayMs?: number },
+  ) => {
     deliveryVersions.set(deliveryId, (deliveryVersions.get(deliveryId) ?? 0) + 1);
     scheduleFlush(deliveryId, options);
+  };
+
+  const scheduleCardkitSequenceReconcile = (input: {
+    bindingsRepo: LarkObjectBindingsRepo;
+    channelInstallationId: string;
+    internalObjectKind: string;
+    internalObjectId: string;
+    metadataJson: string;
+    nextSequenceFloor: number;
+    deliveryId: string;
+    logContext: Record<string, unknown>;
+    reason: "ambiguous_transport_failure" | "sequence_compare_failed";
+  }) => {
+    const nextMetadataJson = setCardkitSequenceFloorInMetadata(
+      input.metadataJson,
+      input.nextSequenceFloor,
+    );
+    input.bindingsRepo.updateDeliveryState({
+      channelInstallationId: input.channelInstallationId,
+      internalObjectKind: input.internalObjectKind,
+      internalObjectId: input.internalObjectId,
+      metadataJson: nextMetadataJson,
+    });
+    logger.warn("scheduled lark cardkit reconcile after sequence uncertainty", {
+      reason: input.reason,
+      nextSequenceFloor: input.nextSequenceFloor,
+      deliveryId: input.deliveryId,
+      ...input.logContext,
+    });
+    bumpVersionAndSchedule(input.deliveryId, {
+      delayMs: LARK_CARDKIT_RECONCILE_RETRY_DELAY_MS,
+    });
   };
 
   const flushDelivery = async (deliveryId: string) => {
@@ -268,6 +303,7 @@ export function createLarkOutboundRuntime(
 
     if (binding.larkCardId == null) {
       const createResp = await invokeLarkCardkitCallWithBusinessRetry({
+        logger,
         operation: "card.create",
         logContext: bindingInput.logContext,
         invoke: () =>
@@ -462,15 +498,18 @@ export function createLarkOutboundRuntime(
           state.terminal === "running" && renderedPage.pageIndex === renderedPage.pageCount
             ? "active"
             : "finalized";
-        const metadataJson = JSON.stringify({
-          activeAssistantBlockId,
-          pageIndex: renderedPage.pageIndex,
-          pageCount: renderedPage.pageCount,
-          runId: state.runId,
-          sessionId: state.sessionId,
-          taskRunId: state.taskRunId,
-          taskRunType: state.taskRunType,
-        });
+        const metadataJson = buildBindingMetadata(
+          {
+            activeAssistantBlockId,
+            pageIndex: renderedPage.pageIndex,
+            pageCount: renderedPage.pageCount,
+            runId: state.runId,
+            sessionId: state.sessionId,
+            taskRunId: state.taskRunId,
+            taskRunType: state.taskRunType,
+          },
+          existing?.metadataJson ?? null,
+        );
 
         logger.debug("computed lark run card delivery decision", {
           runId: state.runId,
@@ -553,13 +592,15 @@ export function createLarkOutboundRuntime(
           if (elementId == null || existing.larkCardId == null) {
             continue;
           }
-          const sequence = (existing.lastSequence ?? 0) + 1;
+          const sequence = getNextCardkitSequence(existing);
           const larkCardId = existing.larkCardId;
           if (larkCardId == null) {
             continue;
           }
-          await invokeLarkCardkitCallWithBusinessRetry({
+          const mutation = await invokeSequencedLarkCardkitMutation({
+            logger,
             operation: "cardElement.content",
+            sequence,
             logContext: {
               runId: state.runId,
               runCardObjectId,
@@ -581,6 +622,28 @@ export function createLarkOutboundRuntime(
                 },
               }),
           });
+          if (mutation.kind === "reconcile") {
+            scheduleCardkitSequenceReconcile({
+              bindingsRepo,
+              channelInstallationId: target.channelInstallationId,
+              internalObjectKind: RUN_CARD_OBJECT_KIND,
+              internalObjectId: pageObjectId,
+              metadataJson,
+              nextSequenceFloor: mutation.nextSequenceFloor,
+              deliveryId: `run:${runCardObjectId}`,
+              logContext: {
+                runId: state.runId,
+                runCardObjectId,
+                pageObjectId,
+                pageIndex: renderedPage.pageIndex,
+                channelInstallationId: target.channelInstallationId,
+                larkCardId,
+                sequence,
+              },
+              reason: mutation.reason,
+            });
+            continue;
+          }
           bindingsRepo.updateDeliveryState({
             channelInstallationId: target.channelInstallationId,
             internalObjectKind: RUN_CARD_OBJECT_KIND,
@@ -611,13 +674,15 @@ export function createLarkOutboundRuntime(
           continue;
         }
 
-        const sequence = (existing.lastSequence ?? 0) + 1;
+        const sequence = getNextCardkitSequence(existing);
         const larkCardId = existing.larkCardId;
         if (larkCardId == null) {
           continue;
         }
-        await invokeLarkCardkitCallWithBusinessRetry({
+        const mutation = await invokeSequencedLarkCardkitMutation({
+          logger,
           operation: "card.update",
+          sequence,
           logContext: {
             runId: state.runId,
             runCardObjectId,
@@ -639,6 +704,28 @@ export function createLarkOutboundRuntime(
               },
             }),
         });
+        if (mutation.kind === "reconcile") {
+          scheduleCardkitSequenceReconcile({
+            bindingsRepo,
+            channelInstallationId: target.channelInstallationId,
+            internalObjectKind: RUN_CARD_OBJECT_KIND,
+            internalObjectId: pageObjectId,
+            metadataJson,
+            nextSequenceFloor: mutation.nextSequenceFloor,
+            deliveryId: `run:${runCardObjectId}`,
+            logContext: {
+              runId: state.runId,
+              runCardObjectId,
+              pageObjectId,
+              pageIndex: renderedPage.pageIndex,
+              channelInstallationId: target.channelInstallationId,
+              larkCardId,
+              sequence,
+            },
+            reason: mutation.reason,
+          });
+          continue;
+        }
         bindingsRepo.updateDeliveryState({
           channelInstallationId: target.channelInstallationId,
           internalObjectKind: RUN_CARD_OBJECT_KIND,
@@ -673,13 +760,22 @@ export function createLarkOutboundRuntime(
         }
 
         const staleCard = buildStaleRunCardCard();
-        const sequence = (binding.lastSequence ?? 0) + 1;
+        const sequence = getNextCardkitSequence(binding);
         const larkCardId = binding.larkCardId;
         if (larkCardId == null) {
           continue;
         }
-        await invokeLarkCardkitCallWithBusinessRetry({
+        const staleMetadataJson = buildBindingMetadata(
+          {
+            pageState: "stale",
+            runId: state.runId,
+          },
+          binding.metadataJson,
+        );
+        const mutation = await invokeSequencedLarkCardkitMutation({
+          logger,
           operation: "card.update",
+          sequence,
           logContext: {
             runId: state.runId,
             runCardObjectId,
@@ -700,16 +796,34 @@ export function createLarkOutboundRuntime(
               },
             }),
         });
+        if (mutation.kind === "reconcile") {
+          scheduleCardkitSequenceReconcile({
+            bindingsRepo,
+            channelInstallationId: target.channelInstallationId,
+            internalObjectKind: RUN_CARD_OBJECT_KIND,
+            internalObjectId: binding.internalObjectId,
+            metadataJson: staleMetadataJson,
+            nextSequenceFloor: mutation.nextSequenceFloor,
+            deliveryId: `run:${runCardObjectId}`,
+            logContext: {
+              runId: state.runId,
+              runCardObjectId,
+              stalePageObjectId: binding.internalObjectId,
+              channelInstallationId: target.channelInstallationId,
+              larkCardId,
+              sequence,
+            },
+            reason: mutation.reason,
+          });
+          continue;
+        }
         bindingsRepo.updateDeliveryState({
           channelInstallationId: target.channelInstallationId,
           internalObjectKind: RUN_CARD_OBJECT_KIND,
           internalObjectId: binding.internalObjectId,
           lastSequence: sequence,
           status: "stale",
-          metadataJson: JSON.stringify({
-            pageState: "stale",
-            runId: state.runId,
-          }),
+          metadataJson: staleMetadataJson,
         });
         deliverySnapshots.set(`${target.channelInstallationId}:run:${binding.internalObjectId}`, {
           structureSignature: JSON.stringify(staleCard),
@@ -770,20 +884,23 @@ export function createLarkOutboundRuntime(
       const snapshot = deliverySnapshots.get(snapshotKey) ?? null;
       const shouldRenderUpdate =
         snapshot == null || snapshot.structureSignature !== rendered.structureSignature;
-      let metadataJson = JSON.stringify({
-        sessionId: state.sessionId,
-        taskRunId: state.taskRunId,
-        taskRunType: state.taskRunType,
-        role: "task_status",
-        ...(taskTitle == null ? {} : { taskTitle }),
-        ...(readStringValue(existingMetadata.fullTerminalMessageSignature) == null
-          ? {}
-          : {
-              fullTerminalMessageSignature: readStringValue(
-                existingMetadata.fullTerminalMessageSignature,
-              ),
-            }),
-      });
+      let metadataJson = buildBindingMetadata(
+        {
+          sessionId: state.sessionId,
+          taskRunId: state.taskRunId,
+          taskRunType: state.taskRunType,
+          role: "task_status",
+          ...(taskTitle == null ? {} : { taskTitle }),
+          ...(readStringValue(existingMetadata.fullTerminalMessageSignature) == null
+            ? {}
+            : {
+                fullTerminalMessageSignature: readStringValue(
+                  existingMetadata.fullTerminalMessageSignature,
+                ),
+              }),
+        },
+        existing?.metadataJson ?? null,
+      );
       const status = state.terminal === "running" ? "active" : "finalized";
 
       if (existing?.larkCardId == null || existing.larkMessageId == null) {
@@ -845,13 +962,15 @@ export function createLarkOutboundRuntime(
         continue;
       }
 
-      const sequence = (existing.lastSequence ?? 0) + 1;
+      const sequence = getNextCardkitSequence(existing);
       const larkCardId = existing.larkCardId;
       if (larkCardId == null) {
         continue;
       }
-      await invokeLarkCardkitCallWithBusinessRetry({
+      const mutation = await invokeSequencedLarkCardkitMutation({
+        logger,
         operation: "card.update",
+        sequence,
         logContext: {
           taskRunId,
           cardRole: "task_status",
@@ -871,6 +990,26 @@ export function createLarkOutboundRuntime(
             },
           }),
       });
+      if (mutation.kind === "reconcile") {
+        scheduleCardkitSequenceReconcile({
+          bindingsRepo,
+          channelInstallationId: target.channelInstallationId,
+          internalObjectKind: RUN_CARD_OBJECT_KIND,
+          internalObjectId,
+          metadataJson,
+          nextSequenceFloor: mutation.nextSequenceFloor,
+          deliveryId: `${TASK_STATUS_DELIVERY_PREFIX}${taskRunId}`,
+          logContext: {
+            taskRunId,
+            cardRole: "task_status",
+            channelInstallationId: target.channelInstallationId,
+            larkCardId,
+            sequence,
+          },
+          reason: mutation.reason,
+        });
+        continue;
+      }
       bindingsRepo.updateDeliveryState({
         channelInstallationId: target.channelInstallationId,
         internalObjectKind: RUN_CARD_OBJECT_KIND,
@@ -990,13 +1129,22 @@ export function createLarkOutboundRuntime(
         continue;
       }
 
-      const sequence = (existing.lastSequence ?? 0) + 1;
+      const sequence = getNextCardkitSequence(existing);
       const larkCardId = existing.larkCardId;
       if (larkCardId == null) {
         continue;
       }
-      await invokeLarkCardkitCallWithBusinessRetry({
+      const metadataJson = buildBindingMetadata(
+        {
+          approvalId,
+          runId: state.runId,
+        },
+        existing.metadataJson,
+      );
+      const mutation = await invokeSequencedLarkCardkitMutation({
+        logger,
         operation: "card.update",
+        sequence,
         logContext: {
           approvalId,
           runId: state.runId,
@@ -1016,16 +1164,33 @@ export function createLarkOutboundRuntime(
             },
           }),
       });
+      if (mutation.kind === "reconcile") {
+        scheduleCardkitSequenceReconcile({
+          bindingsRepo,
+          channelInstallationId: target.channelInstallationId,
+          internalObjectKind: APPROVAL_CARD_OBJECT_KIND,
+          internalObjectId: approvalId,
+          metadataJson,
+          nextSequenceFloor: mutation.nextSequenceFloor,
+          deliveryId: `approval:${approvalId}`,
+          logContext: {
+            approvalId,
+            runId: state.runId,
+            channelInstallationId: target.channelInstallationId,
+            larkCardId,
+            sequence,
+          },
+          reason: mutation.reason,
+        });
+        continue;
+      }
       bindingsRepo.updateDeliveryState({
         channelInstallationId: target.channelInstallationId,
         internalObjectKind: APPROVAL_CARD_OBJECT_KIND,
         internalObjectId: approvalId,
         lastSequence: sequence,
         status: state.resolved ? "finalized" : "active",
-        metadataJson: JSON.stringify({
-          approvalId,
-          runId: state.runId,
-        }),
+        metadataJson,
       });
       logger.debug("updated standalone lark approval card", {
         approvalId,
@@ -1096,13 +1261,22 @@ export function createLarkOutboundRuntime(
         continue;
       }
 
-      const sequence = (existing.lastSequence ?? 0) + 1;
+      const sequence = getNextCardkitSequence(existing);
       const larkCardId = existing.larkCardId;
       if (larkCardId == null) {
         continue;
       }
-      await invokeLarkCardkitCallWithBusinessRetry({
+      const metadataJson = buildBindingMetadata(
+        {
+          requestId,
+          status: entry.state.status,
+        },
+        existing.metadataJson,
+      );
+      const mutation = await invokeSequencedLarkCardkitMutation({
+        logger,
         operation: "card.update",
+        sequence,
         logContext: {
           requestId,
           status: entry.state.status,
@@ -1122,16 +1296,33 @@ export function createLarkOutboundRuntime(
             },
           }),
       });
+      if (mutation.kind === "reconcile") {
+        scheduleCardkitSequenceReconcile({
+          bindingsRepo,
+          channelInstallationId: surface.channelInstallationId,
+          internalObjectKind: SUBAGENT_REQUEST_CARD_OBJECT_KIND,
+          internalObjectId: requestId,
+          metadataJson,
+          nextSequenceFloor: mutation.nextSequenceFloor,
+          deliveryId: `subagent:${requestId}`,
+          logContext: {
+            requestId,
+            status: entry.state.status,
+            channelInstallationId: surface.channelInstallationId,
+            larkCardId,
+            sequence,
+          },
+          reason: mutation.reason,
+        });
+        continue;
+      }
       bindingsRepo.updateDeliveryState({
         channelInstallationId: surface.channelInstallationId,
         internalObjectKind: SUBAGENT_REQUEST_CARD_OBJECT_KIND,
         internalObjectId: requestId,
         lastSequence: sequence,
         status: entry.state.status === "pending" ? "active" : "finalized",
-        metadataJson: JSON.stringify({
-          requestId,
-          status: entry.state.status,
-        }),
+        metadataJson,
       });
     }
   };
@@ -1607,19 +1798,6 @@ function parseSurfaceObject(raw: string): Record<string, unknown> {
   return {};
 }
 
-function parseBindingMetadata(raw: string | null): Record<string, unknown> {
-  if (raw == null || raw.trim().length === 0) {
-    return {};
-  }
-  try {
-    const parsed = JSON.parse(raw);
-    if (typeof parsed === "object" && parsed != null && !Array.isArray(parsed)) {
-      return parsed as Record<string, unknown>;
-    }
-  } catch {}
-  return {};
-}
-
 async function sendLarkInteractiveCardReferenceMessage(input: {
   client: LarkSdkClient;
   chatId: string;
@@ -2050,53 +2228,6 @@ function truncateLogText(text: string, maxLength: number): string {
   }
 
   return `${text.slice(0, Math.max(0, maxLength - 3))}...`;
-}
-
-async function invokeLarkCardkitCallWithBusinessRetry<T extends LarkCardOperationResponse>(input: {
-  operation: "card.create" | "card.update" | "cardElement.content";
-  logContext: Record<string, unknown>;
-  invoke: () => Promise<T>;
-}): Promise<T> {
-  let attempt = 0;
-  while (true) {
-    const response = await input.invoke();
-    const code = response.code;
-    if (code == null || code === 0) {
-      return response;
-    }
-
-    const responsePreview = truncateLogText(safeJson(response), LARK_CARD_LOG_PREVIEW_MAX_LENGTH);
-    if (attempt < LARK_CARDKIT_NONZERO_CODE_RETRY_LIMIT) {
-      // CardKit sequencing is owned by the caller. Retries must replay the exact
-      // same request payload, including the same sequence number, rather than
-      // incrementing local delivery state inside this helper.
-      logger.warn("lark cardkit call returned non-zero code; retrying once", {
-        operation: input.operation,
-        attempt: attempt + 1,
-        retryLimit: LARK_CARDKIT_NONZERO_CODE_RETRY_LIMIT,
-        code,
-        msg: response.msg ?? null,
-        responsePreview,
-        ...input.logContext,
-      });
-      attempt += 1;
-      continue;
-    }
-
-    logger.error(
-      "lark cardkit call kept non-zero code after retry; continuing with current logic",
-      {
-        operation: input.operation,
-        attempt: attempt + 1,
-        retryLimit: LARK_CARDKIT_NONZERO_CODE_RETRY_LIMIT,
-        code,
-        msg: response.msg ?? null,
-        responsePreview,
-        ...input.logContext,
-      },
-    );
-    return response;
-  }
 }
 
 function getCardkitSdk(client: LarkSdkClient): {

--- a/src/channels/lark/outbound.ts
+++ b/src/channels/lark/outbound.ts
@@ -2067,6 +2067,9 @@ async function invokeLarkCardkitCallWithBusinessRetry<T extends LarkCardOperatio
 
     const responsePreview = truncateLogText(safeJson(response), LARK_CARD_LOG_PREVIEW_MAX_LENGTH);
     if (attempt < LARK_CARDKIT_NONZERO_CODE_RETRY_LIMIT) {
+      // CardKit sequencing is owned by the caller. Retries must replay the exact
+      // same request payload, including the same sequence number, rather than
+      // incrementing local delivery state inside this helper.
       logger.warn("lark cardkit call returned non-zero code; retrying once", {
         operation: input.operation,
         attempt: attempt + 1,

--- a/tests/channels/lark/outbound.test.ts
+++ b/tests/channels/lark/outbound.test.ts
@@ -399,6 +399,116 @@ describe("lark outbound runtime", () => {
     await runtime.shutdown();
   });
 
+  test("retries card.create once when card.create returns a non-zero code", async () => {
+    vi.useFakeTimers();
+    handle = await createTestDatabase(import.meta.url);
+    handle.storage.sqlite.exec(`
+      INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+      VALUES ('ci_lark_default', 'lark', 'default', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+      VALUES ('conv_1', 'ci_lark_default', 'oc_chat_1', 'dm', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+      VALUES ('branch_1', 'conv_1', 'dm_main', 'main', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+    `);
+
+    new ChannelSurfacesRepo(handle.storage.db).upsert({
+      id: "surface_1",
+      channelType: "lark",
+      channelInstallationId: "default",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      surfaceKey: "chat:oc_chat_1",
+      surfaceObjectJson: JSON.stringify({ chat_id: "oc_chat_1" }),
+    });
+
+    const createCard = vi
+      .fn()
+      .mockResolvedValueOnce({ code: 999, msg: "busy" })
+      .mockResolvedValueOnce({ data: { card_id: "card_1" } });
+    const createMessage = vi.fn(async (_input: unknown) => ({
+      data: { message_id: "om_card_1", open_message_id: "om_open_1" },
+    }));
+    const updateCard = vi.fn(async (_input: unknown) => ({}));
+    const streamContent = vi.fn(async (_input: unknown) => ({}));
+    const bus = new RuntimeEventBus<OrchestratedOutboundEventEnvelope>();
+    const runtime = createLarkOutboundRuntime({
+      storage: handle.storage.db,
+      outboundEventBus: bus,
+      clients: {
+        getOrCreate: () =>
+          ({
+            sdk: {
+              cardkit: {
+                v1: {
+                  card: {
+                    create: createCard,
+                    update: updateCard,
+                  },
+                  cardElement: {
+                    content: streamContent,
+                  },
+                },
+              },
+              im: {
+                message: {
+                  create: createMessage,
+                },
+              },
+            },
+          }) as never,
+      },
+    });
+
+    runtime.start();
+
+    bus.publish(
+      makeEnvelope({
+        type: "assistant_message_started",
+        eventId: "evt_create_retry_1",
+        createdAt: "2026-03-28T00:00:00.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        messageId: "msg_1",
+      }),
+    );
+    bus.publish(
+      makeEnvelope({
+        type: "assistant_message_delta",
+        eventId: "evt_create_retry_2",
+        createdAt: "2026-03-28T00:00:01.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        messageId: "msg_1",
+        delta: "hello",
+        accumulatedText: "hello",
+      }),
+    );
+
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(createCard).toHaveBeenCalledTimes(2);
+    expect(createMessage).toHaveBeenCalledTimes(1);
+
+    const binding = new LarkObjectBindingsRepo(handle.storage.db).getByInternalObject({
+      channelInstallationId: "default",
+      internalObjectKind: "run_card",
+      internalObjectId: "run_1:seg:1",
+    });
+    expect(binding?.larkCardId).toBe("card_1");
+    expect(binding?.larkMessageId).toBe("om_card_1");
+
+    await runtime.shutdown();
+  });
+
   test("retries run card stream content once when cardElement.content returns a non-zero code", async () => {
     vi.useFakeTimers();
     handle = await createTestDatabase(import.meta.url);

--- a/tests/channels/lark/outbound.test.ts
+++ b/tests/channels/lark/outbound.test.ts
@@ -783,6 +783,287 @@ describe("lark outbound runtime", () => {
     await runtime.shutdown();
   });
 
+  test("reconciles run card with a higher sequence after an ambiguous 504 update failure", async () => {
+    vi.useFakeTimers();
+    handle = await createTestDatabase(import.meta.url);
+    handle.storage.sqlite.exec(`
+      INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+      VALUES ('ci_lark_default', 'lark', 'default', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+      VALUES ('conv_1', 'ci_lark_default', 'oc_chat_1', 'dm', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+      VALUES ('branch_1', 'conv_1', 'dm_main', 'main', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+    `);
+
+    new ChannelSurfacesRepo(handle.storage.db).upsert({
+      id: "surface_1",
+      channelType: "lark",
+      channelInstallationId: "default",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      surfaceKey: "chat:oc_chat_1",
+      surfaceObjectJson: JSON.stringify({ chat_id: "oc_chat_1" }),
+    });
+
+    const createCard = vi.fn(async (_input: unknown) => ({
+      data: { card_id: "card_1" },
+    }));
+    const createMessage = vi.fn(async (_input: unknown) => ({
+      data: { message_id: "om_card_1", open_message_id: "om_open_1" },
+    }));
+    const streamContent = vi.fn(async (_input: unknown) => ({}));
+    const ambiguous504 = new Error("Request failed with status code 504") as Error & {
+      response?: { status: number };
+    };
+    ambiguous504.response = { status: 504 };
+    const updateCard = vi.fn().mockRejectedValueOnce(ambiguous504).mockResolvedValueOnce({});
+    const bus = new RuntimeEventBus<OrchestratedOutboundEventEnvelope>();
+    const runtime = createLarkOutboundRuntime({
+      storage: handle.storage.db,
+      outboundEventBus: bus,
+      clients: {
+        getOrCreate: () =>
+          ({
+            sdk: {
+              cardkit: {
+                v1: {
+                  card: {
+                    create: createCard,
+                    update: updateCard,
+                  },
+                  cardElement: {
+                    content: streamContent,
+                  },
+                },
+              },
+              im: {
+                message: {
+                  create: createMessage,
+                },
+              },
+            },
+          }) as never,
+      },
+    });
+
+    runtime.start();
+
+    bus.publish(
+      makeEnvelope({
+        type: "assistant_message_started",
+        eventId: "evt_504_1",
+        createdAt: "2026-03-28T00:00:00.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        messageId: "msg_1",
+      }),
+    );
+    bus.publish(
+      makeEnvelope({
+        type: "assistant_message_delta",
+        eventId: "evt_504_2",
+        createdAt: "2026-03-28T00:00:01.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        messageId: "msg_1",
+        delta: "hello",
+        accumulatedText: "hello",
+      }),
+    );
+
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(250);
+
+    bus.publish(
+      makeEnvelope({
+        type: "assistant_message_completed",
+        eventId: "evt_504_3",
+        createdAt: "2026-03-28T00:00:02.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        messageId: "msg_1",
+        text: "hello",
+        reasoningText: null,
+        toolCalls: [],
+        usage: null,
+      }),
+    );
+
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(updateCard).toHaveBeenCalledTimes(2);
+    expect(updateCard.mock.calls.at(0)?.[0]).toMatchObject({
+      path: { card_id: "card_1" },
+      data: { sequence: 1 },
+    });
+    expect(updateCard.mock.calls.at(1)?.[0]).toMatchObject({
+      path: { card_id: "card_1" },
+      data: { sequence: 2 },
+    });
+
+    const binding = new LarkObjectBindingsRepo(handle.storage.db).getByInternalObject({
+      channelInstallationId: "default",
+      internalObjectKind: "run_card",
+      internalObjectId: "run_1:seg:1",
+    });
+    expect(binding?.lastSequence).toBe(2);
+
+    await runtime.shutdown();
+  });
+
+  test("reconciles run card with a higher sequence after a sequence-compare failure", async () => {
+    vi.useFakeTimers();
+    handle = await createTestDatabase(import.meta.url);
+    handle.storage.sqlite.exec(`
+      INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+      VALUES ('ci_lark_default', 'lark', 'default', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+      VALUES ('conv_1', 'ci_lark_default', 'oc_chat_1', 'dm', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+      VALUES ('branch_1', 'conv_1', 'dm_main', 'main', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+    `);
+
+    new ChannelSurfacesRepo(handle.storage.db).upsert({
+      id: "surface_1",
+      channelType: "lark",
+      channelInstallationId: "default",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      surfaceKey: "chat:oc_chat_1",
+      surfaceObjectJson: JSON.stringify({ chat_id: "oc_chat_1" }),
+    });
+
+    const createCard = vi.fn(async (_input: unknown) => ({
+      data: { card_id: "card_1" },
+    }));
+    const createMessage = vi.fn(async (_input: unknown) => ({
+      data: { message_id: "om_card_1", open_message_id: "om_open_1" },
+    }));
+    const streamContent = vi.fn(async (_input: unknown) => ({}));
+    const updateCard = vi
+      .fn()
+      .mockResolvedValueOnce({ code: 300317, msg: "ErrMsg: sequence number compare failed;" })
+      .mockResolvedValueOnce({});
+    const bus = new RuntimeEventBus<OrchestratedOutboundEventEnvelope>();
+    const runtime = createLarkOutboundRuntime({
+      storage: handle.storage.db,
+      outboundEventBus: bus,
+      clients: {
+        getOrCreate: () =>
+          ({
+            sdk: {
+              cardkit: {
+                v1: {
+                  card: {
+                    create: createCard,
+                    update: updateCard,
+                  },
+                  cardElement: {
+                    content: streamContent,
+                  },
+                },
+              },
+              im: {
+                message: {
+                  create: createMessage,
+                },
+              },
+            },
+          }) as never,
+      },
+    });
+
+    runtime.start();
+
+    bus.publish(
+      makeEnvelope({
+        type: "assistant_message_started",
+        eventId: "evt_300317_1",
+        createdAt: "2026-03-28T00:00:00.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        messageId: "msg_1",
+      }),
+    );
+    bus.publish(
+      makeEnvelope({
+        type: "assistant_message_delta",
+        eventId: "evt_300317_2",
+        createdAt: "2026-03-28T00:00:01.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        messageId: "msg_1",
+        delta: "hello",
+        accumulatedText: "hello",
+      }),
+    );
+
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(250);
+
+    bus.publish(
+      makeEnvelope({
+        type: "assistant_message_completed",
+        eventId: "evt_300317_3",
+        createdAt: "2026-03-28T00:00:02.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        messageId: "msg_1",
+        text: "hello",
+        reasoningText: null,
+        toolCalls: [],
+        usage: null,
+      }),
+    );
+
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(updateCard).toHaveBeenCalledTimes(2);
+    expect(updateCard.mock.calls.at(0)?.[0]).toMatchObject({
+      path: { card_id: "card_1" },
+      data: { sequence: 1 },
+    });
+    expect(updateCard.mock.calls.at(1)?.[0]).toMatchObject({
+      path: { card_id: "card_1" },
+      data: { sequence: 2 },
+    });
+
+    const binding = new LarkObjectBindingsRepo(handle.storage.db).getByInternalObject({
+      channelInstallationId: "default",
+      internalObjectKind: "run_card",
+      internalObjectId: "run_1:seg:1",
+    });
+    expect(binding?.lastSequence).toBe(2);
+
+    await runtime.shutdown();
+  });
+
   test("updates steer reactions when a queued steer message is consumed", async () => {
     handle = await createTestDatabase(import.meta.url);
     handle.storage.sqlite.exec(`

--- a/tests/channels/lark/outbound.test.ts
+++ b/tests/channels/lark/outbound.test.ts
@@ -399,6 +399,280 @@ describe("lark outbound runtime", () => {
     await runtime.shutdown();
   });
 
+  test("retries run card stream content once when cardElement.content returns a non-zero code", async () => {
+    vi.useFakeTimers();
+    handle = await createTestDatabase(import.meta.url);
+    handle.storage.sqlite.exec(`
+      INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+      VALUES ('ci_lark_default', 'lark', 'default', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+      VALUES ('conv_1', 'ci_lark_default', 'oc_chat_1', 'dm', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+      VALUES ('branch_1', 'conv_1', 'dm_main', 'main', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+    `);
+
+    new ChannelSurfacesRepo(handle.storage.db).upsert({
+      id: "surface_1",
+      channelType: "lark",
+      channelInstallationId: "default",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      surfaceKey: "chat:oc_chat_1",
+      surfaceObjectJson: JSON.stringify({ chat_id: "oc_chat_1" }),
+    });
+
+    const createCard = vi.fn(async (_input: unknown) => ({
+      data: { card_id: "card_1" },
+    }));
+    const createMessage = vi.fn(async (_input: unknown) => ({
+      data: { message_id: "om_card_1", open_message_id: "om_open_1" },
+    }));
+    const updateCard = vi.fn(async (_input: unknown) => ({}));
+    const streamContent = vi
+      .fn()
+      .mockResolvedValueOnce({ code: 999, msg: "busy" })
+      .mockResolvedValueOnce({});
+    const bus = new RuntimeEventBus<OrchestratedOutboundEventEnvelope>();
+    const runtime = createLarkOutboundRuntime({
+      storage: handle.storage.db,
+      outboundEventBus: bus,
+      clients: {
+        getOrCreate: () =>
+          ({
+            sdk: {
+              cardkit: {
+                v1: {
+                  card: {
+                    create: createCard,
+                    update: updateCard,
+                  },
+                  cardElement: {
+                    content: streamContent,
+                  },
+                },
+              },
+              im: {
+                message: {
+                  create: createMessage,
+                },
+              },
+            },
+          }) as never,
+      },
+    });
+
+    runtime.start();
+
+    bus.publish(
+      makeEnvelope({
+        type: "assistant_message_started",
+        eventId: "evt_stream_retry_1",
+        createdAt: "2026-03-28T00:00:00.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        messageId: "msg_1",
+      }),
+    );
+    bus.publish(
+      makeEnvelope({
+        type: "assistant_message_delta",
+        eventId: "evt_stream_retry_2",
+        createdAt: "2026-03-28T00:00:01.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        messageId: "msg_1",
+        delta: "hello",
+        accumulatedText: "hello",
+      }),
+    );
+
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(250);
+
+    bus.publish(
+      makeEnvelope({
+        type: "assistant_message_delta",
+        eventId: "evt_stream_retry_3",
+        createdAt: "2026-03-28T00:00:01.500Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        messageId: "msg_1",
+        delta: " world",
+        accumulatedText: "hello world",
+      }),
+    );
+
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(streamContent).toHaveBeenCalledTimes(2);
+    expect(streamContent.mock.calls.at(0)?.[0]).toMatchObject({
+      path: {
+        card_id: "card_1",
+        element_id: buildLarkAssistantElementId("msg_1"),
+      },
+      data: {
+        content: "hello world",
+        sequence: 1,
+      },
+    });
+    expect(streamContent.mock.calls.at(1)?.[0]).toMatchObject({
+      path: {
+        card_id: "card_1",
+        element_id: buildLarkAssistantElementId("msg_1"),
+      },
+      data: {
+        content: "hello world",
+        sequence: 1,
+      },
+    });
+
+    await runtime.shutdown();
+  });
+
+  test("retries run card full update once when card.update returns a non-zero code", async () => {
+    vi.useFakeTimers();
+    handle = await createTestDatabase(import.meta.url);
+    handle.storage.sqlite.exec(`
+      INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+      VALUES ('ci_lark_default', 'lark', 'default', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+      VALUES ('conv_1', 'ci_lark_default', 'oc_chat_1', 'dm', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+      VALUES ('branch_1', 'conv_1', 'dm_main', 'main', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+    `);
+
+    new ChannelSurfacesRepo(handle.storage.db).upsert({
+      id: "surface_1",
+      channelType: "lark",
+      channelInstallationId: "default",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      surfaceKey: "chat:oc_chat_1",
+      surfaceObjectJson: JSON.stringify({ chat_id: "oc_chat_1" }),
+    });
+
+    const createCard = vi.fn(async (_input: unknown) => ({
+      data: { card_id: "card_1" },
+    }));
+    const createMessage = vi.fn(async (_input: unknown) => ({
+      data: { message_id: "om_card_1", open_message_id: "om_open_1" },
+    }));
+    const updateCard = vi
+      .fn()
+      .mockResolvedValueOnce({ code: 999, msg: "busy" })
+      .mockResolvedValueOnce({});
+    const streamContent = vi.fn(async (_input: unknown) => ({}));
+    const bus = new RuntimeEventBus<OrchestratedOutboundEventEnvelope>();
+    const runtime = createLarkOutboundRuntime({
+      storage: handle.storage.db,
+      outboundEventBus: bus,
+      clients: {
+        getOrCreate: () =>
+          ({
+            sdk: {
+              cardkit: {
+                v1: {
+                  card: {
+                    create: createCard,
+                    update: updateCard,
+                  },
+                  cardElement: {
+                    content: streamContent,
+                  },
+                },
+              },
+              im: {
+                message: {
+                  create: createMessage,
+                },
+              },
+            },
+          }) as never,
+      },
+    });
+
+    runtime.start();
+
+    bus.publish(
+      makeEnvelope({
+        type: "assistant_message_started",
+        eventId: "evt_update_retry_1",
+        createdAt: "2026-03-28T00:00:00.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        messageId: "msg_1",
+      }),
+    );
+    bus.publish(
+      makeEnvelope({
+        type: "assistant_message_delta",
+        eventId: "evt_update_retry_2",
+        createdAt: "2026-03-28T00:00:01.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        messageId: "msg_1",
+        delta: "hello",
+        accumulatedText: "hello",
+      }),
+    );
+
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(250);
+
+    bus.publish(
+      makeEnvelope({
+        type: "assistant_message_completed",
+        eventId: "evt_update_retry_3",
+        createdAt: "2026-03-28T00:00:02.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        messageId: "msg_1",
+        text: "hello",
+        reasoningText: null,
+        toolCalls: [],
+        usage: null,
+      }),
+    );
+
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(updateCard).toHaveBeenCalledTimes(2);
+    expect(updateCard.mock.calls.at(0)?.[0]).toMatchObject({
+      path: { card_id: "card_1" },
+      data: { sequence: 1 },
+    });
+    expect(updateCard.mock.calls.at(1)?.[0]).toMatchObject({
+      path: { card_id: "card_1" },
+      data: { sequence: 1 },
+    });
+
+    await runtime.shutdown();
+  });
+
   test("updates steer reactions when a queued steer message is consumed", async () => {
     handle = await createTestDatabase(import.meta.url);
     handle.storage.sqlite.exec(`


### PR DESCRIPTION
## Summary
- validate Lark CardKit create/update/content responses for non-zero business codes
- log full response payloads and retry once when CardKit resolves with code != 0
- keep current outbound flow after one retry so card sync issues do not break core runtime behavior
- add outbound regression coverage for non-zero code retries on full update and streaming content

## Testing
- pnpm preflight