### PR TITLE
Unify bash approval parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "croner": "^10.0.1",
     "drizzle-orm": "^0.45.1",
     "openai": "6.26.0",
-    "toml": "^3.0.0"
+    "toml": "^3.0.0",
+    "tree-sitter-bash": "^0.25.1",
+    "web-tree-sitter": "^0.26.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,12 @@ importers:
       toml:
         specifier: ^3.0.0
         version: 3.0.0
+      tree-sitter-bash:
+        specifier: ^0.25.1
+        version: 0.25.1
+      web-tree-sitter:
+        specifier: ^0.26.8
+        version: 0.26.8
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.8
@@ -1809,6 +1815,10 @@ packages:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
 
+  node-addon-api@8.7.0:
+    resolution: {integrity: sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==}
+    engines: {node: ^18 || ^20 || >= 21}
+
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -1817,6 +1827,10 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -2061,6 +2075,14 @@ packages:
   toml@3.0.0:
     resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
 
+  tree-sitter-bash@0.25.1:
+    resolution: {integrity: sha512-7hMytuYIMoXOq24yRulgIxthE9YmggZIOHCyPTTuJcu6EU54tYD+4G39cUb28kxC6jMf/AbPfWGLQtgPTdh3xw==}
+    peerDependencies:
+      tree-sitter: ^0.25.0
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
@@ -2171,6 +2193,9 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  web-tree-sitter@0.26.8:
+    resolution: {integrity: sha512-4sUwi7ZyOrIk5KLgYLkc2A/F0LFMQnBhfb+2Cdl7ik4ePJ6JD+fk4ofI2sA5eGawBKBaK4Vntt7Ww5KcEsay4A==}
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -4020,6 +4045,8 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  node-addon-api@8.7.0: {}
+
   node-domexception@1.0.0: {}
 
   node-fetch@3.3.2:
@@ -4027,6 +4054,8 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-gyp-build@4.8.4: {}
 
   object-inspect@1.13.4: {}
 
@@ -4322,6 +4351,11 @@ snapshots:
 
   toml@3.0.0: {}
 
+  tree-sitter-bash@0.25.1:
+    dependencies:
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+
   ts-algebra@2.0.0: {}
 
   tslib@2.8.1: {}
@@ -4387,6 +4421,8 @@ snapshots:
       - msw
 
   web-streams-polyfill@3.3.3: {}
+
+  web-tree-sitter@0.26.8: {}
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/src/agent/events.ts
+++ b/src/agent/events.ts
@@ -168,6 +168,7 @@ export interface ApprovalRequestedEvent extends AgentRuntimeEventBase {
   approvalFlowId: string;
   approvalAttemptIndex: number;
   approvalTarget: "user" | "main_agent";
+  grantOnApprove?: boolean;
   title: string;
   request: PermissionRequest;
   reasonText: string;

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -1495,6 +1495,7 @@ export class AgentLoop {
           reasonText: error.reasonText,
           ...(error.approvalTitle == null ? {} : { approvalTitle: error.approvalTitle }),
           ...(error.approvalCommand == null ? {} : { approvalCommand: error.approvalCommand }),
+          grantOnApprove: error.grantOnApprove,
           signal: input.signal,
           recordEvent: (event) => this.recordEvent(input.events, event),
           onRequested: ({ approvalId }) => this.markWaitingApproval(input.runId, approvalId),

--- a/src/agent/tool-approval.ts
+++ b/src/agent/tool-approval.ts
@@ -54,6 +54,7 @@ export async function requestToolApproval(input: {
   reasonText: string;
   approvalTitle?: string;
   approvalCommand?: string;
+  grantOnApprove: boolean;
   signal: AbortSignal;
   recordEvent(event: AgentRuntimeEventInput): void;
   onRequested?: (input: { approvalId: number; createdAt: Date; expiresAt: Date }) => void;
@@ -171,6 +172,7 @@ async function requestApprovalRound(input: {
   reasonText: string;
   approvalTitle?: string;
   approvalCommand?: string;
+  grantOnApprove: boolean;
   signal: AbortSignal;
   recordEvent(event: AgentRuntimeEventInput): void;
   onRequested?: (input: { approvalId: number; createdAt: Date; expiresAt: Date }) => void;
@@ -240,6 +242,7 @@ async function requestApprovalRound(input: {
     approvalFlowId: input.approvalFlowId,
     approvalAttemptIndex: input.approvalAttemptIndex,
     approvalTarget: input.approvalTarget,
+    grantOnApprove: input.grantOnApprove,
     title: input.approvalTitle ?? buildApprovalTitle(),
     request: input.request,
     reasonText: input.reasonText,

--- a/src/channels/lark/approval-state.ts
+++ b/src/channels/lark/approval-state.ts
@@ -33,6 +33,7 @@ export interface LarkApprovalState {
   taskRunId: string | null;
   taskRunType: string | null;
   title: string;
+  grantOnApprove: boolean;
   request: PermissionRequest;
   reasonText: string;
   commandText: string | null;
@@ -65,6 +66,7 @@ export function createLarkApprovalStateFromRequest(input: {
     taskRunId: input.taskRunId ?? null,
     taskRunType: input.taskRunType ?? null,
     title: input.event.title,
+    grantOnApprove: input.event.grantOnApprove ?? true,
     request: input.event.request,
     reasonText: input.event.reasonText,
     commandText: input.event.commandText ?? null,
@@ -147,6 +149,7 @@ function onApprovalRequested(
     taskRunId: envelope.taskRun.taskRunId ?? previous.taskRunId,
     taskRunType: envelope.taskRun.runType ?? previous.taskRunType,
     title: envelope.event.title,
+    grantOnApprove: envelope.event.grantOnApprove ?? true,
     request: envelope.event.request,
     reasonText: envelope.event.reasonText,
     commandText: envelope.event.commandText ?? null,

--- a/src/channels/lark/inbound.ts
+++ b/src/channels/lark/inbound.ts
@@ -999,7 +999,9 @@ export function createLarkCardActionHandler(input: {
           ? "deny"
           : normalized.grantTtl === "one_day"
             ? "approve_1d"
-            : "approve_permanent",
+            : normalized.grantTtl === "permanent"
+              ? "approve_permanent"
+              : "approve",
       grantedBy: "user",
       ...(normalized.action === "deny_permission"
         ? {}
@@ -1033,7 +1035,9 @@ export function createLarkCardActionHandler(input: {
             ? "已拒绝"
             : normalized.grantTtl === "one_day"
               ? "已允许 1天"
-              : "已允许 永久",
+              : normalized.grantTtl === "permanent"
+                ? "已允许 永久"
+                : "已允许 本次",
       },
     };
   };

--- a/src/channels/lark/render.ts
+++ b/src/channels/lark/render.ts
@@ -154,51 +154,7 @@ function buildApprovalCardElements(state: LarkApprovalState): Array<Record<strin
   }
 
   elements.push({ tag: "hr" });
-  elements.push({
-    tag: "column_set",
-    flex_mode: "none",
-    horizontal_align: "right",
-    columns: [
-      {
-        tag: "column",
-        width: "auto",
-        elements: [
-          {
-            tag: "button",
-            text: { tag: "plain_text", content: "允许 1天" },
-            type: "default",
-            size: "medium",
-            value: {
-              action: "approve_permission",
-              approvalId: state.currentApprovalId ?? state.approvalId,
-              grantTtl: "one_day",
-            },
-          },
-          {
-            tag: "button",
-            text: { tag: "plain_text", content: "允许 永久" },
-            type: "primary",
-            size: "medium",
-            value: {
-              action: "approve_permission",
-              approvalId: state.currentApprovalId ?? state.approvalId,
-              grantTtl: "permanent",
-            },
-          },
-          {
-            tag: "button",
-            text: { tag: "plain_text", content: "拒绝" },
-            type: "danger",
-            size: "medium",
-            value: {
-              action: "deny_permission",
-              approvalId: state.currentApprovalId ?? state.approvalId,
-            },
-          },
-        ],
-      },
-    ],
-  });
+  elements.push(buildApprovalActionButtons(state));
 
   return elements;
 }
@@ -366,7 +322,7 @@ function buildApprovalCardBodyMarkdown(
   if (state.phase === "approved") {
     return [
       `**操作**：${formatApprovalTitleMarkdown(state.title)}`,
-      ...formatResolvedPermissionLines(state.request),
+      ...formatResolvedPermissionLinesForState(state),
       "",
       `**结果**：${describeApprovalActorLabel(state.actor)}已批准，任务将继续执行。`,
     ].join("\n");
@@ -374,7 +330,7 @@ function buildApprovalCardBodyMarkdown(
 
   return [
     `**操作**：${formatApprovalTitleMarkdown(state.title)}`,
-    ...formatResolvedPermissionLines(state.request),
+    ...formatResolvedPermissionLinesForState(state),
     "",
     `**结果**：${describeDeniedApprovalResult(state.actor)}`,
   ].join("\n");
@@ -448,6 +404,10 @@ function formatHumanLocalTimestamp(isoTimestamp: string): string {
 }
 
 function formatPermissionSummaryLines(state: LarkApprovalState): string[] {
+  if (!state.grantOnApprove) {
+    return [];
+  }
+
   const bashPrefixes = state.request.scopes.flatMap((scope) =>
     scope.kind === "bash.full_access" ? [scope.prefix] : [],
   );
@@ -457,6 +417,14 @@ function formatPermissionSummaryLines(state: LarkApprovalState): string[] {
       commandText: state.commandText,
       prefixes: bashPrefixes,
     });
+  }
+
+  return formatResolvedPermissionLines(state.request);
+}
+
+function formatResolvedPermissionLinesForState(state: LarkApprovalState): string[] {
+  if (!state.grantOnApprove) {
+    return formatApprovalCommandLines(state.commandText);
   }
 
   return formatResolvedPermissionLines(state.request);
@@ -496,6 +464,69 @@ function formatBashPermissionSummaryLines(input: {
   }
 
   return ["", "**授权范围**", ...widerPrefixes.map((prefix) => `- \`${prefix}\``)];
+}
+
+function buildApprovalActionButtons(state: LarkApprovalState): Record<string, unknown> {
+  const approvalId = state.currentApprovalId ?? state.approvalId;
+  const approveValue =
+    state.grantOnApprove === true
+      ? {
+          action: "approve_permission",
+          approvalId,
+          grantTtl: "permanent",
+        }
+      : {
+          action: "approve_permission",
+          approvalId,
+        };
+
+  const approveLabel = state.grantOnApprove ? "允许 永久" : "允许本次";
+  const primaryButtons: Array<Record<string, unknown>> = [];
+
+  if (state.grantOnApprove) {
+    primaryButtons.push({
+      tag: "button",
+      text: { tag: "plain_text", content: "允许 1天" },
+      type: "default",
+      size: "medium",
+      value: {
+        action: "approve_permission",
+        approvalId,
+        grantTtl: "one_day",
+      },
+    });
+  }
+
+  primaryButtons.push({
+    tag: "button",
+    text: { tag: "plain_text", content: approveLabel },
+    type: "primary",
+    size: "medium",
+    value: approveValue,
+  });
+  primaryButtons.push({
+    tag: "button",
+    text: { tag: "plain_text", content: "拒绝" },
+    type: "danger",
+    size: "medium",
+    value: {
+      action: "deny_permission",
+      approvalId,
+    },
+  });
+
+  return {
+    tag: "column_set",
+    flex_mode: "none",
+    horizontal_align: "right",
+    columns: [
+      {
+        tag: "column",
+        width: "auto",
+        elements: primaryButtons,
+      },
+    ],
+  };
 }
 
 function formatRequestedPermissionLines(lines: string[]): string[] {

--- a/src/security/bash-prefix.ts
+++ b/src/security/bash-prefix.ts
@@ -1,49 +1,87 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Language, type Node, Parser } from "web-tree-sitter";
+
+import { createSubsystemLogger } from "@/src/shared/logger.js";
+
+const logger = createSubsystemLogger("security/bash-prefix");
+
+const WEB_TREE_SITTER_WASM_PATH = fileURLToPath(
+  new URL("../../node_modules/web-tree-sitter/web-tree-sitter.wasm", import.meta.url),
+);
+const TREE_SITTER_BASH_WASM_PATH = fileURLToPath(
+  new URL("../../node_modules/tree-sitter-bash/tree-sitter-bash.wasm", import.meta.url),
+);
+
 export interface SimpleBashCommand {
   envAssignments: string[];
   argv: string[];
 }
 
-const ENV_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=.*$/;
-const UNSUPPORTED_UNQUOTED_CHARS = new Set([
-  "|",
-  "&",
-  ";",
-  "(",
-  ")",
-  "<",
-  ">",
-  "\n",
-  "\r",
-  "`",
-  "$",
-]);
+export interface ParsedBashCommandSequence {
+  kind: "simple" | "compound";
+  commands: SimpleBashCommand[];
+}
 
-// This parser is intentionally conservative. It only recognizes a single
-// literal shell command with optional leading KEY=value assignments. Anything
-// more complex falls back to one-shot approval rather than guessing.
+type BashParserState =
+  | {
+      available: true;
+      language: Language;
+    }
+  | {
+      available: false;
+      reason: string;
+    };
+
+const bashParserState = await initializeBashParserState();
+
+export function parseConservativeBashCommandSequence(
+  command: string,
+): ParsedBashCommandSequence | null {
+  if (!bashParserState.available) {
+    return null;
+  }
+
+  const parser = new Parser();
+  parser.setLanguage(bashParserState.language);
+
+  try {
+    const tree = parser.parse(command);
+    if (tree == null) {
+      return null;
+    }
+
+    try {
+      const commands = extractCommandSequence(tree.rootNode);
+      if (commands == null || commands.length === 0) {
+        return null;
+      }
+
+      return {
+        kind: commands.length === 1 ? "simple" : "compound",
+        commands,
+      };
+    } finally {
+      tree.delete();
+    }
+  } catch (error) {
+    logger.warn("failed to parse bash command sequence", {
+      error: error instanceof Error ? error.message : String(error),
+      commandPreview: command.slice(0, 200),
+    });
+    return null;
+  } finally {
+    parser.delete();
+  }
+}
+
 export function parseSimpleBashCommand(command: string): SimpleBashCommand | null {
-  const tokens = tokenizeLiteralShellWords(command);
-  if (tokens == null || tokens.length === 0) {
+  const parsed = parseConservativeBashCommandSequence(command);
+  if (parsed?.kind !== "simple") {
     return null;
   }
 
-  const envAssignments: string[] = [];
-  let argvStart = 0;
-
-  while (argvStart < tokens.length && ENV_ASSIGNMENT_RE.test(tokens[argvStart] ?? "")) {
-    envAssignments.push(tokens[argvStart] as string);
-    argvStart += 1;
-  }
-
-  const argv = tokens.slice(argvStart);
-  if (argv.length === 0) {
-    return null;
-  }
-
-  return {
-    envAssignments,
-    argv,
-  };
+  return parsed.commands[0] ?? null;
 }
 
 export function normalizeBashCommandPrefix(command: string): string[] | null {
@@ -64,88 +102,253 @@ export function bashPrefixMatchesCommand(prefix: string[], commandArgv: string[]
   return true;
 }
 
-function tokenizeLiteralShellWords(command: string): string[] | null {
-  const tokens: string[] = [];
-  let current = "";
-  let quote: "'" | '"' | null = null;
-  let escaping = false;
+async function initializeBashParserState(): Promise<BashParserState> {
+  try {
+    await Parser.init({
+      locateFile(scriptName: string) {
+        if (scriptName === "web-tree-sitter.wasm") {
+          return WEB_TREE_SITTER_WASM_PATH;
+        }
 
-  const pushCurrent = () => {
-    if (current.length === 0) {
-      return;
-    }
-    tokens.push(current);
-    current = "";
-  };
+        return path.join(path.dirname(WEB_TREE_SITTER_WASM_PATH), scriptName);
+      },
+    });
 
-  for (const char of command) {
-    if (quote === "'") {
-      if (char === "'") {
-        quote = null;
-        continue;
+    const language = await Language.load(TREE_SITTER_BASH_WASM_PATH);
+    return {
+      available: true,
+      language,
+    };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    logger.warn("failed to initialize bash parser", { reason });
+    return {
+      available: false,
+      reason,
+    };
+  }
+}
+
+function extractCommandSequence(node: Node): SimpleBashCommand[] | null {
+  switch (node.type) {
+    case "program":
+    case "list":
+    case "pipeline": {
+      const commands: SimpleBashCommand[] = [];
+      for (const child of node.namedChildren) {
+        const extracted = extractCommandSequence(child);
+        if (extracted == null) {
+          return null;
+        }
+        commands.push(...extracted);
       }
-
-      current += char;
-      continue;
+      return commands;
     }
-
-    if (quote === '"') {
-      if (escaping) {
-        current += char;
-        escaping = false;
-        continue;
-      }
-
-      if (char === "\\") {
-        escaping = true;
-        continue;
-      }
-
-      if (char === '"') {
-        quote = null;
-        continue;
-      }
-
-      if (char === "$" || char === "`") {
-        return null;
-      }
-
-      current += char;
-      continue;
+    case "redirected_statement": {
+      return extractRedirectedStatement(node);
     }
-
-    if (escaping) {
-      current += char;
-      escaping = false;
-      continue;
+    case "command": {
+      const command = extractPlainCommand(node);
+      return command == null ? null : [command];
     }
-
-    if (char === "\\") {
-      escaping = true;
-      continue;
-    }
-
-    if (char === "'" || char === '"') {
-      quote = char;
-      continue;
-    }
-
-    if (char.trim().length === 0) {
-      pushCurrent();
-      continue;
-    }
-
-    if (UNSUPPORTED_UNQUOTED_CHARS.has(char) || char === "#") {
+    default:
       return null;
-    }
+  }
+}
 
-    current += char;
+function extractPlainCommand(node: Node): SimpleBashCommand | null {
+  const envAssignments: string[] = [];
+  const argv: string[] = [];
+
+  for (const child of node.namedChildren) {
+    switch (child.type) {
+      case "variable_assignment": {
+        const assignment = extractVariableAssignment(child);
+        if (assignment == null) {
+          return null;
+        }
+        envAssignments.push(assignment);
+        break;
+      }
+      case "command_name":
+      case "word":
+      case "raw_string":
+      case "string":
+      case "number": {
+        const literal = extractLiteralWord(child);
+        if (literal == null) {
+          return null;
+        }
+        argv.push(literal);
+        break;
+      }
+      default:
+        return null;
+    }
   }
 
-  if (quote != null || escaping) {
+  if (argv.length === 0) {
     return null;
   }
 
-  pushCurrent();
-  return tokens;
+  return {
+    envAssignments,
+    argv,
+  };
+}
+
+function extractRedirectedStatement(node: Node): SimpleBashCommand[] | null {
+  const body = node.childForFieldName("body");
+  if (body == null) {
+    return null;
+  }
+
+  const redirects = node.childrenForFieldName("redirect");
+  if (redirects.length === 0) {
+    return null;
+  }
+
+  for (const redirect of redirects) {
+    if (!isSupportedOutputRedirect(redirect)) {
+      return null;
+    }
+  }
+
+  return extractCommandSequence(body);
+}
+
+function extractVariableAssignment(node: Node): string | null {
+  const nameNode = node.childForFieldName("name");
+  if (nameNode == null || nameNode.type !== "variable_name") {
+    return null;
+  }
+
+  const valueNode = node.childForFieldName("value");
+  if (valueNode == null) {
+    return `${nameNode.text}=`;
+  }
+
+  const normalizedValue = extractLiteralWord(valueNode);
+  if (normalizedValue == null) {
+    return null;
+  }
+
+  return `${nameNode.text}=${normalizedValue}`;
+}
+
+function extractLiteralWord(node: Node): string | null {
+  switch (node.type) {
+    case "command_name":
+      return extractCommandName(node);
+    case "word":
+      return containsUnsupportedExpansion(node) ? null : node.text;
+    case "raw_string":
+      return extractRawStringLiteral(node);
+    case "string":
+      return extractStringLiteral(node);
+    case "number":
+      return node.text;
+    default:
+      return null;
+  }
+}
+
+function extractCommandName(node: Node): string | null {
+  if (node.namedChildren.length !== 1) {
+    return null;
+  }
+
+  const [child] = node.namedChildren;
+  return child?.type === "word" && !containsUnsupportedExpansion(child) ? child.text : null;
+}
+
+function extractRawStringLiteral(node: Node): string | null {
+  const text = node.text;
+  if (text.length < 2 || !text.startsWith("'") || !text.endsWith("'")) {
+    return null;
+  }
+
+  return text.slice(1, -1);
+}
+
+function extractStringLiteral(node: Node): string | null {
+  if (containsUnsupportedExpansion(node)) {
+    return null;
+  }
+
+  const allowedChildTypes = new Set(["string_content"]);
+  if (node.namedChildren.some((child) => !allowedChildTypes.has(child.type))) {
+    return null;
+  }
+
+  return node.namedChildren.map((child) => child.text).join("");
+}
+
+function isSupportedOutputRedirect(node: Node): boolean {
+  if (node.type !== "file_redirect") {
+    return false;
+  }
+
+  const operator = readRedirectOperator(node);
+  if (operator == null) {
+    return false;
+  }
+
+  switch (operator) {
+    case ">":
+    case ">>":
+    case ">|":
+    case "&>":
+    case "&>>":
+      return hasLiteralRedirectDestination(node);
+    case ">&":
+      return isFileDescriptorDuplication(node);
+    default:
+      return false;
+  }
+}
+
+function readRedirectOperator(node: Node): string | null {
+  for (let index = 0; index < node.childCount; index += 1) {
+    const child = node.child(index);
+    if (child == null || child.isNamed) {
+      continue;
+    }
+
+    return child.text;
+  }
+
+  return null;
+}
+
+function hasLiteralRedirectDestination(node: Node): boolean {
+  const destination = node.childrenForFieldName("destination");
+  if (destination.length === 0) {
+    return false;
+  }
+
+  return destination.every((entry) => extractLiteralWord(entry) != null);
+}
+
+function isFileDescriptorDuplication(node: Node): boolean {
+  const destination = node.childrenForFieldName("destination");
+  if (destination.length !== 1) {
+    return false;
+  }
+
+  return destination[0]?.type === "number";
+}
+
+function containsUnsupportedExpansion(node: Node): boolean {
+  if (
+    node.type === "command_substitution" ||
+    node.type === "process_substitution" ||
+    node.type === "simple_expansion" ||
+    node.type === "expansion" ||
+    node.type === "subshell"
+  ) {
+    return true;
+  }
+
+  return node.namedChildren.some((child) => containsUnsupportedExpansion(child));
 }

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -3,6 +3,8 @@ import { type Static, Type } from "@sinclair/typebox";
 import {
   bashPrefixMatchesCommand,
   normalizeBashCommandPrefix,
+  type ParsedBashCommandSequence,
+  parseConservativeBashCommandSequence,
 } from "@/src/security/bash-prefix.js";
 import { buildSystemPolicy } from "@/src/security/policy.js";
 import { executeSandboxedBash, executeUnsandboxedBash } from "@/src/security/sandbox.js";
@@ -108,7 +110,14 @@ export function createBashTool() {
         context.storage,
         buildSystemPolicy({ security: context.securityConfig }),
       );
-      const normalizedCommandPrefix = normalizeBashCommandPrefix(args.command);
+      const parsedCommandSequence =
+        sandboxMode === "full_access"
+          ? await parseConservativeBashCommandSequence(args.command)
+          : null;
+      const normalizedCommandPrefix =
+        parsedCommandSequence?.kind === "simple"
+          ? (parsedCommandSequence.commands[0]?.argv ?? null)
+          : normalizeBashCommandPrefix(args.command);
 
       const result =
         sandboxMode === "full_access"
@@ -118,6 +127,7 @@ export function createBashTool() {
               timeoutMs,
               security,
               normalizedCommandPrefix,
+              parsedCommandSequence,
             })
           : await executeSandboxedBash({
               context,
@@ -177,6 +187,7 @@ async function executeBashWithFullAccessIfAllowed(input: {
   timeoutMs: number;
   security: SecurityService;
   normalizedCommandPrefix: string[] | null;
+  parsedCommandSequence: ParsedBashCommandSequence | null;
 }) {
   const justification = input.args.justification?.trim();
   if (justification == null || justification.length === 0) {
@@ -215,12 +226,15 @@ async function executeBashWithFullAccessIfAllowed(input: {
     });
   }
 
-  if (input.normalizedCommandPrefix != null) {
-    const access = input.security.checkBashFullAccess({
-      ownerAgentId,
-      commandPrefix: input.normalizedCommandPrefix,
+  if (input.parsedCommandSequence != null) {
+    const hasFullAccess = input.parsedCommandSequence.commands.every((command) => {
+      const access = input.security.checkBashFullAccess({
+        ownerAgentId,
+        commandPrefix: command.argv,
+      });
+      return access.result === "allow";
     });
-    if (access.result === "allow") {
+    if (hasFullAccess) {
       return await executeUnsandboxedBash({
         context: input.context,
         command: input.args.command,

--- a/tests/security/bash-command-parser.test.ts
+++ b/tests/security/bash-command-parser.test.ts
@@ -19,6 +19,22 @@ describe("parseConservativeBashCommandSequence", () => {
     });
   });
 
+  test("parses single-quoted raw string arguments", () => {
+    expect(
+      parseConservativeBashCommandSequence(
+        "python -m agent_browser_cli --url 'https://example.com'",
+      ),
+    ).toEqual({
+      kind: "simple",
+      commands: [
+        {
+          envAssignments: [],
+          argv: ["python", "-m", "agent_browser_cli", "--url", "https://example.com"],
+        },
+      ],
+    });
+  });
+
   test("parses compound commands and preserves each subcommand argv", () => {
     expect(parseConservativeBashCommandSequence("npm test && echo done | cat")).toEqual({
       kind: "compound",

--- a/tests/security/bash-command-parser.test.ts
+++ b/tests/security/bash-command-parser.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "vitest";
+
+import { parseConservativeBashCommandSequence } from "@/src/security/bash-prefix.js";
+
+describe("parseConservativeBashCommandSequence", () => {
+  test("parses a simple command with env assignments and quoted literals", () => {
+    expect(
+      parseConservativeBashCommandSequence(
+        'FOO=1 BAR=two python -m agent_browser_cli --url "https://example.com"',
+      ),
+    ).toEqual({
+      kind: "simple",
+      commands: [
+        {
+          envAssignments: ["FOO=1", "BAR=two"],
+          argv: ["python", "-m", "agent_browser_cli", "--url", "https://example.com"],
+        },
+      ],
+    });
+  });
+
+  test("parses compound commands and preserves each subcommand argv", () => {
+    expect(parseConservativeBashCommandSequence("npm test && echo done | cat")).toEqual({
+      kind: "compound",
+      commands: [
+        {
+          envAssignments: [],
+          argv: ["npm", "test"],
+        },
+        {
+          envAssignments: [],
+          argv: ["echo", "done"],
+        },
+        {
+          envAssignments: [],
+          argv: ["cat"],
+        },
+      ],
+    });
+  });
+
+  test("accepts supported output redirections without changing argv extraction", () => {
+    expect(
+      parseConservativeBashCommandSequence(
+        "agent-browser snapshot -s main > /tmp/browser.txt 2>&1",
+      ),
+    ).toEqual({
+      kind: "simple",
+      commands: [
+        {
+          envAssignments: [],
+          argv: ["agent-browser", "snapshot", "-s", "main"],
+        },
+      ],
+    });
+  });
+
+  test("rejects unsupported shell expansions", () => {
+    expect(parseConservativeBashCommandSequence("FOO=$BAR npm test")).toBeNull();
+    expect(parseConservativeBashCommandSequence("npm run $(cat cmd.txt)")).toBeNull();
+    expect(parseConservativeBashCommandSequence('echo "$' + "{HOME}" + '"')).toBeNull();
+  });
+
+  test("rejects unsupported input-side redirections", () => {
+    expect(parseConservativeBashCommandSequence("cat < input.txt")).toBeNull();
+    expect(parseConservativeBashCommandSequence("cat <<EOF\nhello\nEOF")).toBeNull();
+  });
+});

--- a/tests/tools/bash.test.ts
+++ b/tests/tools/bash.test.ts
@@ -635,6 +635,95 @@ Use this exact bash argument object on the next retry if full access is warrante
     });
   });
 
+  test("uses existing bash full-access grants for every parsed subcommand in a compound command", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+    new SecurityService(handle.storage.db).grantScopes({
+      ownerAgentId: "agent_1",
+      grantedBy: "user",
+      scopes: [{ kind: "bash.full_access", prefix: ["agent-browser"] }],
+    });
+    executeUnsandboxedBashMock.mockResolvedValue({
+      command:
+        "agent-browser open https://example.com && agent-browser wait 2500 && agent-browser snapshot -s main > /tmp/browser.txt",
+      cwd: "/tmp/work",
+      timeoutMs: 10_000,
+      stdout: "ok\n",
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    });
+
+    const registry = new ToolRegistry([createBashTool()]);
+    const result = await registry.execute(
+      "bash",
+      {
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        ownerAgentId: "agent_1",
+        cwd: "/tmp/work",
+        securityConfig: DEFAULT_CONFIG.security,
+        storage: handle.storage.db,
+      },
+      {
+        command:
+          "agent-browser open https://example.com && agent-browser wait 2500 && agent-browser snapshot -s main > /tmp/browser.txt",
+        sandboxMode: "full_access",
+        justification: "Need to browse the requested page and save the captured output.",
+      },
+    );
+
+    expect(executeUnsandboxedBashMock).toHaveBeenCalledTimes(1);
+    expect(executeSandboxedBashMock).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({
+      command:
+        "agent-browser open https://example.com && agent-browser wait 2500 && agent-browser snapshot -s main > /tmp/browser.txt",
+      cwd: "/tmp/work",
+      exitCode: 0,
+    });
+  });
+
+  test("still requests approval when a compound command is only partially covered by existing grants", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+    new SecurityService(handle.storage.db).grantScopes({
+      ownerAgentId: "agent_1",
+      grantedBy: "user",
+      scopes: [{ kind: "bash.full_access", prefix: ["agent-browser", "open"] }],
+    });
+
+    const registry = new ToolRegistry([createBashTool()]);
+
+    await expect(
+      registry.execute(
+        "bash",
+        {
+          sessionId: "sess_1",
+          conversationId: "conv_1",
+          ownerAgentId: "agent_1",
+          cwd: "/tmp/work",
+          securityConfig: DEFAULT_CONFIG.security,
+          storage: handle.storage.db,
+        },
+        {
+          command:
+            "agent-browser open https://example.com && agent-browser wait 2500 && agent-browser snapshot -s main > /tmp/browser.txt",
+          sandboxMode: "full_access",
+          justification: "Need to browse the requested page and save the captured output.",
+        },
+      ),
+    ).rejects.toMatchObject({
+      name: "ToolApprovalRequired",
+      grantOnApprove: false,
+      approvalTitle: "Approval required: run bash command with full access",
+      request: {
+        scopes: [{ kind: "bash.full_access", prefix: ["bash", "-lc"] }],
+      },
+    });
+
+    expect(executeUnsandboxedBashMock).not.toHaveBeenCalled();
+  });
+
   test("rejects reusable full-access prefixes for complex shell commands", async () => {
     handle = await createTestDatabase(import.meta.url);
     seedConversationAndAgentFixture(handle);


### PR DESCRIPTION
## Summary

- unify bash approval parsing onto the tree-sitter-based parser path
- allow full_access chained commands to reuse existing bash prefix grants when every parsed subcommand is covered
- fix one-shot bash approval UI semantics so non-persistent approvals show `允许本次` instead of remember-style buttons

## Details

- replace the hand-rolled simple-command parser with the unified conservative parser in `src/security/bash-prefix.ts`
- teach `src/tools/bash.ts` to evaluate parsed subcommands for existing `bash.full_access` grants before requesting approval
- thread `grantOnApprove` through approval events/state so Lark rendering can distinguish one-shot approvals from durable prefix approvals
- update approval rendering to stop exposing misleading remember-style actions for non-persistent bash approvals
- add `web-tree-sitter` and `tree-sitter-bash` dependencies for the parser implementation

## Validation

- `pnpm preflight`
