### PR TITLE
Add YOLO and autopilot runtime modes

### DIFF
--- a/src/agent/approval-round.ts
+++ b/src/agent/approval-round.ts
@@ -1,0 +1,25 @@
+import type { ApprovalRecord } from "@/src/storage/schema/types.js";
+
+export function parseApprovalResumeRunId(approval: ApprovalRecord | null): string | null {
+  if (approval?.resumePayloadJson == null || approval.resumePayloadJson.length === 0) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(approval.resumePayloadJson) as { runId?: unknown };
+    return typeof parsed.runId === "string" && parsed.runId.length > 0 ? parsed.runId : null;
+  } catch {
+    return null;
+  }
+}
+
+export function approvalBelongsToActiveRound(
+  approval: ApprovalRecord,
+  activeRunId: string | null,
+): boolean {
+  if (activeRunId == null) {
+    return true;
+  }
+
+  return parseApprovalResumeRunId(approval) === activeRunId;
+}

--- a/src/agent/events.ts
+++ b/src/agent/events.ts
@@ -187,6 +187,23 @@ export interface ApprovalResolvedEvent extends AgentRuntimeEventBase {
   flowContinues?: boolean;
 }
 
+export type RuntimeNudgeAnchor = {
+  type: "approval_flow";
+  id: string;
+};
+
+export interface RuntimeNudge {
+  kind: "yolo_suggestion";
+  message: string;
+}
+
+export interface RuntimeNudgeEvent extends AgentRuntimeEventBase {
+  type: "runtime_nudge";
+  ownerAgentId: string;
+  anchor: RuntimeNudgeAnchor;
+  nudge: RuntimeNudge;
+}
+
 export interface SteerMessageConsumedEvent extends AgentRuntimeEventBase {
   type: "steer_message_consumed";
   turn: number;
@@ -214,6 +231,7 @@ export type AgentRuntimeEvent =
   | CompactionFailedEvent
   | ApprovalRequestedEvent
   | ApprovalResolvedEvent
+  | RuntimeNudgeEvent
   | SteerMessageConsumedEvent;
 
 export type AgentRuntimeEventInput =
@@ -236,4 +254,5 @@ export type AgentRuntimeEventInput =
   | Omit<CompactionFailedEvent, "eventId" | "createdAt">
   | Omit<ApprovalRequestedEvent, "eventId" | "createdAt">
   | Omit<ApprovalResolvedEvent, "eventId" | "createdAt">
+  | Omit<RuntimeNudgeEvent, "eventId" | "createdAt">
   | Omit<SteerMessageConsumedEvent, "eventId" | "createdAt">;

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -7,6 +7,10 @@
  */
 import { randomUUID } from "node:crypto";
 import {
+  approvalBelongsToActiveRound,
+  parseApprovalResumeRunId,
+} from "@/src/agent/approval-round.js";
+import {
   type AgentBootstrapResolver,
   FilesystemAgentBootstrapResolver,
 } from "@/src/agent/bootstrap.js";
@@ -48,6 +52,10 @@ import {
 import { buildAgentSystemPrompt } from "@/src/agent/system-prompt.js";
 import { requestToolApproval } from "@/src/agent/tool-approval.js";
 import {
+  buildApprovedToolExecutionState,
+  buildRuntimeModeToolExecutionState,
+} from "@/src/agent/tool-approval-state.js";
+import {
   DEFAULT_RUNTIME_APPROVAL_GRANT_TTL_MS,
   DEFAULT_RUNTIME_APPROVAL_TIMEOUT_MS,
   DEFAULT_RUNTIME_MAX_TURNS,
@@ -61,6 +69,7 @@ import {
 } from "@/src/runtime/approval-waits.js";
 import type { SessionRunAbortRegistry } from "@/src/runtime/cancel.js";
 import type { RuntimeControlService } from "@/src/runtime/control.js";
+import type { RuntimeModeService } from "@/src/runtime/runtime-modes.js";
 import { SessionSteerQueueRegistry, type SteerInput } from "@/src/runtime/steer-queue.js";
 import { buildSystemPolicy } from "@/src/security/policy.js";
 import type { PermissionRequest } from "@/src/security/scope.js";
@@ -209,6 +218,7 @@ export interface AgentLoopDependencies {
   securityConfig: SecurityConfig;
   compaction: CompactionConfig;
   runtime?: RuntimeConfig;
+  runtimeModes?: RuntimeModeService;
   approvalTimeoutMs?: number;
   approvalGrantTtlMs?: number;
   approvalFlow?: SessionApprovalFlowRegistry;
@@ -222,6 +232,7 @@ interface ExecutedToolCall {
   isError: boolean;
   queuedSteer: SteerInput[];
   stopRemainingToolBatch: boolean;
+  approvalState?: ToolExecutionApprovalState;
 }
 
 export class AgentLoop {
@@ -571,6 +582,9 @@ export class AgentLoop {
       });
 
       let completed = false;
+      let runApprovalState = buildRuntimeModeToolExecutionState(
+        this.deps.runtimeModes?.getEffectiveApprovalMode(context.session.ownerAgentId),
+      );
       for (let turn = 0; turn < maxTurns; turn += 1) {
         throwIfAborted(handle.signal);
         let turnToolExecutions = 0;
@@ -1026,9 +1040,13 @@ export class AgentLoop {
               runId,
               events,
               signal: handle.signal,
+              ...(runApprovalState == null ? {} : { approvalState: runApprovalState }),
             });
 
             throwIfAborted(handle.signal);
+            if (executedTool.approvalState != null) {
+              runApprovalState = executedTool.approvalState;
+            }
 
             const toolResultMessageId = randomUUID();
             const toolResultMessage = appendMessageAndHydrate({
@@ -1443,9 +1461,10 @@ export class AgentLoop {
     runId: string;
     events: AgentRuntimeEvent[];
     signal: AbortSignal;
+    approvalState?: ToolExecutionApprovalState;
   }): Promise<ExecutedToolCall> {
     const queuedSteer: SteerInput[] = [];
-    let approvalState: ToolExecutionApprovalState | undefined;
+    let approvalState: ToolExecutionApprovalState | undefined = input.approvalState;
 
     while (true) {
       try {
@@ -1475,6 +1494,7 @@ export class AgentLoop {
           isError: false,
           queuedSteer,
           stopRemainingToolBatch: false,
+          ...(approvalState == null ? {} : { approvalState }),
         };
       } catch (error) {
         if (!isToolApprovalRequired(error)) {
@@ -1486,6 +1506,7 @@ export class AgentLoop {
           security: this.security,
           approvalWaits: this.approvalWaits,
           approvalFlow: this.approvalFlow,
+          ...(this.deps.runtimeModes == null ? {} : { runtimeModes: this.deps.runtimeModes }),
           sessions: this.deps.sessions,
           approvalTimeoutMs: this.approvalTimeoutMs,
           runInput: input.input,
@@ -1506,7 +1527,14 @@ export class AgentLoop {
 
         if (approval.decision === "approve") {
           queuedSteer.push(...approval.queuedSteer);
-          if (error.grantOnApprove) {
+          const nextApprovalState = buildApprovedToolExecutionState({
+            request: approval.request,
+            approvalId: approval.approvalId,
+            skippedHumanApproval: approval.skippedHumanApproval === true,
+            ...(error.approvalState == null ? {} : { baseState: error.approvalState }),
+          });
+
+          if (error.grantOnApprove && approval.skippedHumanApproval !== true) {
             const grantedBy = approval.grantedBy ?? "user";
             const grantExpiresAt =
               approval.expiresAt === undefined
@@ -1529,13 +1557,14 @@ export class AgentLoop {
             });
           }
 
-          approvalState = error.approvalState;
+          approvalState = nextApprovalState;
           this.markToolRunning(input.runId, input.toolCall);
 
           if (input.toolCall.name === "request_permissions") {
             return await this.finishPermissionRequestAfterApproval({
               input,
               approval,
+              ...(nextApprovalState == null ? {} : { approvalState: nextApprovalState }),
               queuedSteer,
               ...(error.retryToolCallId == null ? {} : { retryToolCallId: error.retryToolCallId }),
             });
@@ -1588,6 +1617,7 @@ export class AgentLoop {
           isError: true,
           queuedSteer: [...queuedSteer, ...approval.queuedSteer],
           stopRemainingToolBatch: approval.actor === "user:intervention",
+          ...(approvalState == null ? {} : { approvalState }),
         };
       }
     }
@@ -1606,6 +1636,7 @@ export class AgentLoop {
       signal: AbortSignal;
     };
     approval: ApprovalWaitOutcome & { approvalId: number; request: PermissionRequest };
+    approvalState?: ToolExecutionApprovalState;
     queuedSteer: SteerInput[];
     retryToolCallId?: string;
   }): Promise<ExecutedToolCall> {
@@ -1630,6 +1661,7 @@ export class AgentLoop {
         isError: false,
         queuedSteer: input.queuedSteer,
         stopRemainingToolBatch: false,
+        ...(input.approvalState == null ? {} : { approvalState: input.approvalState }),
       };
     }
 
@@ -1656,6 +1688,7 @@ export class AgentLoop {
         isError: true,
         queuedSteer: input.queuedSteer,
         stopRemainingToolBatch: false,
+        ...(input.approvalState == null ? {} : { approvalState: input.approvalState }),
       };
     }
 
@@ -1684,6 +1717,7 @@ export class AgentLoop {
           ...(input.input.ownerAgent?.workdir == null
             ? {}
             : { cwd: input.input.ownerAgent.workdir }),
+          ...(input.approvalState == null ? {} : { approvalState: input.approvalState }),
         }),
         retryTarget.args,
       );
@@ -1719,6 +1753,7 @@ export class AgentLoop {
         isError: false,
         queuedSteer: input.queuedSteer,
         stopRemainingToolBatch: false,
+        ...(input.approvalState == null ? {} : { approvalState: input.approvalState }),
       };
     } catch (error) {
       const failure = normalizeToolFailure(error);
@@ -1766,6 +1801,7 @@ export class AgentLoop {
         isError: true,
         queuedSteer: input.queuedSteer,
         stopRemainingToolBatch: false,
+        ...(input.approvalState == null ? {} : { approvalState: input.approvalState }),
       };
     }
   }
@@ -1907,30 +1943,6 @@ export class AgentLoop {
       createdAt: input.decidedAt,
     });
   }
-}
-
-function parseApprovalResumeRunId(approval: ApprovalRecord | null): string | null {
-  if (approval?.resumePayloadJson == null || approval.resumePayloadJson.length === 0) {
-    return null;
-  }
-
-  try {
-    const parsed = JSON.parse(approval.resumePayloadJson) as { runId?: unknown };
-    return typeof parsed.runId === "string" && parsed.runId.length > 0 ? parsed.runId : null;
-  } catch {
-    return null;
-  }
-}
-
-function approvalBelongsToActiveRound(
-  approval: ApprovalRecord,
-  activeRunId: string | null,
-): boolean {
-  if (activeRunId == null) {
-    return true;
-  }
-
-  return parseApprovalResumeRunId(approval) === activeRunId;
 }
 
 function buildAbortedToolBatchResult(): ToolResult {

--- a/src/agent/tool-approval-state.ts
+++ b/src/agent/tool-approval-state.ts
@@ -1,0 +1,69 @@
+import type { EffectiveApprovalMode } from "@/src/runtime/runtime-modes.js";
+import type { PermissionRequest, PermissionScope } from "@/src/security/scope.js";
+import type { ToolExecutionApprovalState } from "@/src/tools/core/types.js";
+
+export function buildRuntimeModeToolExecutionState(
+  mode: EffectiveApprovalMode | undefined,
+): ToolExecutionApprovalState | undefined {
+  if (mode?.skipHumanApproval !== true || mode.source === "normal") {
+    return undefined;
+  }
+
+  return {
+    runtimeModeAutoApproval: {
+      source: mode.source,
+    },
+  };
+}
+
+export function buildApprovedToolExecutionState(input: {
+  baseState?: ToolExecutionApprovalState;
+  request: PermissionRequest;
+  approvalId: number;
+  skippedHumanApproval: boolean;
+}): ToolExecutionApprovalState | undefined {
+  if (!input.skippedHumanApproval) {
+    return input.baseState;
+  }
+
+  const nextState: ToolExecutionApprovalState = {
+    ...(input.baseState ?? {}),
+  };
+  const ephemeralScopes = input.request.scopes.filter((scope) => scope.kind !== "bash.full_access");
+  if (ephemeralScopes.length > 0) {
+    nextState.ephemeralPermissionScopes = dedupePermissionScopes([
+      ...(input.baseState?.ephemeralPermissionScopes ?? []),
+      ...ephemeralScopes,
+    ]);
+  }
+
+  if (input.request.scopes.some((scope) => scope.kind === "bash.full_access")) {
+    nextState.bashFullAccess = {
+      approved: true,
+      mode: "one_shot",
+      approvalId: input.approvalId,
+    };
+  }
+
+  return nextState;
+}
+
+function dedupePermissionScopes(scopes: PermissionScope[]): PermissionScope[] {
+  const unique = new Map<string, PermissionScope>();
+
+  for (const scope of scopes) {
+    if ("path" in scope) {
+      unique.set(`${scope.kind}:${scope.path}`, scope);
+      continue;
+    }
+
+    if ("prefix" in scope) {
+      unique.set(`${scope.kind}:${scope.prefix.join("\u0000")}`, scope);
+      continue;
+    }
+
+    unique.set(`${scope.kind}:${scope.database}`, scope);
+  }
+
+  return [...unique.values()];
+}

--- a/src/agent/tool-approval.ts
+++ b/src/agent/tool-approval.ts
@@ -17,6 +17,11 @@ import type {
   ApprovalWaitOutcome,
   SessionApprovalWaitRegistry,
 } from "@/src/runtime/approval-waits.js";
+import type {
+  EffectiveApprovalModeSource,
+  RuntimeModeService,
+} from "@/src/runtime/runtime-modes.js";
+import { YOLO_SUGGESTION_MESSAGE } from "@/src/runtime/runtime-modes.js";
 import { describePermissionScope, type PermissionRequest } from "@/src/security/scope.js";
 import type { SecurityService } from "@/src/security/service.js";
 import { createSubsystemLogger } from "@/src/shared/logger.js";
@@ -45,6 +50,7 @@ export async function requestToolApproval(input: {
   };
   approvalTimeoutMs: number;
   approvalFlow: SessionApprovalFlowRegistry;
+  runtimeModes?: RuntimeModeService;
   runInput: RunAgentLoopInput;
   session: Session;
   toolCall: AgentToolCall;
@@ -58,7 +64,14 @@ export async function requestToolApproval(input: {
   signal: AbortSignal;
   recordEvent(event: AgentRuntimeEventInput): void;
   onRequested?: (input: { approvalId: number; createdAt: Date; expiresAt: Date }) => void;
-}): Promise<ApprovalWaitOutcome & { approvalId: number; request: PermissionRequest }> {
+}): Promise<
+  ApprovalWaitOutcome & {
+    approvalId: number;
+    request: PermissionRequest;
+    skippedHumanApproval?: boolean;
+    approvalModeSource?: EffectiveApprovalModeSource;
+  }
+> {
   const approvalRoute = resolveApprovalRouteForSession({
     db: input.storage,
     session: input.session,
@@ -71,6 +84,17 @@ export async function requestToolApproval(input: {
     sessionId: input.runInput.sessionId,
     route: approvalRoute,
   });
+  const effectiveMode = input.runtimeModes?.getEffectiveApprovalMode(input.session.ownerAgentId);
+
+  if (effectiveMode?.skipHumanApproval === true) {
+    return approveWithoutHumanApproval({
+      ...input,
+      approvalFlowId,
+      approvalAttemptIndex: 1,
+      approvalTarget: approvalPlan.initialTarget,
+      effectiveMode,
+    });
+  }
 
   let currentApprovalId: number | null = null;
   input.sessions.updateStatus({
@@ -155,6 +179,87 @@ function buildApprovalTitle(): string {
   return "Approval required";
 }
 
+function approveWithoutHumanApproval(input: {
+  security: SecurityService;
+  approvalTimeoutMs: number;
+  runInput: RunAgentLoopInput;
+  session: Session;
+  toolCall: AgentToolCall;
+  turn: number;
+  runId: string;
+  request: PermissionRequest;
+  reasonText: string;
+  approvalFlowId: string;
+  approvalAttemptIndex: number;
+  approvalTarget: "user" | "main_agent";
+  effectiveMode: ReturnType<RuntimeModeService["getEffectiveApprovalMode"]>;
+}): ApprovalWaitOutcome & {
+  approvalId: number;
+  request: PermissionRequest;
+  approvalTarget: "user" | "main_agent";
+  skippedHumanApproval: true;
+  approvalModeSource: EffectiveApprovalModeSource;
+} {
+  const createdAt = new Date();
+  const expiresAt = new Date(createdAt.getTime() + input.approvalTimeoutMs);
+  const approvalId = input.security.createApprovalRequest({
+    ownerAgentId: input.session.ownerAgentId ?? "",
+    requestedBySessionId: input.runInput.sessionId,
+    request: input.request,
+    approvalTarget: input.approvalTarget,
+    reasonText: input.reasonText,
+    createdAt,
+    expiresAt,
+    resumePayloadJson: buildApprovalResumePayloadJson(input),
+  });
+  const decidedAt = new Date();
+  const actor = `system:${input.effectiveMode.source}`;
+  const reasonText =
+    input.effectiveMode.source === "autopilot"
+      ? "Skipped human approval because Autopilot is active."
+      : "Skipped human approval because YOLO mode is active.";
+
+  logger.info("approval skipped by runtime mode without user-visible approval event", {
+    sessionId: input.runInput.sessionId,
+    approvalId,
+    toolName: input.toolCall.name,
+    actor,
+    mode: input.effectiveMode.source,
+    runId: input.runId,
+    approvalFlowId: input.approvalFlowId,
+    approvalAttemptIndex: input.approvalAttemptIndex,
+  });
+
+  return {
+    decision: "approve",
+    actor,
+    rawInput: null,
+    grantedBy: null,
+    reasonText,
+    decidedAt,
+    queuedSteer: [],
+    approvalId,
+    request: input.request,
+    approvalTarget: input.approvalTarget,
+    skippedHumanApproval: true,
+    approvalModeSource: input.effectiveMode.source,
+  };
+}
+
+function buildApprovalResumePayloadJson(input: {
+  toolCall: AgentToolCall;
+  turn: number;
+  runId: string;
+}): string {
+  return JSON.stringify({
+    toolCallId: input.toolCall.id,
+    toolName: input.toolCall.name,
+    toolArgs: input.toolCall.args,
+    turn: input.turn,
+    runId: input.runId,
+  } satisfies ApprovalResumePayload);
+}
+
 async function requestApprovalRound(input: {
   storage: import("@/src/storage/db/client.js").StorageDb;
   security: SecurityService;
@@ -176,6 +281,7 @@ async function requestApprovalRound(input: {
   signal: AbortSignal;
   recordEvent(event: AgentRuntimeEventInput): void;
   onRequested?: (input: { approvalId: number; createdAt: Date; expiresAt: Date }) => void;
+  runtimeModes?: RuntimeModeService;
   approvalRoute: ReturnType<typeof resolveApprovalRouteForSession>;
   approvalFlowId: string;
   approvalAttemptIndex: number;
@@ -187,17 +293,13 @@ async function requestApprovalRound(input: {
     approvalId: number;
     request: PermissionRequest;
     approvalTarget: "user" | "main_agent";
+    skippedHumanApproval?: boolean;
+    approvalModeSource?: EffectiveApprovalModeSource;
   }
 > {
   const createdAt = new Date();
   const expiresAt = new Date(createdAt.getTime() + input.approvalTimeoutMs);
-  const resumePayloadJson = JSON.stringify({
-    toolCallId: input.toolCall.id,
-    toolName: input.toolCall.name,
-    toolArgs: input.toolCall.args,
-    turn: input.turn,
-    runId: input.runId,
-  } satisfies ApprovalResumePayload);
+  const resumePayloadJson = buildApprovalResumePayloadJson(input);
   const approvalId = input.security.createApprovalRequest({
     ownerAgentId: input.session.ownerAgentId ?? "",
     requestedBySessionId: input.runInput.sessionId,
@@ -230,12 +332,6 @@ async function requestApprovalRound(input: {
     expiresAt,
   });
 
-  const waitPromise = input.approvalWaits.beginWait({
-    sessionId: input.runInput.sessionId,
-    approvalId,
-    timeoutMs: input.approvalTimeoutMs,
-  });
-
   input.recordEvent({
     type: "approval_requested",
     approvalId: String(approvalId),
@@ -252,6 +348,39 @@ async function requestApprovalRound(input: {
     conversationId: input.session.conversationId,
     branchId: input.session.branchId,
     runId: input.runId,
+  });
+
+  const ownerAgentId = input.session.ownerAgentId;
+  if (
+    input.runtimeModes?.recordApprovalRequestForYoloSuggestion({
+      ownerAgentId,
+      approvalTarget: input.approvalTarget,
+      requestedAt: createdAt,
+    }) === true &&
+    ownerAgentId != null
+  ) {
+    input.recordEvent({
+      type: "runtime_nudge",
+      ownerAgentId,
+      anchor: {
+        type: "approval_flow",
+        id: input.approvalFlowId,
+      },
+      nudge: {
+        kind: "yolo_suggestion",
+        message: YOLO_SUGGESTION_MESSAGE,
+      },
+      sessionId: input.runInput.sessionId,
+      conversationId: input.session.conversationId,
+      branchId: input.session.branchId,
+      runId: input.runId,
+    });
+  }
+
+  const waitPromise = input.approvalWaits.beginWait({
+    sessionId: input.runInput.sessionId,
+    approvalId,
+    timeoutMs: input.approvalTimeoutMs,
   });
 
   const outcome = await waitPromise;

--- a/src/channels/help.ts
+++ b/src/channels/help.ts
@@ -30,6 +30,10 @@ const SLASH_COMMANDS: SlashCommandHelpEntry[] = [
     command: "/stop",
     description: "Stop the current conversation or session.",
   },
+  {
+    command: "/yolo",
+    description: "Toggle YOLO mode for this agent.",
+  },
 ];
 
 export function buildSlashCommandHelpPresentation(

--- a/src/channels/lark/approval-state.ts
+++ b/src/channels/lark/approval-state.ts
@@ -5,7 +5,12 @@
  * attempts so channel rendering can present a stable card even when a task
  * approval times out and falls back to delegated review.
  */
-import type { ApprovalRequestedEvent, ApprovalResolvedEvent } from "@/src/agent/events.js";
+import type {
+  ApprovalRequestedEvent,
+  ApprovalResolvedEvent,
+  RuntimeNudge,
+  RuntimeNudgeEvent,
+} from "@/src/agent/events.js";
 import type { OrchestratedRuntimeEventEnvelope } from "@/src/orchestration/outbound-events.js";
 import type { PermissionRequest } from "@/src/security/scope.js";
 
@@ -22,6 +27,11 @@ export interface LarkApprovalAttemptState {
   approvalTarget: "user" | "main_agent";
   status: "pending" | "timed_out" | "approved" | "denied";
   actor: string | null;
+}
+
+export interface LarkApprovalRuntimeNudge {
+  kind: RuntimeNudge["kind"];
+  message: string;
 }
 
 export interface LarkApprovalState {
@@ -47,6 +57,7 @@ export interface LarkApprovalState {
   decision: "approve" | "deny" | null;
   actor: string | null;
   sourceRunCardObjectId: string | null;
+  runtimeNudges: LarkApprovalRuntimeNudge[];
 }
 
 export function createLarkApprovalStateFromRequest(input: {
@@ -88,6 +99,7 @@ export function createLarkApprovalStateFromRequest(input: {
     decision: null,
     actor: null,
     sourceRunCardObjectId: input.sourceRunCardObjectId,
+    runtimeNudges: [],
   };
 }
 
@@ -121,6 +133,37 @@ export function shouldHandleLarkApprovalRuntimeEvent(
   return (
     envelope.event.type === "approval_requested" || envelope.event.type === "approval_resolved"
   );
+}
+
+export function addLarkApprovalRuntimeNudge(
+  state: LarkApprovalState,
+  event: RuntimeNudgeEvent,
+): LarkApprovalState {
+  if (
+    event.anchor.type !== "approval_flow" ||
+    event.anchor.id !== state.flowId ||
+    state.phase !== "waiting_user" ||
+    state.currentApprovalId == null ||
+    state.resolved
+  ) {
+    return state;
+  }
+
+  const nextNudge: LarkApprovalRuntimeNudge = {
+    kind: event.nudge.kind,
+    message: event.nudge.message,
+  };
+  const alreadyPresent = state.runtimeNudges.some(
+    (nudge) => nudge.kind === nextNudge.kind && nudge.message === nextNudge.message,
+  );
+  if (alreadyPresent) {
+    return state;
+  }
+
+  return {
+    ...state,
+    runtimeNudges: [...state.runtimeNudges, nextNudge],
+  };
 }
 
 function onApprovalRequested(
@@ -169,6 +212,7 @@ function onApprovalRequested(
     decision: null,
     actor: null,
     sourceRunCardObjectId: input?.sourceRunCardObjectId ?? previous.sourceRunCardObjectId ?? null,
+    runtimeNudges: previous.resolved ? [] : previous.runtimeNudges,
   };
 }
 

--- a/src/channels/lark/channel.ts
+++ b/src/channels/lark/channel.ts
@@ -29,6 +29,7 @@ import type { ResolveSubagentCreationRequestResult } from "@/src/orchestration/a
 import type { OrchestratedOutboundEventEnvelope } from "@/src/orchestration/outbound-events.js";
 import type { RuntimeControlService } from "@/src/runtime/control.js";
 import type { RuntimeEventBus } from "@/src/runtime/event-bus.js";
+import type { RuntimeModeService } from "@/src/runtime/runtime-modes.js";
 import type { RuntimeStatusService } from "@/src/runtime/status.js";
 import { createSubsystemLogger } from "@/src/shared/logger.js";
 import type { StorageDb } from "@/src/storage/db/client.js";
@@ -58,6 +59,7 @@ export interface CreateLarkChannelRuntimeInput {
   ingress: LarkInboundIngress;
   control: RuntimeControlService;
   status?: RuntimeStatusService;
+  runtimeModes?: RuntimeModeService;
   modelSwitch?: ScenarioModelSwitchService;
   outboundEventBus: RuntimeEventBus<OrchestratedOutboundEventEnvelope>;
   wsClientFactory?: (installation: ConfiguredLarkInstallation) => Lark.WSClient;
@@ -109,6 +111,7 @@ export function createLarkChannelRuntime(input: CreateLarkChannelRuntimeInput): 
     ingress: input.ingress,
     control: input.control,
     ...(input.status == null ? {} : { status: input.status }),
+    ...(input.runtimeModes == null ? {} : { runtimeModes: input.runtimeModes }),
     ...(input.modelSwitch == null ? {} : { modelSwitch: input.modelSwitch }),
     clients,
     ...(input.wsClientFactory == null ? {} : { wsClientFactory: input.wsClientFactory }),

--- a/src/channels/lark/delivery-targets.ts
+++ b/src/channels/lark/delivery-targets.ts
@@ -1,0 +1,69 @@
+import type { StorageDb } from "@/src/storage/db/client.js";
+import { ChannelSurfacesRepo } from "@/src/storage/repos/channel-surfaces.repo.js";
+import { ChannelThreadsRepo } from "@/src/storage/repos/channel-threads.repo.js";
+import { TaskRunsRepo } from "@/src/storage/repos/task-runs.repo.js";
+
+const LARK_CHANNEL_TYPE = "lark";
+
+export interface LarkDeliveryTarget {
+  channelInstallationId: string;
+  surfaceObject: Record<string, unknown>;
+}
+
+export function readStringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export function listLarkDeliveryTargets(
+  storage: StorageDb,
+  input: {
+    conversationId: string;
+    branchId: string;
+    taskRunId?: string | null;
+  },
+): LarkDeliveryTarget[] {
+  const surfaces = new ChannelSurfacesRepo(storage).listByConversationBranch({
+    channelType: LARK_CHANNEL_TYPE,
+    conversationId: input.conversationId,
+    branchId: input.branchId,
+  });
+  const taskRun =
+    input.taskRunId == null ? null : new TaskRunsRepo(storage).getById(input.taskRunId);
+  const channelThreadsRepo = new ChannelThreadsRepo(storage);
+
+  return surfaces.map((surface) => {
+    const threadBinding =
+      taskRun == null
+        ? null
+        : channelThreadsRepo.getByRootTaskRun({
+            channelType: LARK_CHANNEL_TYPE,
+            channelInstallationId: surface.channelInstallationId,
+            rootTaskRunId: taskRun.threadRootRunId ?? taskRun.id,
+          });
+
+    return {
+      channelInstallationId: surface.channelInstallationId,
+      surfaceObject:
+        threadBinding == null
+          ? parseSurfaceObject(surface.surfaceObjectJson)
+          : {
+              chat_id: threadBinding.externalChatId,
+              thread_id: threadBinding.externalThreadId,
+              ...(threadBinding.openedFromMessageId == null
+                ? {}
+                : { reply_to_message_id: threadBinding.openedFromMessageId }),
+            },
+    };
+  });
+}
+
+function parseSurfaceObject(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed === "object" && parsed != null && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {}
+
+  return {};
+}

--- a/src/channels/lark/inbound.ts
+++ b/src/channels/lark/inbound.ts
@@ -25,12 +25,15 @@ import {
   type LarkModelSwitchCardState,
 } from "@/src/channels/lark/render.js";
 import type { LarkSteerReactionState } from "@/src/channels/lark/steer-reaction-state.js";
+import { sendLarkTextMessage } from "@/src/channels/lark/text-message.js";
 import type { ConfiguredLarkInstallation } from "@/src/channels/lark/types.js";
+import { handleLarkYoloCommand, isLarkYoloCommand } from "@/src/channels/lark/yolo-command.js";
 import type { ScenarioModelSwitchService } from "@/src/config/scenario-model-switch.js";
 import type { ResolveSubagentCreationRequestResult } from "@/src/orchestration/agent-manager.js";
 import { materializeForkedSessionSnapshotInStorage } from "@/src/orchestration/session-fork.js";
 import type { RuntimeControlService } from "@/src/runtime/control.js";
 import type { SubmitMessageResult } from "@/src/runtime/ingress.js";
+import type { RuntimeModeService } from "@/src/runtime/runtime-modes.js";
 import {
   buildConversationStatusPresentation,
   type RuntimeStatusService,
@@ -93,6 +96,7 @@ export interface CreateLarkInboundRuntimeInput {
   ingress: LarkInboundIngress;
   control: RuntimeControlService;
   status?: RuntimeStatusService;
+  runtimeModes?: RuntimeModeService;
   modelSwitch?: ScenarioModelSwitchService;
   clients?: {
     getOrCreate(installationId: string): LarkSdkClient;
@@ -333,6 +337,7 @@ export function createLarkMessageReceiveHandler(input: {
   ingress: LarkInboundIngress;
   control: RuntimeControlService;
   status?: RuntimeStatusService;
+  runtimeModes?: RuntimeModeService;
   modelSwitch?: ScenarioModelSwitchService;
   clients?: {
     getOrCreate(installationId: string): LarkSdkClient;
@@ -472,6 +477,19 @@ export function createLarkMessageReceiveHandler(input: {
         sessionId: route.sessionId,
         scenario: route.scenario,
         routeKind: route.kind,
+      });
+      return;
+    }
+
+    if (isLarkYoloCommand(hydrated.text)) {
+      await handleLarkYoloCommand({
+        text: hydrated.text,
+        installationId: input.installationId,
+        storage: input.storage,
+        ...(input.runtimeModes == null ? {} : { runtimeModes: input.runtimeModes }),
+        route,
+        message: hydrated,
+        ...(input.clients == null ? {} : { clients: input.clients }),
       });
       return;
     }
@@ -1131,6 +1149,7 @@ export function createLarkInboundRuntime(input: CreateLarkInboundRuntimeInput): 
           control: input.control,
           ...(input.clients == null ? {} : { clients: input.clients }),
           ...(input.status == null ? {} : { status: input.status }),
+          ...(input.runtimeModes == null ? {} : { runtimeModes: input.runtimeModes }),
           ...(input.modelSwitch == null ? {} : { modelSwitch: input.modelSwitch }),
           ...(input.clients == null
             ? {}
@@ -2197,7 +2216,13 @@ function extractStartedSubmitMessageResult(
 }
 
 function isLarkThreadControlCommand(text: string): boolean {
-  return text === "/stop" || text === "/status" || text === "/model" || text === "/help";
+  return (
+    text === "/stop" ||
+    text === "/status" ||
+    text === "/model" ||
+    text === "/help" ||
+    isLarkYoloCommand(text)
+  );
 }
 
 function buildTaskRunCardObjectId(taskRunId: string): string {
@@ -3177,47 +3202,6 @@ async function sendLarkHelpMessage(input: {
     ...(input.replyToMessageId == null ? {} : { replyToMessageId: input.replyToMessageId }),
     text: presentation.plainText,
     ...(input.clients == null ? {} : { clients: input.clients }),
-  });
-}
-
-async function sendLarkTextMessage(input: {
-  installationId: string;
-  chatId: string;
-  replyToMessageId?: string | null;
-  text: string;
-  clients?: {
-    getOrCreate(installationId: string): LarkSdkClient;
-  };
-}): Promise<void> {
-  if (input.clients == null) {
-    logger.warn("cannot send lark text message because no sdk clients are configured", {
-      installationId: input.installationId,
-      chatId: input.chatId,
-    });
-    return;
-  }
-
-  const client = input.clients.getOrCreate(input.installationId);
-  const content = JSON.stringify({ text: input.text });
-  if (input.replyToMessageId != null && input.replyToMessageId.length > 0) {
-    await client.sdk.im.message.reply({
-      path: { message_id: input.replyToMessageId },
-      data: {
-        msg_type: "text",
-        content,
-        reply_in_thread: true,
-      },
-    });
-    return;
-  }
-
-  await client.sdk.im.message.create({
-    params: { receive_id_type: "chat_id" },
-    data: {
-      receive_id: input.chatId,
-      msg_type: "text",
-      content,
-    },
   });
 }
 

--- a/src/channels/lark/outbound.ts
+++ b/src/channels/lark/outbound.ts
@@ -6,7 +6,9 @@
  * throttling, sequencing, and durable lark object bindings.
  */
 import { randomUUID } from "node:crypto";
+import type { RuntimeNudgeEvent } from "@/src/agent/events.js";
 import {
+  addLarkApprovalRuntimeNudge,
   type LarkApprovalState,
   reduceLarkApprovalState,
   shouldHandleLarkApprovalRuntimeEvent,
@@ -22,6 +24,7 @@ import {
   setCardkitSequenceFloorInMetadata,
 } from "@/src/channels/lark/cardkit-mutations.js";
 import type { LarkSdkClient } from "@/src/channels/lark/client.js";
+import { listLarkDeliveryTargets, readStringValue } from "@/src/channels/lark/delivery-targets.js";
 import {
   addLarkMessageReaction,
   removeLarkMessageReaction,
@@ -53,7 +56,6 @@ import type { RuntimeEventBus } from "@/src/runtime/event-bus.js";
 import { createSubsystemLogger } from "@/src/shared/logger.js";
 import type { StorageDb } from "@/src/storage/db/client.js";
 import { ChannelSurfacesRepo } from "@/src/storage/repos/channel-surfaces.repo.js";
-import { ChannelThreadsRepo } from "@/src/storage/repos/channel-threads.repo.js";
 import { CronJobsRepo } from "@/src/storage/repos/cron-jobs.repo.js";
 import { LarkObjectBindingsRepo } from "@/src/storage/repos/lark-object-bindings.repo.js";
 import { TaskRunsRepo } from "@/src/storage/repos/task-runs.repo.js";
@@ -134,6 +136,7 @@ export function createLarkOutboundRuntime(
   const runStates = new Map<string, LarkRunState>();
   const taskStates = new Map<string, LarkRunState>();
   const approvalStates = new Map<string, LarkApprovalState>();
+  const pendingRuntimeNudgesByApprovalFlowId = new Map<string, RuntimeNudgeEvent[]>();
   const activeRunSegmentByRunId = new Map<string, string>();
   const latestRunSegmentByRunId = new Map<string, string>();
   const nextRunSegmentIndexByRunId = new Map<string, number>();
@@ -1487,12 +1490,17 @@ export function createLarkOutboundRuntime(
         }
       }
       const previousApprovalState = approvalStates.get(approvalFlowId) ?? null;
-      const nextApprovalState = reduceLarkApprovalState(previousApprovalState, envelope, {
+      let nextApprovalState = reduceLarkApprovalState(previousApprovalState, envelope, {
         sourceRunCardObjectId:
           sourceRunCardObjectId ?? previousApprovalState?.sourceRunCardObjectId ?? null,
       });
       if (nextApprovalState == null) {
         return;
+      }
+      const pendingNudges = pendingRuntimeNudgesByApprovalFlowId.get(approvalFlowId) ?? [];
+      pendingRuntimeNudgesByApprovalFlowId.delete(approvalFlowId);
+      for (const pendingNudge of pendingNudges) {
+        nextApprovalState = addLarkApprovalRuntimeNudge(nextApprovalState, pendingNudge);
       }
       approvalStates.set(approvalFlowId, nextApprovalState);
       latestApprovalByRunId.set(runId, approvalFlowId);
@@ -1555,6 +1563,41 @@ export function createLarkOutboundRuntime(
           decision: event.decision,
         });
         bumpVersionAndSchedule(`run:${previousApprovalState.sourceRunCardObjectId}`);
+      }
+    }
+  };
+
+  const handleRuntimeNudgeEvent = (envelope: OrchestratedRuntimeEventEnvelope) => {
+    if (envelope.event.type !== "runtime_nudge") {
+      return;
+    }
+
+    switch (envelope.event.anchor.type) {
+      case "approval_flow": {
+        const approvalFlowId = envelope.event.anchor.id;
+        const previousApprovalState = approvalStates.get(approvalFlowId);
+        if (previousApprovalState == null) {
+          const pendingNudges = pendingRuntimeNudgesByApprovalFlowId.get(approvalFlowId) ?? [];
+          pendingRuntimeNudgesByApprovalFlowId.set(approvalFlowId, [
+            ...pendingNudges,
+            envelope.event,
+          ]);
+          return;
+        }
+
+        const nextApprovalState = addLarkApprovalRuntimeNudge(
+          previousApprovalState,
+          envelope.event,
+        );
+        if (nextApprovalState === previousApprovalState) {
+          return;
+        }
+
+        approvalStates.set(approvalFlowId, nextApprovalState);
+        if (shouldCreateStandaloneLarkApprovalCard(nextApprovalState)) {
+          bumpVersionAndSchedule(`approval:${approvalFlowId}`);
+        }
+        return;
       }
     }
   };
@@ -1696,6 +1739,11 @@ export function createLarkOutboundRuntime(
           return;
         }
 
+        if (envelope.event.type === "runtime_nudge") {
+          handleRuntimeNudgeEvent(envelope);
+          return;
+        }
+
         if (shouldHandleLarkApprovalRuntimeEvent(envelope)) {
           handleApprovalEvent(envelope);
           return;
@@ -1834,6 +1882,7 @@ export function createLarkOutboundRuntime(
       runStates.clear();
       taskStates.clear();
       approvalStates.clear();
+      pendingRuntimeNudgesByApprovalFlowId.clear();
       activeRunSegmentByRunId.clear();
       latestRunSegmentByRunId.clear();
       nextRunSegmentIndexByRunId.clear();
@@ -1998,56 +2047,6 @@ async function maybeSendFullTaskTerminalMessageToThread(input: {
 
 function describeTaskTitleFallback(state: LarkRunState): string {
   return describeTaskRunKind(state.taskRunType);
-}
-
-function readStringValue(value: unknown): string | null {
-  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
-}
-
-function listLarkDeliveryTargets(
-  storage: StorageDb,
-  input: {
-    conversationId: string;
-    branchId: string;
-    taskRunId?: string | null;
-  },
-): Array<{
-  channelInstallationId: string;
-  surfaceObject: Record<string, unknown>;
-}> {
-  const surfaces = new ChannelSurfacesRepo(storage).listByConversationBranch({
-    channelType: LARK_CHANNEL_TYPE,
-    conversationId: input.conversationId,
-    branchId: input.branchId,
-  });
-  const taskRun =
-    input.taskRunId == null ? null : new TaskRunsRepo(storage).getById(input.taskRunId);
-  const channelThreadsRepo = new ChannelThreadsRepo(storage);
-
-  return surfaces.map((surface) => {
-    const threadBinding =
-      taskRun == null
-        ? null
-        : channelThreadsRepo.getByRootTaskRun({
-            channelType: LARK_CHANNEL_TYPE,
-            channelInstallationId: surface.channelInstallationId,
-            rootTaskRunId: taskRun.threadRootRunId ?? taskRun.id,
-          });
-
-    return {
-      channelInstallationId: surface.channelInstallationId,
-      surfaceObject:
-        threadBinding == null
-          ? parseSurfaceObject(surface.surfaceObjectJson)
-          : {
-              chat_id: threadBinding.externalChatId,
-              thread_id: threadBinding.externalThreadId,
-              ...(threadBinding.openedFromMessageId == null
-                ? {}
-                : { reply_to_message_id: threadBinding.openedFromMessageId }),
-            },
-    };
-  });
 }
 
 function listTaskCardDeliveryTargets(

--- a/src/channels/lark/render.ts
+++ b/src/channels/lark/render.ts
@@ -153,10 +153,28 @@ function buildApprovalCardElements(state: LarkApprovalState): Array<Record<strin
     return elements;
   }
 
+  const runtimeNudgeElement = buildApprovalRuntimeNudgeElement(state);
+  if (runtimeNudgeElement != null) {
+    elements.push(runtimeNudgeElement);
+  }
   elements.push({ tag: "hr" });
   elements.push(buildApprovalActionButtons(state));
 
   return elements;
+}
+
+function buildApprovalRuntimeNudgeElement(
+  state: LarkApprovalState,
+): Record<string, unknown> | null {
+  if (state.runtimeNudges.length === 0) {
+    return null;
+  }
+
+  return {
+    tag: "markdown",
+    content: state.runtimeNudges.map((nudge) => `> ${nudge.message}`).join("\n"),
+    text_size: "normal",
+  };
 }
 
 function buildSubagentCreationRequestCardElements(
@@ -300,8 +318,6 @@ function buildApprovalCardBodyMarkdown(
       ...formatApprovalCommandLines(state.commandText),
       ...permissionSummaryLines,
       ...formatHumanDeadlineLines("有效期至", state.expiresAt),
-      "",
-      "> 你处理后，agent 才会继续执行。",
     ].join("\n");
   }
 

--- a/src/channels/lark/text-message.ts
+++ b/src/channels/lark/text-message.ts
@@ -1,0 +1,45 @@
+import type { LarkSdkClient } from "@/src/channels/lark/client.js";
+import { createSubsystemLogger } from "@/src/shared/logger.js";
+
+const logger = createSubsystemLogger("channels/lark-text-message");
+
+export async function sendLarkTextMessage(input: {
+  installationId: string;
+  chatId: string;
+  replyToMessageId?: string | null;
+  text: string;
+  clients?: {
+    getOrCreate(installationId: string): LarkSdkClient;
+  };
+}): Promise<void> {
+  if (input.clients == null) {
+    logger.warn("cannot send lark text message because no sdk clients are configured", {
+      installationId: input.installationId,
+      chatId: input.chatId,
+    });
+    return;
+  }
+
+  const client = input.clients.getOrCreate(input.installationId);
+  const content = JSON.stringify({ text: input.text });
+  if (input.replyToMessageId != null && input.replyToMessageId.length > 0) {
+    await client.sdk.im.message.reply({
+      path: { message_id: input.replyToMessageId },
+      data: {
+        msg_type: "text",
+        content,
+        reply_in_thread: true,
+      },
+    });
+    return;
+  }
+
+  await client.sdk.im.message.create({
+    params: { receive_id_type: "chat_id" },
+    data: {
+      receive_id: input.chatId,
+      msg_type: "text",
+      content,
+    },
+  });
+}

--- a/src/channels/lark/yolo-command.ts
+++ b/src/channels/lark/yolo-command.ts
@@ -1,0 +1,102 @@
+import type { LarkSdkClient } from "@/src/channels/lark/client.js";
+import { sendLarkTextMessage } from "@/src/channels/lark/text-message.js";
+import type { RuntimeModeService } from "@/src/runtime/runtime-modes.js";
+import { createSubsystemLogger } from "@/src/shared/logger.js";
+import type { StorageDb } from "@/src/storage/db/client.js";
+import { SessionsRepo } from "@/src/storage/repos/sessions.repo.js";
+
+const logger = createSubsystemLogger("channels/lark-yolo-command");
+
+export const LARK_YOLO_ENABLED_MESSAGE =
+  "⚠️ YOLO mode is on. Risky actions may run without asking first. Send /yolo again to turn it off.";
+export const LARK_YOLO_DISABLED_MESSAGE =
+  "🔒 YOLO mode is off. Future privileged actions will ask for approval again.";
+export const LARK_YOLO_MISSING_OWNER_MESSAGE =
+  "YOLO mode could not be changed because this route has no owner agent.";
+
+export function isLarkYoloCommand(text: string): boolean {
+  return text === "/yolo";
+}
+
+export async function handleLarkYoloCommand(input: {
+  text: string;
+  installationId: string;
+  storage: StorageDb;
+  runtimeModes?: RuntimeModeService;
+  route: {
+    kind: string;
+    conversationId: string;
+    sessionId: string;
+    chatId: string;
+    replyToMessageId: string | null;
+  };
+  message: {
+    chatId: string;
+    messageId: string;
+    senderOpenId: string | null;
+    createdAt?: Date;
+  };
+  clients?: {
+    getOrCreate(installationId: string): LarkSdkClient;
+  };
+}): Promise<boolean> {
+  if (!isLarkYoloCommand(input.text)) {
+    return false;
+  }
+
+  if (input.runtimeModes == null) {
+    logger.warn("ignoring lark yolo command because no runtime mode service is configured", {
+      installationId: input.installationId,
+      chatId: input.message.chatId,
+      messageId: input.message.messageId,
+    });
+    return true;
+  }
+
+  const session = new SessionsRepo(input.storage).getById(input.route.sessionId);
+  if (session?.ownerAgentId == null || session.ownerAgentId.trim().length === 0) {
+    await sendLarkTextMessage({
+      installationId: input.installationId,
+      chatId: input.route.chatId,
+      replyToMessageId: input.route.replyToMessageId,
+      text: LARK_YOLO_MISSING_OWNER_MESSAGE,
+      ...(input.clients == null ? {} : { clients: input.clients }),
+    });
+    logger.warn("failed to process lark yolo command because route has no owner agent", {
+      installationId: input.installationId,
+      chatId: input.message.chatId,
+      messageId: input.message.messageId,
+      conversationId: input.route.conversationId,
+      sessionId: input.route.sessionId,
+      routeKind: input.route.kind,
+    });
+    return true;
+  }
+
+  const toggled = input.runtimeModes.toggleYolo({
+    ownerAgentId: session.ownerAgentId,
+    updatedBy:
+      input.message.senderOpenId == null
+        ? `lark:${input.installationId}:unknown`
+        : `lark:${input.installationId}:${input.message.senderOpenId}`,
+    updatedAt: input.message.createdAt ?? new Date(),
+  });
+  await sendLarkTextMessage({
+    installationId: input.installationId,
+    chatId: input.route.chatId,
+    replyToMessageId: input.route.replyToMessageId,
+    text: toggled.yoloEnabled ? LARK_YOLO_ENABLED_MESSAGE : LARK_YOLO_DISABLED_MESSAGE,
+    ...(input.clients == null ? {} : { clients: input.clients }),
+  });
+  logger.info("processed lark yolo command", {
+    installationId: input.installationId,
+    chatId: input.message.chatId,
+    messageId: input.message.messageId,
+    conversationId: input.route.conversationId,
+    sessionId: input.route.sessionId,
+    ownerAgentId: session.ownerAgentId,
+    yoloEnabled: toggled.yoloEnabled,
+    routeKind: input.route.kind,
+  });
+  return true;
+}

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -30,6 +30,7 @@ export const DEFAULT_CONFIG: RawConfig = {
     maxTurns: DEFAULT_RUNTIME_MAX_TURNS,
     approvalTimeoutMs: DEFAULT_RUNTIME_APPROVAL_TIMEOUT_MS,
     approvalGrantTtlMs: DEFAULT_RUNTIME_APPROVAL_GRANT_TTL_MS,
+    autopilot: false,
   },
   selfHarness: {
     meditation: {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -65,6 +65,7 @@ export interface RuntimeConfig {
   maxTurns: number;
   approvalTimeoutMs: number;
   approvalGrantTtlMs: number;
+  autopilot: boolean;
 }
 
 export interface MeditationConfig {
@@ -208,6 +209,7 @@ interface RuntimeConfigInput {
   maxTurns?: unknown;
   approvalTimeoutMs?: unknown;
   approvalGrantTtlMs?: unknown;
+  autopilot?: unknown;
 }
 
 interface MeditationConfigInput {
@@ -796,7 +798,7 @@ function validateRuntimeConfig(input: unknown, defaults: RuntimeConfig): Runtime
   const config = input as RuntimeConfigInput;
   assertAllowedKeys(
     config,
-    new Set(["maxTurns", "approvalTimeoutMs", "approvalGrantTtlMs"]),
+    new Set(["maxTurns", "approvalTimeoutMs", "approvalGrantTtlMs", "autopilot"]),
     "config.toml runtime",
   );
 
@@ -812,6 +814,11 @@ function validateRuntimeConfig(input: unknown, defaults: RuntimeConfig): Runtime
     approvalGrantTtlMs: validatePositiveInteger(
       config.approvalGrantTtlMs ?? defaults.approvalGrantTtlMs,
       "config.toml runtime.approvalGrantTtlMs",
+    ),
+    autopilot: validateOptionalBoolean(
+      config.autopilot,
+      defaults.autopilot,
+      "config.toml runtime.autopilot",
     ),
   };
 }

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -37,6 +37,7 @@ import {
   createRuntimeOrchestrationBridge,
   type RuntimeOrchestrationBridge,
 } from "@/src/runtime/orchestration-bridge.js";
+import { RuntimeModeService } from "@/src/runtime/runtime-modes.js";
 import { RuntimeStatusService } from "@/src/runtime/status.js";
 import { createSubsystemLogger } from "@/src/shared/logger.js";
 import type { StorageDb } from "@/src/storage/db/client.js";
@@ -94,12 +95,17 @@ export function createRuntimeBootstrap(input: CreateRuntimeBootstrapInput): Runt
     taskRuns: new TaskRunsRepo(input.storage),
   });
   const scenarioModelSwitch = new ScenarioModelSwitchService(liveConfig);
+  const runtimeModes = new RuntimeModeService({
+    storage: input.storage,
+    autopilotEnabled: input.config.runtime.autopilot,
+  });
   const providerApiKeyResolver = new CodexProviderApiKeyResolver();
   const llmBridge = new PiBridge(providerApiKeyResolver);
   const status = new RuntimeStatusService({
     storage: input.storage,
     control,
     models: liveModels,
+    runtimeModes,
   });
   const loop = new AgentLoop({
     sessions: new AgentSessionService(sessions, messages),
@@ -112,6 +118,7 @@ export function createRuntimeBootstrap(input: CreateRuntimeBootstrapInput): Runt
     securityConfig: input.config.security,
     compaction: input.config.compaction,
     runtime: input.config.runtime,
+    runtimeModes,
     runtimeControl: bridge.runtimeControl,
     control,
     emitEvent: bridge.emitRuntimeEvent,
@@ -163,6 +170,7 @@ export function createRuntimeBootstrap(input: CreateRuntimeBootstrapInput): Runt
     ingress,
     control,
     status,
+    runtimeModes,
     modelSwitch: scenarioModelSwitch,
     outboundEventBus,
     clients: larkClients,

--- a/src/runtime/runtime-modes.ts
+++ b/src/runtime/runtime-modes.ts
@@ -1,0 +1,157 @@
+import type { StorageDb } from "@/src/storage/db/client.js";
+import { AgentRuntimeModesRepo } from "@/src/storage/repos/agent-runtime-modes.repo.js";
+import type { AgentRuntimeMode } from "@/src/storage/schema/types.js";
+
+export const YOLO_SUGGESTION_APPROVAL_THRESHOLD = 2;
+export const YOLO_SUGGESTION_STREAK_WINDOW_MS = 5 * 60 * 1000;
+export const YOLO_SUGGESTION_DEBOUNCE_MS = 12 * 60 * 60 * 1000;
+export const YOLO_MANUAL_DISABLE_SNOOZE_MS = 3 * 24 * 60 * 60 * 1000;
+export const YOLO_SUGGESTION_MESSAGE =
+  "💡 Too many approval stops? Send `/yolo` if you want this agent to keep going without asking each time.";
+
+export type EffectiveApprovalModeSource = "normal" | "yolo" | "autopilot";
+
+export interface EffectiveApprovalMode {
+  autopilotEnabled: boolean;
+  yoloEnabled: boolean;
+  skipHumanApproval: boolean;
+  source: EffectiveApprovalModeSource;
+}
+
+export interface RuntimeModeServiceInput {
+  storage: StorageDb;
+  autopilotEnabled: boolean;
+}
+
+export interface ToggleYoloRuntimeModeInput {
+  ownerAgentId: string;
+  updatedBy?: string | null;
+  updatedAt?: Date;
+}
+
+export interface RecordApprovalRequestForYoloSuggestionInput {
+  ownerAgentId: string | null | undefined;
+  approvalTarget: "user" | "main_agent";
+  requestedAt?: Date;
+}
+
+export class RuntimeModeService {
+  private readonly repo: AgentRuntimeModesRepo;
+
+  constructor(private readonly input: RuntimeModeServiceInput) {
+    this.repo = new AgentRuntimeModesRepo(input.storage);
+  }
+
+  isAutopilotEnabled(): boolean {
+    return this.input.autopilotEnabled;
+  }
+
+  getEffectiveApprovalMode(ownerAgentId: string | null | undefined): EffectiveApprovalMode {
+    const yoloEnabled =
+      ownerAgentId == null || ownerAgentId.trim().length === 0
+        ? false
+        : this.repo.isYoloEnabled(ownerAgentId);
+
+    if (this.input.autopilotEnabled) {
+      return {
+        autopilotEnabled: true,
+        yoloEnabled,
+        skipHumanApproval: true,
+        source: "autopilot",
+      };
+    }
+
+    if (yoloEnabled) {
+      return {
+        autopilotEnabled: false,
+        yoloEnabled: true,
+        skipHumanApproval: true,
+        source: "yolo",
+      };
+    }
+
+    return {
+      autopilotEnabled: false,
+      yoloEnabled: false,
+      skipHumanApproval: false,
+      source: "normal",
+    };
+  }
+
+  toggleYolo(input: ToggleYoloRuntimeModeInput): AgentRuntimeMode {
+    const updatedAt = input.updatedAt ?? new Date();
+    return this.repo.toggleYolo({
+      ownerAgentId: input.ownerAgentId,
+      updatedAt,
+      updatedBy: input.updatedBy ?? null,
+      disableSnoozedUntil: new Date(updatedAt.getTime() + YOLO_MANUAL_DISABLE_SNOOZE_MS),
+    });
+  }
+
+  recordApprovalRequestForYoloSuggestion(
+    input: RecordApprovalRequestForYoloSuggestionInput,
+  ): boolean {
+    if (
+      input.approvalTarget !== "user" ||
+      this.input.autopilotEnabled ||
+      input.ownerAgentId == null ||
+      input.ownerAgentId.trim().length === 0
+    ) {
+      return false;
+    }
+
+    const ownerAgentId = input.ownerAgentId;
+    const requestedAt = input.requestedAt ?? new Date();
+    const existing = this.repo.getByOwnerAgentId(ownerAgentId);
+    if (existing?.yoloEnabled === true) {
+      return false;
+    }
+
+    const snoozedUntil = parseTimestamp(existing?.yoloSnoozedUntil);
+    if (snoozedUntil != null && snoozedUntil.getTime() > requestedAt.getTime()) {
+      return false;
+    }
+
+    const lastPromptedAt = parseTimestamp(existing?.lastYoloPromptedAt);
+    if (
+      lastPromptedAt != null &&
+      requestedAt.getTime() - lastPromptedAt.getTime() < YOLO_SUGGESTION_DEBOUNCE_MS
+    ) {
+      return false;
+    }
+
+    const streakStartedAt = parseTimestamp(existing?.approvalStreakStartedAt);
+    const lastApprovalRequestedAt = parseTimestamp(existing?.lastApprovalRequestedAt);
+    const streakExpired =
+      streakStartedAt == null ||
+      lastApprovalRequestedAt == null ||
+      requestedAt.getTime() - streakStartedAt.getTime() > YOLO_SUGGESTION_STREAK_WINDOW_MS;
+    const nextStreakStartedAt = streakExpired ? requestedAt : streakStartedAt;
+    const nextStreakCount = streakExpired ? 1 : (existing?.approvalStreakCount ?? 0) + 1;
+    const shouldSuggest = nextStreakCount >= YOLO_SUGGESTION_APPROVAL_THRESHOLD;
+
+    this.repo.updateYoloPromptState({
+      ownerAgentId,
+      updatedAt: requestedAt,
+      approvalStreakCount: shouldSuggest ? 0 : nextStreakCount,
+      approvalStreakStartedAt: shouldSuggest ? null : nextStreakStartedAt,
+      lastApprovalRequestedAt: requestedAt,
+      ...(shouldSuggest
+        ? {
+            lastYoloPromptedAt: requestedAt,
+          }
+        : {}),
+    });
+
+    return shouldSuggest;
+  }
+}
+
+function parseTimestamp(value: string | null | undefined): Date | null {
+  if (value == null) {
+    return null;
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}

--- a/src/runtime/status.ts
+++ b/src/runtime/status.ts
@@ -14,6 +14,11 @@ import {
 } from "@/src/agent/llm/provider-registry-source.js";
 import type { RuntimeControlService } from "@/src/runtime/control.js";
 import { resolveSessionLiveState } from "@/src/runtime/live-state.js";
+import type {
+  EffectiveApprovalMode,
+  EffectiveApprovalModeSource,
+  RuntimeModeService,
+} from "@/src/runtime/runtime-modes.js";
 import { toCanonicalUtcIsoTimestamp } from "@/src/shared/time.js";
 import type { StorageDb } from "@/src/storage/db/client.js";
 import { AgentsRepo } from "@/src/storage/repos/agents.repo.js";
@@ -66,10 +71,18 @@ export interface StatusPendingApprovalSnapshot {
   expiresAt: string | null;
 }
 
+export interface StatusRuntimeModeSnapshot {
+  source: EffectiveApprovalModeSource;
+  autopilotEnabled: boolean;
+  yoloEnabled: boolean;
+  skipHumanApproval: boolean;
+}
+
 export interface ConversationStatusSnapshot {
   conversationId: string;
   sessionId: string;
   model: StatusModelSnapshot;
+  runtimeMode: StatusRuntimeModeSnapshot;
   sessionUsage: StatusUsageSnapshot | null;
   latestTurnUsage: StatusUsageSnapshot | null;
   latestTurnErrorMessage: string | null;
@@ -89,6 +102,7 @@ export class RuntimeStatusService {
       storage: StorageDb;
       control: RuntimeControlService;
       models: ProviderRegistry | ProviderRegistrySource;
+      runtimeModes?: RuntimeModeService;
     },
   ) {}
 
@@ -157,11 +171,15 @@ export class RuntimeStatusService {
       });
 
     const latestTurnUsage = latestAssistant == null ? null : parseMessageUsage(latestAssistant);
+    const runtimeMode = toStatusRuntimeMode(
+      this.deps.runtimeModes?.getEffectiveApprovalMode(session.ownerAgentId),
+    );
 
     return {
       conversationId: input.conversationId,
       sessionId: input.sessionId,
       model,
+      runtimeMode,
       sessionUsage,
       latestTurnUsage,
       latestTurnErrorMessage:
@@ -190,6 +208,7 @@ export function formatConversationStatusText(snapshot: ConversationStatusSnapsho
   if (snapshot.model.supportsReasoning != null) {
     lines.push(`Reasoning: ${snapshot.model.supportsReasoning ? "支持" : "不支持"}`);
   }
+  lines.push(`运行模式：${formatRuntimeModeLine(snapshot.runtimeMode)}`);
 
   lines.push("");
   lines.push("Usage");
@@ -251,6 +270,7 @@ export function buildConversationStatusPresentation(
         ...(snapshot.model.supportsReasoning == null
           ? []
           : [`**Reasoning**: ${snapshot.model.supportsReasoning ? "支持" : "不支持"}`]),
+        `**运行模式**：${formatRuntimeModeLine(snapshot.runtimeMode)}`,
       ].join("\n"),
       [
         "### Usage",
@@ -296,6 +316,30 @@ export function buildConversationStatusPresentation(
       ].join("\n"),
     ],
   };
+}
+
+function toStatusRuntimeMode(
+  mode: EffectiveApprovalMode | null | undefined,
+): StatusRuntimeModeSnapshot {
+  return (
+    mode ?? {
+      source: "normal",
+      autopilotEnabled: false,
+      yoloEnabled: false,
+      skipHumanApproval: false,
+    }
+  );
+}
+
+function formatRuntimeModeLine(mode: StatusRuntimeModeSnapshot): string {
+  switch (mode.source) {
+    case "autopilot":
+      return "🛸 Autopilot";
+    case "yolo":
+      return "🐯 YOLO";
+    case "normal":
+      return "🧸 手动审批";
+  }
 }
 
 function resolveStatusModel(input: {

--- a/src/security/sandbox.ts
+++ b/src/security/sandbox.ts
@@ -32,6 +32,7 @@ export interface BuildSandboxConfigForAgentInput {
   ownerAgentId: string;
   systemPolicy?: SystemPermissionPolicy;
   activeAt?: Date;
+  ephemeralScopes?: PermissionScope[];
 }
 
 export interface ExecuteSandboxedBashInput {
@@ -90,7 +91,11 @@ export function buildSandboxConfigForAgent(
 ): SandboxRuntimeConfig {
   const systemPolicy = input.systemPolicy ?? buildSystemPolicy();
   const security = new SecurityService(input.storage, systemPolicy);
-  const permissions = security.getEffectivePermissions(input.ownerAgentId, input.activeAt);
+  const permissions = security.getEffectivePermissionsWithEphemeralScopes({
+    ownerAgentId: input.ownerAgentId,
+    ...(input.activeAt == null ? {} : { activeAt: input.activeAt }),
+    ...(input.ephemeralScopes == null ? {} : { ephemeralScopes: input.ephemeralScopes }),
+  });
   const denyReadPatterns = [...permissions.fs.read.hardDeny, ...permissions.fs.read.deny];
   const allowReadPatterns = [
     ...permissions.fs.read.allow,
@@ -183,6 +188,9 @@ export async function executeSandboxedBash(
     storage: input.context.storage,
     ownerAgentId,
     systemPolicy,
+    ...(input.context.approvalState?.ephemeralPermissionScopes == null
+      ? {}
+      : { ephemeralScopes: input.context.approvalState.ephemeralPermissionScopes }),
   });
 
   return await executeBashInSandbox({
@@ -332,6 +340,9 @@ async function resolveSandboxCwd(input: {
     kind: "fs.read",
     targetPath: normalizedPath,
     cwd: fallbackCwd,
+    ...(input.context.approvalState?.ephemeralPermissionScopes == null
+      ? {}
+      : { ephemeralScopes: input.context.approvalState.ephemeralPermissionScopes }),
   });
 
   if (access.result === "deny" && access.reason === "hard_deny") {
@@ -505,7 +516,12 @@ function translateSandboxPermissionError(input: {
       kind: issue.kind,
       targetPath: issue.path,
       cwd: input.cwd,
-      permissions: input.security.getEffectivePermissions(input.ownerAgentId),
+      permissions: input.security.getEffectivePermissionsWithEphemeralScopes({
+        ownerAgentId: input.ownerAgentId,
+        ...(input.context.approvalState?.ephemeralPermissionScopes == null
+          ? {}
+          : { ephemeralScopes: input.context.approvalState.ephemeralPermissionScopes }),
+      }),
     });
 
     if (access.result === "deny" && access.reason === "hard_deny") {

--- a/src/security/service.ts
+++ b/src/security/service.ts
@@ -71,6 +71,26 @@ export class SecurityService {
   getEffectivePermissions(ownerAgentId: string, activeAt?: Date): EffectivePermissions {
     const grants = this.grantsRepo.listActiveByOwner(ownerAgentId, activeAt);
     const scopes = parseGrantedScopes(grants.map((grant) => grant.scopeJson));
+    return this.buildEffectivePermissionsForScopes(ownerAgentId, scopes);
+  }
+
+  getEffectivePermissionsWithEphemeralScopes(input: {
+    ownerAgentId: string;
+    activeAt?: Date;
+    ephemeralScopes?: PermissionScope[];
+  }): EffectivePermissions {
+    const grants = this.grantsRepo.listActiveByOwner(input.ownerAgentId, input.activeAt);
+    const scopes = [
+      ...parseGrantedScopes(grants.map((grant) => grant.scopeJson)),
+      ...(input.ephemeralScopes ?? []),
+    ];
+    return this.buildEffectivePermissionsForScopes(input.ownerAgentId, scopes);
+  }
+
+  private buildEffectivePermissionsForScopes(
+    ownerAgentId: string,
+    scopes: PermissionScope[],
+  ): EffectivePermissions {
     return buildEffectivePermissions(
       scopes,
       this.systemPolicy,
@@ -84,11 +104,16 @@ export class SecurityService {
     targetPath: string;
     cwd?: string;
     activeAt?: Date;
+    ephemeralScopes?: PermissionScope[];
   }): PermissionCheckResult {
     return checkFilesystemPermission({
       kind: input.kind,
       targetPath: input.targetPath,
-      permissions: this.getEffectivePermissions(input.ownerAgentId, input.activeAt),
+      permissions: this.getEffectivePermissionsWithEphemeralScopes({
+        ownerAgentId: input.ownerAgentId,
+        ...(input.activeAt == null ? {} : { activeAt: input.activeAt }),
+        ...(input.ephemeralScopes == null ? {} : { ephemeralScopes: input.ephemeralScopes }),
+      }),
       ...(input.cwd == null ? {} : { cwd: input.cwd }),
     });
   }
@@ -97,10 +122,15 @@ export class SecurityService {
     ownerAgentId: string;
     kind: DbPermissionKind;
     activeAt?: Date;
+    ephemeralScopes?: PermissionScope[];
   }): PermissionCheckResult {
     return checkDatabasePermission({
       kind: input.kind,
-      permissions: this.getEffectivePermissions(input.ownerAgentId, input.activeAt),
+      permissions: this.getEffectivePermissionsWithEphemeralScopes({
+        ownerAgentId: input.ownerAgentId,
+        ...(input.activeAt == null ? {} : { activeAt: input.activeAt }),
+        ...(input.ephemeralScopes == null ? {} : { ephemeralScopes: input.ephemeralScopes }),
+      }),
     });
   }
 
@@ -108,10 +138,15 @@ export class SecurityService {
     ownerAgentId: string;
     commandPrefix: string[];
     activeAt?: Date;
+    ephemeralScopes?: PermissionScope[];
   }): PermissionCheckResult {
     return checkBashFullAccessPermission({
       commandPrefix: input.commandPrefix,
-      permissions: this.getEffectivePermissions(input.ownerAgentId, input.activeAt),
+      permissions: this.getEffectivePermissionsWithEphemeralScopes({
+        ownerAgentId: input.ownerAgentId,
+        ...(input.activeAt == null ? {} : { activeAt: input.activeAt }),
+        ...(input.ephemeralScopes == null ? {} : { ephemeralScopes: input.ephemeralScopes }),
+      }),
     });
   }
 

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -46,6 +46,7 @@ export {
   type StorageDb,
 } from "@/src/storage/db/client.js";
 export { getProductionDatabasePath, getTestDatabasePath } from "@/src/storage/db/paths.js";
+export { AgentRuntimeModesRepo } from "@/src/storage/repos/agent-runtime-modes.repo.js";
 export { AgentsRepo } from "@/src/storage/repos/agents.repo.js";
 export { ApprovalsRepo } from "@/src/storage/repos/approvals.repo.js";
 export { ChannelInstancesRepo } from "@/src/storage/repos/channel-instances.repo.js";

--- a/src/storage/migrate/files/0002_agent_runtime_modes.sql
+++ b/src/storage/migrate/files/0002_agent_runtime_modes.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS agent_runtime_modes (
+  owner_agent_id TEXT PRIMARY KEY REFERENCES agents(id) ON DELETE CASCADE,
+  yolo_enabled INTEGER NOT NULL DEFAULT 0
+    CHECK (yolo_enabled IN (0, 1)),
+  yolo_enabled_at TEXT
+    CHECK (yolo_enabled_at IS NULL OR (yolo_enabled_at GLOB '????-??-??T??:??:??*Z' AND datetime(yolo_enabled_at) IS NOT NULL)),
+  yolo_updated_at TEXT NOT NULL
+    CHECK (yolo_updated_at GLOB '????-??-??T??:??:??*Z' AND datetime(yolo_updated_at) IS NOT NULL),
+  yolo_updated_by TEXT,
+  approval_streak_count INTEGER NOT NULL DEFAULT 0,
+  approval_streak_started_at TEXT
+    CHECK (approval_streak_started_at IS NULL OR (approval_streak_started_at GLOB '????-??-??T??:??:??*Z' AND datetime(approval_streak_started_at) IS NOT NULL)),
+  last_approval_requested_at TEXT
+    CHECK (last_approval_requested_at IS NULL OR (last_approval_requested_at GLOB '????-??-??T??:??:??*Z' AND datetime(last_approval_requested_at) IS NOT NULL)),
+  last_yolo_prompted_at TEXT
+    CHECK (last_yolo_prompted_at IS NULL OR (last_yolo_prompted_at GLOB '????-??-??T??:??:??*Z' AND datetime(last_yolo_prompted_at) IS NOT NULL)),
+  yolo_prompt_count_today INTEGER NOT NULL DEFAULT 0,
+  yolo_prompt_count_day TEXT,
+  yolo_snoozed_until TEXT
+    CHECK (yolo_snoozed_until IS NULL OR (yolo_snoozed_until GLOB '????-??-??T??:??:??*Z' AND datetime(yolo_snoozed_until) IS NOT NULL))
+);

--- a/src/storage/repos/agent-runtime-modes.repo.ts
+++ b/src/storage/repos/agent-runtime-modes.repo.ts
@@ -1,0 +1,198 @@
+import { eq } from "drizzle-orm";
+
+import { toCanonicalUtcIsoTimestamp } from "@/src/shared/time.js";
+import type { StorageDb } from "@/src/storage/db/client.js";
+import { agentRuntimeModes } from "@/src/storage/schema/tables.js";
+import type { AgentRuntimeMode, NewAgentRuntimeMode } from "@/src/storage/schema/types.js";
+
+export interface SetYoloEnabledInput {
+  ownerAgentId: string;
+  enabled: boolean;
+  updatedAt?: Date;
+  updatedBy?: string | null;
+  snoozedUntil?: Date | null;
+}
+
+export interface ToggleYoloInput {
+  ownerAgentId: string;
+  updatedAt?: Date;
+  updatedBy?: string | null;
+  disableSnoozedUntil?: Date | null;
+}
+
+export interface UpdateYoloPromptStateInput {
+  ownerAgentId: string;
+  updatedAt?: Date;
+  approvalStreakCount?: number;
+  approvalStreakStartedAt?: Date | null;
+  lastApprovalRequestedAt?: Date | null;
+  lastYoloPromptedAt?: Date | null;
+  yoloPromptCountToday?: number;
+  yoloPromptCountDay?: string | null;
+  yoloSnoozedUntil?: Date | null;
+}
+
+export class AgentRuntimeModesRepo {
+  constructor(private readonly db: StorageDb) {}
+
+  getByOwnerAgentId(ownerAgentId: string): AgentRuntimeMode | null {
+    return (
+      this.db
+        .select()
+        .from(agentRuntimeModes)
+        .where(eq(agentRuntimeModes.ownerAgentId, ownerAgentId))
+        .get() ?? null
+    );
+  }
+
+  isYoloEnabled(ownerAgentId: string): boolean {
+    return this.getByOwnerAgentId(ownerAgentId)?.yoloEnabled ?? false;
+  }
+
+  setYoloEnabled(input: SetYoloEnabledInput): AgentRuntimeMode {
+    const updatedAt = input.updatedAt ?? new Date();
+    const updatedAtIso = toCanonicalUtcIsoTimestamp(updatedAt);
+    const yoloEnabledAt = input.enabled ? updatedAtIso : null;
+    const snoozedUntil =
+      input.snoozedUntil === undefined
+        ? undefined
+        : input.snoozedUntil == null
+          ? null
+          : toCanonicalUtcIsoTimestamp(input.snoozedUntil);
+    const row: NewAgentRuntimeMode = {
+      ownerAgentId: input.ownerAgentId,
+      yoloEnabled: input.enabled,
+      yoloEnabledAt,
+      yoloUpdatedAt: updatedAtIso,
+      yoloUpdatedBy: input.updatedBy ?? null,
+      approvalStreakCount: 0,
+      approvalStreakStartedAt: null,
+      lastApprovalRequestedAt: null,
+      lastYoloPromptedAt: null,
+      yoloPromptCountToday: 0,
+      yoloPromptCountDay: null,
+      yoloSnoozedUntil: snoozedUntil ?? null,
+    };
+
+    this.db
+      .insert(agentRuntimeModes)
+      .values(row)
+      .onConflictDoUpdate({
+        target: agentRuntimeModes.ownerAgentId,
+        set: {
+          yoloEnabled: row.yoloEnabled,
+          yoloEnabledAt: row.yoloEnabledAt,
+          yoloUpdatedAt: row.yoloUpdatedAt,
+          yoloUpdatedBy: row.yoloUpdatedBy,
+          approvalStreakCount: 0,
+          approvalStreakStartedAt: null,
+          lastApprovalRequestedAt: null,
+          ...(snoozedUntil === undefined ? {} : { yoloSnoozedUntil: snoozedUntil }),
+        },
+      })
+      .run();
+
+    return this.requireByOwnerAgentId(input.ownerAgentId);
+  }
+
+  toggleYolo(input: ToggleYoloInput): AgentRuntimeMode {
+    const enabled = !this.isYoloEnabled(input.ownerAgentId);
+    return this.setYoloEnabled({
+      ownerAgentId: input.ownerAgentId,
+      enabled,
+      ...(input.updatedAt == null ? {} : { updatedAt: input.updatedAt }),
+      updatedBy: input.updatedBy ?? null,
+      ...(enabled || input.disableSnoozedUntil === undefined
+        ? {}
+        : { snoozedUntil: input.disableSnoozedUntil }),
+    });
+  }
+
+  updateYoloPromptState(input: UpdateYoloPromptStateInput): AgentRuntimeMode {
+    const updatedAt = input.updatedAt ?? new Date();
+    this.ensureRow(input.ownerAgentId, updatedAt);
+
+    this.db
+      .update(agentRuntimeModes)
+      .set({
+        ...(input.approvalStreakCount === undefined
+          ? {}
+          : { approvalStreakCount: input.approvalStreakCount }),
+        ...(input.approvalStreakStartedAt === undefined
+          ? {}
+          : {
+              approvalStreakStartedAt:
+                input.approvalStreakStartedAt == null
+                  ? null
+                  : toCanonicalUtcIsoTimestamp(input.approvalStreakStartedAt),
+            }),
+        ...(input.lastApprovalRequestedAt === undefined
+          ? {}
+          : {
+              lastApprovalRequestedAt:
+                input.lastApprovalRequestedAt == null
+                  ? null
+                  : toCanonicalUtcIsoTimestamp(input.lastApprovalRequestedAt),
+            }),
+        ...(input.lastYoloPromptedAt === undefined
+          ? {}
+          : {
+              lastYoloPromptedAt:
+                input.lastYoloPromptedAt == null
+                  ? null
+                  : toCanonicalUtcIsoTimestamp(input.lastYoloPromptedAt),
+            }),
+        ...(input.yoloPromptCountToday === undefined
+          ? {}
+          : { yoloPromptCountToday: input.yoloPromptCountToday }),
+        ...(input.yoloPromptCountDay === undefined
+          ? {}
+          : { yoloPromptCountDay: input.yoloPromptCountDay }),
+        ...(input.yoloSnoozedUntil === undefined
+          ? {}
+          : {
+              yoloSnoozedUntil:
+                input.yoloSnoozedUntil == null
+                  ? null
+                  : toCanonicalUtcIsoTimestamp(input.yoloSnoozedUntil),
+            }),
+      })
+      .where(eq(agentRuntimeModes.ownerAgentId, input.ownerAgentId))
+      .run();
+
+    return this.requireByOwnerAgentId(input.ownerAgentId);
+  }
+
+  private ensureRow(ownerAgentId: string, now: Date): void {
+    if (this.getByOwnerAgentId(ownerAgentId) != null) {
+      return;
+    }
+
+    this.db
+      .insert(agentRuntimeModes)
+      .values({
+        ownerAgentId,
+        yoloEnabled: false,
+        yoloEnabledAt: null,
+        yoloUpdatedAt: toCanonicalUtcIsoTimestamp(now),
+        yoloUpdatedBy: null,
+        approvalStreakCount: 0,
+        approvalStreakStartedAt: null,
+        lastApprovalRequestedAt: null,
+        lastYoloPromptedAt: null,
+        yoloPromptCountToday: 0,
+        yoloPromptCountDay: null,
+        yoloSnoozedUntil: null,
+      })
+      .onConflictDoNothing()
+      .run();
+  }
+
+  private requireByOwnerAgentId(ownerAgentId: string): AgentRuntimeMode {
+    const row = this.getByOwnerAgentId(ownerAgentId);
+    if (row == null) {
+      throw new Error(`Agent runtime mode row missing after write: ${ownerAgentId}`);
+    }
+    return row;
+  }
+}

--- a/src/storage/schema/relations.ts
+++ b/src/storage/schema/relations.ts
@@ -2,6 +2,7 @@ import { relations } from "drizzle-orm";
 
 import {
   agentPermissionGrants,
+  agentRuntimeModes,
   agents,
   approvalLedger,
   authEvents,
@@ -84,6 +85,10 @@ export const agentsRelations = relations(agents, ({ one, many }) => ({
   taskRuns: many(taskRuns),
   approvals: many(approvalLedger),
   permissionGrants: many(agentPermissionGrants),
+  runtimeMode: one(agentRuntimeModes, {
+    fields: [agents.id],
+    references: [agentRuntimeModes.ownerAgentId],
+  }),
   authEvents: many(authEvents),
   harnessEvents: many(harnessEvents),
   subagentCreationRequests: many(subagentCreationRequests, {
@@ -91,6 +96,13 @@ export const agentsRelations = relations(agents, ({ one, many }) => ({
   }),
   createdFromRequests: many(subagentCreationRequests, {
     relationName: "subagent_creation_request_created_agent",
+  }),
+}));
+
+export const agentRuntimeModesRelations = relations(agentRuntimeModes, ({ one }) => ({
+  ownerAgent: one(agents, {
+    fields: [agentRuntimeModes.ownerAgentId],
+    references: [agents.id],
   }),
 }));
 

--- a/src/storage/schema/tables.ts
+++ b/src/storage/schema/tables.ts
@@ -129,6 +129,23 @@ export const agents = sqliteTable("agents", {
   archivedAt: text("archived_at"),
 });
 
+export const agentRuntimeModes = sqliteTable("agent_runtime_modes", {
+  ownerAgentId: text("owner_agent_id")
+    .primaryKey()
+    .references(() => agents.id, { onDelete: "cascade" }),
+  yoloEnabled: integer("yolo_enabled", { mode: "boolean" }).notNull().default(false),
+  yoloEnabledAt: text("yolo_enabled_at"),
+  yoloUpdatedAt: text("yolo_updated_at").notNull(),
+  yoloUpdatedBy: text("yolo_updated_by"),
+  approvalStreakCount: integer("approval_streak_count").notNull().default(0),
+  approvalStreakStartedAt: text("approval_streak_started_at"),
+  lastApprovalRequestedAt: text("last_approval_requested_at"),
+  lastYoloPromptedAt: text("last_yolo_prompted_at"),
+  yoloPromptCountToday: integer("yolo_prompt_count_today").notNull().default(0),
+  yoloPromptCountDay: text("yolo_prompt_count_day"),
+  yoloSnoozedUntil: text("yolo_snoozed_until"),
+});
+
 export const taskWorkstreams = sqliteTable(
   "task_workstreams",
   {

--- a/src/storage/schema/types.ts
+++ b/src/storage/schema/types.ts
@@ -2,6 +2,7 @@ import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 import type {
   agentPermissionGrants,
+  agentRuntimeModes,
   agents,
   approvalLedger,
   authEvents,
@@ -38,6 +39,9 @@ export type NewChannelThread = InferInsertModel<typeof channelThreads>;
 
 export type Agent = InferSelectModel<typeof agents>;
 export type NewAgent = InferInsertModel<typeof agents>;
+
+export type AgentRuntimeMode = InferSelectModel<typeof agentRuntimeModes>;
+export type NewAgentRuntimeMode = InferInsertModel<typeof agentRuntimeModes>;
 
 export type TaskWorkstream = InferSelectModel<typeof taskWorkstreams>;
 export type NewTaskWorkstream = InferInsertModel<typeof taskWorkstreams>;

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -217,7 +217,10 @@ async function executeBashWithFullAccessIfAllowed(input: {
     }
   }
 
-  if (input.context.approvalState?.bashFullAccess?.approved === true) {
+  if (
+    input.context.approvalState?.bashFullAccess?.approved === true ||
+    input.context.approvalState?.runtimeModeAutoApproval != null
+  ) {
     return await executeFullAccessSandboxedBash({
       context: input.context,
       command: input.args.command,
@@ -231,6 +234,9 @@ async function executeBashWithFullAccessIfAllowed(input: {
       const access = input.security.checkBashFullAccess({
         ownerAgentId,
         commandPrefix: command.argv,
+        ...(input.context.approvalState?.ephemeralPermissionScopes == null
+          ? {}
+          : { ephemeralScopes: input.context.approvalState.ephemeralPermissionScopes }),
       });
       return access.result === "allow";
     });

--- a/src/tools/core/types.ts
+++ b/src/tools/core/types.ts
@@ -3,6 +3,7 @@ import { Errors } from "@sinclair/typebox/errors";
 import { Check, Clone, Default } from "@sinclair/typebox/value";
 import type { SecurityConfig } from "@/src/config/schema.js";
 import type { RunLiveObservabilitySnapshot } from "@/src/runtime/run-observability.js";
+import type { PermissionScope } from "@/src/security/scope.js";
 import type { StorageDb } from "@/src/storage/db/client.js";
 
 export type ToolContentBlock =
@@ -98,11 +99,15 @@ export interface ToolRuntimeControl {
 }
 
 export interface ToolExecutionApprovalState {
+  runtimeModeAutoApproval?: {
+    source: "yolo" | "autopilot";
+  };
   bashFullAccess?: {
     approved: true;
     mode: "one_shot";
     approvalId: number;
   };
+  ephemeralPermissionScopes?: PermissionScope[];
 }
 
 export interface ToolDefinition<TArgs = unknown, TDetails = unknown> {

--- a/src/tools/helpers/common.ts
+++ b/src/tools/helpers/common.ts
@@ -74,6 +74,9 @@ export function createFilesystemAccessController(
       kind: input.kind,
       targetPath: input.targetPath,
       cwd,
+      ...(context.approvalState?.ephemeralPermissionScopes == null
+        ? {}
+        : { ephemeralScopes: context.approvalState.ephemeralPermissionScopes }),
     });
     const normalizedPath = normalizeToolTargetPath(input.targetPath, cwd);
 
@@ -121,6 +124,17 @@ export function createFilesystemAccessController(
           ...(context.toolCallId == null ? {} : { failedToolCallId: context.toolCallId }),
         }),
       );
+    }
+
+    if (context.approvalState?.runtimeModeAutoApproval != null) {
+      return decisions.map(({ normalizedPath }) => ({
+        access: {
+          result: "allow",
+          reason: "granted",
+          summary: `Access auto-approved by ${context.approvalState?.runtimeModeAutoApproval?.source} mode for ${normalizedPath}`,
+        },
+        normalizedPath,
+      }));
     }
 
     const requestedScopes = collectMissingFilesystemScopes(decisions);

--- a/src/tools/query-system-db.ts
+++ b/src/tools/query-system-db.ts
@@ -38,8 +38,11 @@ export function createQuerySystemDbTool() {
       const access = security.checkDatabaseAccess({
         ownerAgentId,
         kind: "db.read",
+        ...(context.approvalState?.ephemeralPermissionScopes == null
+          ? {}
+          : { ephemeralScopes: context.approvalState.ephemeralPermissionScopes }),
       });
-      if (access.result !== "allow") {
+      if (access.result !== "allow" && context.approvalState?.runtimeModeAutoApproval == null) {
         throw toolRecoverableError(access.summary, {
           code: "db_read_not_granted",
           kind: "db.read",

--- a/src/tools/request-permissions.ts
+++ b/src/tools/request-permissions.ts
@@ -129,6 +129,9 @@ export function createRequestPermissionsTool() {
           kind: scope.kind,
           targetPath: scope.path,
           ...(context.cwd == null ? {} : { cwd: context.cwd }),
+          ...(context.approvalState?.ephemeralPermissionScopes == null
+            ? {}
+            : { ephemeralScopes: context.approvalState.ephemeralPermissionScopes }),
         });
         return access.result === "allow";
       });

--- a/tests/agent/yolo-autopilot.test.ts
+++ b/tests/agent/yolo-autopilot.test.ts
@@ -1,0 +1,541 @@
+import { setTimeout as delay } from "node:timers/promises";
+import { Type } from "@sinclair/typebox";
+import { afterEach, describe, expect, test } from "vitest";
+
+import type { AgentRuntimeEvent } from "@/src/agent/events.js";
+import type { AgentAssistantContentBlock } from "@/src/agent/llm/messages.js";
+import { ProviderRegistry } from "@/src/agent/llm/provider-registry.js";
+import { AgentLoop, type AgentModelRunner } from "@/src/agent/loop.js";
+import { AgentSessionService } from "@/src/agent/session.js";
+import { DEFAULT_CONFIG } from "@/src/config/defaults.js";
+import type { AppConfig } from "@/src/config/schema.js";
+import { SessionRunAbortRegistry } from "@/src/runtime/cancel.js";
+import { RuntimeModeService } from "@/src/runtime/runtime-modes.js";
+import { ApprovalsRepo } from "@/src/storage/repos/approvals.repo.js";
+import { MessagesRepo } from "@/src/storage/repos/messages.repo.js";
+import { PermissionGrantsRepo } from "@/src/storage/repos/permission-grants.repo.js";
+import { SessionsRepo } from "@/src/storage/repos/sessions.repo.js";
+import { toolApprovalRequired, toolRecoverableError } from "@/src/tools/core/errors.js";
+import { ToolRegistry } from "@/src/tools/core/registry.js";
+import { defineTool, textToolResult } from "@/src/tools/core/types.js";
+import { createFilesystemAccessController } from "@/src/tools/helpers/common.js";
+import { createRequestPermissionsTool } from "@/src/tools/request-permissions.js";
+import {
+  createTestDatabase,
+  destroyTestDatabase,
+  type TestDatabaseHandle,
+} from "@/tests/storage/helpers/test-db.js";
+
+const NO_ARGS_TOOL_SCHEMA = Type.Object({}, { additionalProperties: false });
+const LOOP_PROTECTED_FILE = "/tmp/pokoclaw-loop-protected.txt";
+
+function createModelConfig(): Pick<AppConfig, "providers" | "models"> {
+  return {
+    providers: {
+      anthropic_main: {
+        api: "anthropic-messages",
+      },
+    },
+    models: {
+      catalog: [
+        {
+          id: "anthropic_main/claude-sonnet-4-5",
+          provider: "anthropic_main",
+          upstreamId: "claude-sonnet-4-5-20250929",
+          contextWindow: 200_000,
+          maxOutputTokens: 16_384,
+          supportsTools: true,
+          supportsVision: true,
+          reasoning: { enabled: true },
+        },
+      ],
+      scenarios: {
+        chat: ["anthropic_main/claude-sonnet-4-5"],
+        compaction: ["anthropic_main/claude-sonnet-4-5"],
+        task: ["anthropic_main/claude-sonnet-4-5"],
+        meditationBucket: [],
+        meditationConsolidation: [],
+      },
+    },
+  };
+}
+
+function seedConversationAndAgentFixture(handle: TestDatabaseHandle): void {
+  handle.storage.sqlite.exec(`
+    INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+    VALUES ('ci_1', 'lark', 'acct_a', '2026-03-22T00:00:00.000Z', '2026-03-22T00:00:00.000Z');
+
+    INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+    VALUES ('conv_1', 'ci_1', 'chat_1', 'dm', '2026-03-22T00:00:00.000Z', '2026-03-22T00:00:00.000Z');
+
+    INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+    VALUES ('branch_1', 'conv_1', 'dm_main', 'main', '2026-03-22T00:00:00.000Z', '2026-03-22T00:00:00.000Z');
+
+    INSERT INTO agents (id, conversation_id, kind, created_at)
+    VALUES ('agent_1', 'conv_1', 'sub', '2026-03-22T00:00:00.000Z');
+  `);
+}
+
+function seedSession(
+  handle: TestDatabaseHandle,
+  content: string,
+): {
+  sessionsRepo: SessionsRepo;
+  messagesRepo: MessagesRepo;
+} {
+  const sessionsRepo = new SessionsRepo(handle.storage.db);
+  const messagesRepo = new MessagesRepo(handle.storage.db);
+  sessionsRepo.create({
+    id: "sess_1",
+    conversationId: "conv_1",
+    branchId: "branch_1",
+    ownerAgentId: "agent_1",
+    purpose: "chat",
+    createdAt: new Date("2026-03-22T00:00:00.000Z"),
+  });
+  messagesRepo.append({
+    id: "msg_user",
+    sessionId: "sess_1",
+    seq: 1,
+    role: "user",
+    payloadJson: JSON.stringify({ content }),
+    createdAt: new Date("2026-03-22T00:00:01.000Z"),
+  });
+  return { sessionsRepo, messagesRepo };
+}
+
+function makeAssistantResult(params: {
+  content: AgentAssistantContentBlock[];
+  stopReason?: "stop" | "length" | "toolUse" | "error" | "aborted";
+}) {
+  return {
+    provider: "anthropic_main",
+    model: "claude-sonnet-4-5",
+    modelApi: "anthropic-messages",
+    stopReason: params.stopReason ?? "stop",
+    content: params.content,
+    usage: {
+      input: 10,
+      output: 5,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 15,
+    },
+  } as const;
+}
+
+async function waitForApprovalRequestCount(
+  events: Array<{ type: string; approvalId?: string }>,
+  count: number,
+): Promise<string[]> {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    const approvalIds = events
+      .filter((event) => event.type === "approval_requested")
+      .map((event) => event.approvalId)
+      .filter((approvalId): approvalId is string => approvalId != null);
+    if (approvalIds.length >= count) {
+      return approvalIds;
+    }
+
+    await delay(5);
+  }
+
+  throw new Error(`Expected ${count} approval requests to be emitted`);
+}
+
+describe("agent loop yolo and autopilot", () => {
+  let handle: TestDatabaseHandle | null = null;
+
+  afterEach(async () => {
+    if (handle != null) {
+      await destroyTestDatabase(handle);
+      handle = null;
+    }
+  });
+
+  test("yolo skips request_permissions approval and retries with ephemeral filesystem scopes", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+    const { sessionsRepo, messagesRepo } = seedSession(handle, "update the file");
+    const runtimeModes = new RuntimeModeService({
+      storage: handle.storage.db,
+      autopilotEnabled: false,
+    });
+    runtimeModes.toggleYolo({
+      ownerAgentId: "agent_1",
+      updatedAt: new Date("2026-03-22T00:00:02.000Z"),
+    });
+
+    let modelTurnCount = 0;
+    let toolExecuteCount = 0;
+    const runner: AgentModelRunner = {
+      async runTurn() {
+        modelTurnCount += 1;
+        if (modelTurnCount === 1) {
+          return makeAssistantResult({
+            stopReason: "toolUse",
+            content: [{ type: "toolCall", id: "tool_1", name: "gated", arguments: {} }],
+          });
+        }
+
+        if (modelTurnCount === 2) {
+          return makeAssistantResult({
+            stopReason: "toolUse",
+            content: [
+              {
+                type: "toolCall",
+                id: "tool_2",
+                name: "request_permissions",
+                arguments: {
+                  entries: [
+                    {
+                      resource: "filesystem",
+                      path: LOOP_PROTECTED_FILE,
+                      scope: "exact",
+                      access: "write",
+                    },
+                  ],
+                  justification: "Need to write the requested note.",
+                  retryToolCallId: "tool_1",
+                },
+              },
+            ],
+          });
+        }
+
+        if (modelTurnCount === 3) {
+          return makeAssistantResult({
+            stopReason: "toolUse",
+            content: [{ type: "toolCall", id: "tool_3", name: "gated", arguments: {} }],
+          });
+        }
+
+        return makeAssistantResult({
+          content: [{ type: "text", text: "done" }],
+        });
+      },
+    };
+
+    const tools = new ToolRegistry([
+      defineTool({
+        name: "gated",
+        description: "Needs approval first",
+        inputSchema: NO_ARGS_TOOL_SCHEMA,
+        execute(context) {
+          toolExecuteCount += 1;
+          const hasEphemeralWrite = context.approvalState?.ephemeralPermissionScopes?.some(
+            (scope) =>
+              scope.kind === "fs.write" && "path" in scope && scope.path === LOOP_PROTECTED_FILE,
+          );
+          if (hasEphemeralWrite !== true) {
+            throw toolRecoverableError("Write access is missing for workspace notes.", {
+              code: "permission_denied",
+              requestable: true,
+              failedToolCallId: "tool_1",
+              summary: "Write access is missing for workspace notes.",
+              entries: [
+                {
+                  resource: "filesystem",
+                  path: LOOP_PROTECTED_FILE,
+                  scope: "exact",
+                  access: "write",
+                },
+              ],
+            });
+          }
+
+          return textToolResult("ok");
+        },
+      }),
+      createRequestPermissionsTool(),
+    ]);
+
+    const loop = new AgentLoop({
+      sessions: new AgentSessionService(sessionsRepo, messagesRepo),
+      messages: messagesRepo,
+      models: new ProviderRegistry(createModelConfig()),
+      tools,
+      cancel: new SessionRunAbortRegistry(),
+      modelRunner: runner,
+      storage: handle.storage.db,
+      securityConfig: DEFAULT_CONFIG.security,
+      compaction: DEFAULT_CONFIG.compaction,
+      runtimeModes,
+    });
+
+    const result = await loop.run({ sessionId: "sess_1", scenario: "chat" });
+
+    expect(toolExecuteCount).toBe(3);
+    expect(
+      result.events.some(
+        (event) => event.type === "approval_requested" || event.type === "approval_resolved",
+      ),
+    ).toBe(false);
+    expect(new PermissionGrantsRepo(handle.storage.db).listByOwner("agent_1")).toEqual([]);
+    expect(new ApprovalsRepo(handle.storage.db).listByOwner("agent_1")).toMatchObject([
+      {
+        status: "approved",
+      },
+    ]);
+  });
+
+  test("yolo lets filesystem tools proceed without first returning an approval block", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+    const { sessionsRepo, messagesRepo } = seedSession(handle, "write directly");
+    const runtimeModes = new RuntimeModeService({
+      storage: handle.storage.db,
+      autopilotEnabled: false,
+    });
+    runtimeModes.toggleYolo({
+      ownerAgentId: "agent_1",
+      updatedAt: new Date("2026-03-22T00:00:02.000Z"),
+    });
+
+    let modelTurnCount = 0;
+    let toolExecuteCount = 0;
+    const runner: AgentModelRunner = {
+      async runTurn() {
+        modelTurnCount += 1;
+        if (modelTurnCount === 1) {
+          return makeAssistantResult({
+            stopReason: "toolUse",
+            content: [{ type: "toolCall", id: "tool_1", name: "direct_write", arguments: {} }],
+          });
+        }
+
+        return makeAssistantResult({
+          content: [{ type: "text", text: "done" }],
+        });
+      },
+    };
+
+    const tools = new ToolRegistry([
+      defineTool({
+        name: "direct_write",
+        description: "Uses the normal filesystem access controller",
+        inputSchema: NO_ARGS_TOOL_SCHEMA,
+        execute(context) {
+          toolExecuteCount += 1;
+          createFilesystemAccessController(context).require({
+            kind: "fs.write",
+            targetPath: LOOP_PROTECTED_FILE,
+          });
+          return textToolResult("ok");
+        },
+      }),
+    ]);
+
+    const loop = new AgentLoop({
+      sessions: new AgentSessionService(sessionsRepo, messagesRepo),
+      messages: messagesRepo,
+      models: new ProviderRegistry(createModelConfig()),
+      tools,
+      cancel: new SessionRunAbortRegistry(),
+      modelRunner: runner,
+      storage: handle.storage.db,
+      securityConfig: DEFAULT_CONFIG.security,
+      compaction: DEFAULT_CONFIG.compaction,
+      runtimeModes,
+    });
+
+    const result = await loop.run({ sessionId: "sess_1", scenario: "chat" });
+
+    expect(toolExecuteCount).toBe(1);
+    expect(result.events.some((event) => event.type === "tool_call_failed")).toBe(false);
+    expect(
+      result.events.some(
+        (event) => event.type === "approval_requested" || event.type === "approval_resolved",
+      ),
+    ).toBe(false);
+    expect(new ApprovalsRepo(handle.storage.db).listByOwner("agent_1")).toEqual([]);
+  });
+
+  test("autopilot skips bash full_access approval as one-shot without durable grants", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+    const { sessionsRepo, messagesRepo } = seedSession(handle, "run full access command");
+    const runtimeModes = new RuntimeModeService({
+      storage: handle.storage.db,
+      autopilotEnabled: true,
+    });
+    let toolExecuteCount = 0;
+    const runner: AgentModelRunner = {
+      async runTurn() {
+        if (toolExecuteCount === 0) {
+          return makeAssistantResult({
+            stopReason: "toolUse",
+            content: [{ type: "toolCall", id: "tool_1", name: "full_access_step", arguments: {} }],
+          });
+        }
+
+        return makeAssistantResult({
+          content: [{ type: "text", text: "done" }],
+        });
+      },
+    };
+
+    const tools = new ToolRegistry([
+      defineTool({
+        name: "full_access_step",
+        description: "Needs full access first",
+        inputSchema: NO_ARGS_TOOL_SCHEMA,
+        execute(context) {
+          toolExecuteCount += 1;
+          if (context.approvalState?.bashFullAccess?.approved === true) {
+            return textToolResult("ok");
+          }
+
+          throw toolApprovalRequired({
+            request: {
+              scopes: [{ kind: "bash.full_access", prefix: ["git"] }],
+            },
+            reasonText: "Need to run git with full access.",
+            grantOnApprove: true,
+          });
+        },
+      }),
+    ]);
+
+    const loop = new AgentLoop({
+      sessions: new AgentSessionService(sessionsRepo, messagesRepo),
+      messages: messagesRepo,
+      models: new ProviderRegistry(createModelConfig()),
+      tools,
+      cancel: new SessionRunAbortRegistry(),
+      modelRunner: runner,
+      storage: handle.storage.db,
+      securityConfig: DEFAULT_CONFIG.security,
+      compaction: DEFAULT_CONFIG.compaction,
+      runtimeModes,
+    });
+
+    const result = await loop.run({ sessionId: "sess_1", scenario: "chat" });
+
+    expect(toolExecuteCount).toBe(2);
+    expect(
+      result.events.some(
+        (event) => event.type === "approval_requested" || event.type === "approval_resolved",
+      ),
+    ).toBe(false);
+    expect(new PermissionGrantsRepo(handle.storage.db).listByOwner("agent_1")).toEqual([]);
+    expect(new ApprovalsRepo(handle.storage.db).listByOwner("agent_1")).toMatchObject([
+      {
+        status: "approved",
+      },
+    ]);
+  });
+
+  test("emits a yolo suggestion after two user approvals in the streak window", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+    const { sessionsRepo, messagesRepo } = seedSession(handle, "run two gated steps");
+    const runtimeModes = new RuntimeModeService({
+      storage: handle.storage.db,
+      autopilotEnabled: false,
+    });
+    let modelTurnCount = 0;
+    let toolExecuteCount = 0;
+    const runner: AgentModelRunner = {
+      async runTurn() {
+        modelTurnCount += 1;
+        if (modelTurnCount <= 2) {
+          return makeAssistantResult({
+            stopReason: "toolUse",
+            content: [
+              {
+                type: "toolCall",
+                id: `tool_${modelTurnCount}`,
+                name: "needs_approval",
+                arguments: {},
+              },
+            ],
+          });
+        }
+
+        return makeAssistantResult({
+          content: [{ type: "text", text: "done" }],
+        });
+      },
+    };
+
+    const tools = new ToolRegistry([
+      defineTool({
+        name: "needs_approval",
+        description: "Approval-gated step",
+        inputSchema: NO_ARGS_TOOL_SCHEMA,
+        execute() {
+          toolExecuteCount += 1;
+          if (toolExecuteCount % 2 === 1) {
+            throw toolApprovalRequired({
+              request: {
+                scopes: [{ kind: "db.read", database: "system" }],
+              },
+              reasonText: "Need database read for diagnostics.",
+              grantOnApprove: false,
+            });
+          }
+
+          return textToolResult("ok");
+        },
+      }),
+    ]);
+
+    const emittedEvents: AgentRuntimeEvent[] = [];
+    const loop = new AgentLoop({
+      sessions: new AgentSessionService(sessionsRepo, messagesRepo),
+      messages: messagesRepo,
+      models: new ProviderRegistry(createModelConfig()),
+      tools,
+      cancel: new SessionRunAbortRegistry(),
+      modelRunner: runner,
+      storage: handle.storage.db,
+      securityConfig: DEFAULT_CONFIG.security,
+      compaction: DEFAULT_CONFIG.compaction,
+      runtimeModes,
+      emitEvent(event) {
+        emittedEvents.push(event);
+      },
+    });
+
+    const runPromise = loop.run({ sessionId: "sess_1", scenario: "chat" });
+    const firstApprovalId = Number((await waitForApprovalRequestCount(emittedEvents, 1))[0]);
+    expect(
+      loop.submitApprovalResponse({
+        approvalId: firstApprovalId,
+        decision: "approve",
+        actor: "user",
+        rawInput: "approve",
+        grantedBy: "user",
+      }),
+    ).toBe(true);
+
+    const secondApprovalId = Number((await waitForApprovalRequestCount(emittedEvents, 2))[1]);
+    expect(emittedEvents.find((event) => event.type === "runtime_nudge")).toMatchObject({
+      type: "runtime_nudge",
+      ownerAgentId: "agent_1",
+      anchor: {
+        type: "approval_flow",
+      },
+      nudge: {
+        kind: "yolo_suggestion",
+        message:
+          "💡 Too many approval stops? Send `/yolo` if you want this agent to keep going without asking each time.",
+      },
+    });
+    expect(
+      loop.submitApprovalResponse({
+        approvalId: secondApprovalId,
+        decision: "approve",
+        actor: "user",
+        rawInput: "approve",
+        grantedBy: "user",
+      }),
+    ).toBe(true);
+
+    const result = await runPromise;
+
+    expect(toolExecuteCount).toBe(4);
+    expect(result.events.some((event) => event.type === "runtime_nudge")).toBe(true);
+  });
+});

--- a/tests/channels/help.test.ts
+++ b/tests/channels/help.test.ts
@@ -14,6 +14,7 @@ describe("slash command help presentation", () => {
         "- /status — Show the current conversation status, model, usage, and active runs.",
         "- /model — Open the model switch card for the current conversation.",
         "- /stop — Stop the current conversation or session.",
+        "- /yolo — Toggle YOLO mode for this agent.",
       ].join("\n"),
     );
   });

--- a/tests/channels/lark/approval-nudge.test.ts
+++ b/tests/channels/lark/approval-nudge.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "vitest";
+
+import type { RuntimeNudgeEvent } from "@/src/agent/events.js";
+import {
+  addLarkApprovalRuntimeNudge,
+  createLarkApprovalStateFromRequest,
+} from "@/src/channels/lark/approval-state.js";
+import { buildLarkRenderedApprovalCard } from "@/src/channels/lark/render.js";
+
+function makeYoloSuggestionEvent(flowId: string): RuntimeNudgeEvent {
+  return {
+    type: "runtime_nudge",
+    eventId: "evt_nudge_1",
+    createdAt: "2026-03-28T00:00:01.000Z",
+    sessionId: "sess_1",
+    conversationId: "conv_1",
+    branchId: "branch_1",
+    runId: "run_1",
+    ownerAgentId: "agent_1",
+    anchor: {
+      type: "approval_flow",
+      id: flowId,
+    },
+    nudge: {
+      kind: "yolo_suggestion",
+      message:
+        "💡 Too many approval stops? Send `/yolo` if you want this agent to keep going without asking each time.",
+    },
+  };
+}
+
+describe("lark approval runtime nudges", () => {
+  test("renders anchored yolo suggestions inside the live approval card", () => {
+    const approvalState = createLarkApprovalStateFromRequest({
+      event: {
+        type: "approval_requested",
+        eventId: "evt_approval_1",
+        createdAt: "2026-03-28T00:00:00.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        approvalId: "approval_1",
+        approvalFlowId: "flow_1",
+        approvalAttemptIndex: 1,
+        approvalTarget: "user",
+        title: "Approval required",
+        request: {
+          scopes: [{ kind: "fs.write", path: "/tmp/output.txt" }],
+        },
+        reasonText: "需要写入输出文件。",
+        expiresAt: "2026-03-28T00:05:00.000Z",
+      },
+      sourceRunCardObjectId: "run_1:seg:1",
+    });
+
+    const withNudge = addLarkApprovalRuntimeNudge(approvalState, makeYoloSuggestionEvent("flow_1"));
+    const card = buildLarkRenderedApprovalCard(withNudge).card as {
+      body?: { elements?: Array<Record<string, unknown>> };
+    };
+    const elements = card.body?.elements ?? [];
+    const bodyMarkdown = elements[0]?.content;
+    const nudgeMarkdown = elements[1]?.content;
+    const cardText = JSON.stringify(card);
+
+    expect(cardText).toContain(
+      "> 💡 Too many approval stops? Send `/yolo` if you want this agent to keep going without asking each time.",
+    );
+    expect(bodyMarkdown).toEqual(expect.stringContaining("**有效期至**"));
+    expect(bodyMarkdown).not.toEqual(expect.stringContaining("Too many approval stops?"));
+    expect(nudgeMarkdown).toBe(
+      "> 💡 Too many approval stops? Send `/yolo` if you want this agent to keep going without asking each time.",
+    );
+    expect(cardText).not.toContain("你处理后，agent 才会继续执行");
+  });
+
+  test("drops anchored nudges once the approval card is no longer live", () => {
+    const approvalState = createLarkApprovalStateFromRequest({
+      event: {
+        type: "approval_requested",
+        eventId: "evt_approval_2",
+        createdAt: "2026-03-28T00:00:00.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        approvalId: "approval_2",
+        approvalFlowId: "flow_2",
+        approvalAttemptIndex: 1,
+        approvalTarget: "user",
+        title: "Approval required",
+        request: {
+          scopes: [{ kind: "fs.write", path: "/tmp/output.txt" }],
+        },
+        reasonText: "需要写入输出文件。",
+        expiresAt: null,
+      },
+      sourceRunCardObjectId: "run_1:seg:1",
+    });
+    const resolved = {
+      ...approvalState,
+      currentApprovalId: null,
+      phase: "approved" as const,
+      resolved: true,
+      decision: "approve" as const,
+      actor: "user",
+    };
+
+    expect(addLarkApprovalRuntimeNudge(resolved, makeYoloSuggestionEvent("flow_2"))).toBe(resolved);
+  });
+});

--- a/tests/channels/lark/inbound/slash-commands.test.ts
+++ b/tests/channels/lark/inbound/slash-commands.test.ts
@@ -7,7 +7,9 @@ import {
 } from "@/src/channels/lark/inbound.js";
 import { SessionRunAbortRegistry } from "@/src/runtime/cancel.js";
 import { RuntimeControlService } from "@/src/runtime/control.js";
+import { RuntimeModeService } from "@/src/runtime/runtime-modes.js";
 import type { RuntimeStatusService } from "@/src/runtime/status.js";
+import { AgentRuntimeModesRepo } from "@/src/storage/repos/agent-runtime-modes.repo.js";
 import { ChannelSurfacesRepo } from "@/src/storage/repos/channel-surfaces.repo.js";
 import { LarkObjectBindingsRepo } from "@/src/storage/repos/lark-object-bindings.repo.js";
 import { makeTextEvent, seedFixture, withHandle } from "./fixtures.js";
@@ -250,6 +252,12 @@ describe("lark inbound slash commands", () => {
             supportsReasoning: true,
             source: "scenario_default" as const,
           },
+          runtimeMode: {
+            source: "normal" as const,
+            autopilotEnabled: false,
+            yoloEnabled: false,
+            skipHumanApproval: false,
+          },
           sessionUsage: {
             input: 1,
             output: 2,
@@ -376,6 +384,12 @@ describe("lark inbound slash commands", () => {
             supportsReasoning: true,
             source: "scenario_default" as const,
           },
+          runtimeMode: {
+            source: "normal" as const,
+            autopilotEnabled: false,
+            yoloEnabled: false,
+            skipHumanApproval: false,
+          },
           sessionUsage: {
             input: 1,
             output: 2,
@@ -475,6 +489,12 @@ describe("lark inbound slash commands", () => {
             supportsReasoning: true,
             source: "scenario_default" as const,
           },
+          runtimeMode: {
+            source: "normal" as const,
+            autopilotEnabled: false,
+            yoloEnabled: false,
+            skipHumanApproval: false,
+          },
           sessionUsage: {
             input: 100,
             output: 20,
@@ -546,6 +566,7 @@ describe("lark inbound slash commands", () => {
         .join("\n");
       expect(markdown).toContain("openrouter-gpt5.4");
       expect(markdown).toContain("**版本**");
+      expect(markdown).toContain("**运行模式**：🧸 手动审批");
     });
   });
 
@@ -614,8 +635,73 @@ describe("lark inbound slash commands", () => {
           "- /status — Show the current conversation status, model, usage, and active runs.",
           "- /model — Open the model switch card for the current conversation.",
           "- /stop — Stop the current conversation or session.",
+          "- /yolo — Toggle YOLO mode for this agent.",
         ].join("\n"),
       );
+    });
+  });
+
+  test("toggles /yolo for the current main chat owner agent", async () => {
+    await withHandle(async (handle) => {
+      seedFixture(handle);
+      new ChannelSurfacesRepo(handle.storage.db).upsert({
+        id: "surface_yolo_1",
+        channelType: "lark",
+        channelInstallationId: "default",
+        conversationId: "conv_main",
+        branchId: "branch_main",
+        surfaceKey: buildLarkChatSurfaceKey("oc_chat_1"),
+        surfaceObjectJson: JSON.stringify({ chat_id: "oc_chat_1" }),
+      });
+
+      const submitMessage = vi.fn(async () => ({ status: "started" as const }));
+      const create = vi.fn(async () => ({ data: { message_id: "om_yolo_1" } }));
+      const runtimeModes = new RuntimeModeService({
+        storage: handle.storage.db,
+        autopilotEnabled: false,
+      });
+      const handler = createLarkMessageReceiveHandler({
+        installationId: "default",
+        storage: handle.storage.db,
+        ingress: { submitMessage, submitApprovalDecision: vi.fn(() => false) },
+        control: new RuntimeControlService(new SessionRunAbortRegistry()),
+        runtimeModes,
+        clients: {
+          getOrCreate: vi.fn(() => ({
+            sdk: {
+              im: {
+                message: {
+                  create,
+                  reply: vi.fn(),
+                },
+              },
+            },
+          })) as unknown as (installationId: string) => LarkSdkClient,
+        },
+      });
+
+      await handler(makeTextEvent("/yolo"));
+      await handler(makeTextEvent("/yolo"));
+
+      expect(submitMessage).not.toHaveBeenCalled();
+      expect(new AgentRuntimeModesRepo(handle.storage.db).isYoloEnabled("agent_main")).toBe(false);
+      expect(create).toHaveBeenCalledTimes(2);
+      const firstCall = create.mock.calls[0] as [Record<string, unknown>] | undefined;
+      const secondCall = create.mock.calls[1] as [Record<string, unknown>] | undefined;
+      expect(
+        JSON.parse(
+          String((firstCall?.[0] as { data?: { content?: string } } | undefined)?.data?.content),
+        ),
+      ).toEqual({
+        text: "⚠️ YOLO mode is on. Risky actions may run without asking first. Send /yolo again to turn it off.",
+      });
+      expect(
+        JSON.parse(
+          String((secondCall?.[0] as { data?: { content?: string } } | undefined)?.data?.content),
+        ),
+      ).toEqual({
+        text: "🔒 YOLO mode is off. Future privileged actions will ask for approval again.",
+      });
     });
   });
 });

--- a/tests/channels/lark/yolo-autopilot-outbound.test.ts
+++ b/tests/channels/lark/yolo-autopilot-outbound.test.ts
@@ -1,0 +1,307 @@
+import { Type } from "@sinclair/typebox";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { AgentAssistantContentBlock } from "@/src/agent/llm/messages.js";
+import { ProviderRegistry } from "@/src/agent/llm/provider-registry.js";
+import { AgentLoop, type AgentModelRunner } from "@/src/agent/loop.js";
+import { AgentSessionService } from "@/src/agent/session.js";
+import { createLarkOutboundRuntime } from "@/src/channels/lark/outbound.js";
+import { DEFAULT_CONFIG } from "@/src/config/defaults.js";
+import type { AppConfig } from "@/src/config/schema.js";
+import {
+  type OrchestratedOutboundEventEnvelope,
+  projectRuntimeEvent,
+} from "@/src/orchestration/outbound-events.js";
+import { SessionRunAbortRegistry } from "@/src/runtime/cancel.js";
+import { RuntimeEventBus } from "@/src/runtime/event-bus.js";
+import { RuntimeModeService } from "@/src/runtime/runtime-modes.js";
+import { ChannelSurfacesRepo } from "@/src/storage/repos/channel-surfaces.repo.js";
+import { MessagesRepo } from "@/src/storage/repos/messages.repo.js";
+import { SessionsRepo } from "@/src/storage/repos/sessions.repo.js";
+import { toolRecoverableError } from "@/src/tools/core/errors.js";
+import { ToolRegistry } from "@/src/tools/core/registry.js";
+import { defineTool, textToolResult } from "@/src/tools/core/types.js";
+import { createRequestPermissionsTool } from "@/src/tools/request-permissions.js";
+import {
+  createTestDatabase,
+  destroyTestDatabase,
+  type TestDatabaseHandle,
+} from "@/tests/storage/helpers/test-db.js";
+
+const NO_ARGS_TOOL_SCHEMA = Type.Object({}, { additionalProperties: false });
+const PROTECTED_FILE = "/tmp/pokoclaw-yolo-outbound-regression.txt";
+
+function createModelConfig(): Pick<AppConfig, "providers" | "models"> {
+  return {
+    providers: {
+      anthropic_main: {
+        api: "anthropic-messages",
+      },
+    },
+    models: {
+      catalog: [
+        {
+          id: "anthropic_main/claude-sonnet-4-5",
+          provider: "anthropic_main",
+          upstreamId: "claude-sonnet-4-5-20250929",
+          contextWindow: 200_000,
+          maxOutputTokens: 16_384,
+          supportsTools: true,
+          supportsVision: true,
+          reasoning: { enabled: true },
+        },
+      ],
+      scenarios: {
+        chat: ["anthropic_main/claude-sonnet-4-5"],
+        compaction: ["anthropic_main/claude-sonnet-4-5"],
+        task: ["anthropic_main/claude-sonnet-4-5"],
+        meditationBucket: [],
+        meditationConsolidation: [],
+      },
+    },
+  };
+}
+
+function seedFixture(handle: TestDatabaseHandle): {
+  sessionsRepo: SessionsRepo;
+  messagesRepo: MessagesRepo;
+} {
+  handle.storage.sqlite.exec(`
+    INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+    VALUES ('ci_lark_default', 'lark', 'default', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+    INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+    VALUES ('conv_1', 'ci_lark_default', 'oc_chat_1', 'dm', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+    INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+    VALUES ('branch_1', 'conv_1', 'dm_main', 'main', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+    INSERT INTO agents (id, conversation_id, kind, created_at)
+    VALUES ('agent_1', 'conv_1', 'main', '2026-03-28T00:00:00.000Z');
+  `);
+
+  new ChannelSurfacesRepo(handle.storage.db).upsert({
+    id: "surface_1",
+    channelType: "lark",
+    channelInstallationId: "default",
+    conversationId: "conv_1",
+    branchId: "branch_1",
+    surfaceKey: "chat:oc_chat_1",
+    surfaceObjectJson: JSON.stringify({ chat_id: "oc_chat_1" }),
+  });
+
+  const sessionsRepo = new SessionsRepo(handle.storage.db);
+  const messagesRepo = new MessagesRepo(handle.storage.db);
+  sessionsRepo.create({
+    id: "sess_1",
+    conversationId: "conv_1",
+    branchId: "branch_1",
+    ownerAgentId: "agent_1",
+    purpose: "chat",
+    createdAt: new Date("2026-03-28T00:00:01.000Z"),
+  });
+  messagesRepo.append({
+    id: "msg_user",
+    sessionId: "sess_1",
+    seq: 1,
+    role: "user",
+    payloadJson: JSON.stringify({ content: "update the protected file" }),
+    createdAt: new Date("2026-03-28T00:00:02.000Z"),
+  });
+
+  return { sessionsRepo, messagesRepo };
+}
+
+function makeAssistantResult(params: {
+  content: AgentAssistantContentBlock[];
+  stopReason?: "stop" | "length" | "toolUse" | "error" | "aborted";
+}) {
+  return {
+    provider: "anthropic_main",
+    model: "claude-sonnet-4-5",
+    modelApi: "anthropic-messages",
+    stopReason: params.stopReason ?? "stop",
+    content: params.content,
+    usage: {
+      input: 10,
+      output: 5,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 15,
+    },
+  } as const;
+}
+
+function countBindings(handle: TestDatabaseHandle, kind: string): number {
+  const row = handle.storage.sqlite
+    .prepare("SELECT COUNT(*) AS count FROM lark_object_bindings WHERE internal_object_kind = ?")
+    .get(kind) as { count: number } | undefined;
+  return row?.count ?? 0;
+}
+
+describe("lark outbound yolo autopilot regression", () => {
+  let handle: TestDatabaseHandle | null = null;
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    if (handle != null) {
+      await destroyTestDatabase(handle);
+      handle = null;
+    }
+  });
+
+  test("does not create approval cards for yolo auto-approved request_permissions", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    const { sessionsRepo, messagesRepo } = seedFixture(handle);
+    const runtimeModes = new RuntimeModeService({
+      storage: handle.storage.db,
+      autopilotEnabled: false,
+    });
+    runtimeModes.toggleYolo({
+      ownerAgentId: "agent_1",
+      updatedAt: new Date("2026-03-28T00:00:03.000Z"),
+    });
+
+    let modelTurnCount = 0;
+    const runner: AgentModelRunner = {
+      async runTurn() {
+        modelTurnCount += 1;
+        if (modelTurnCount === 1) {
+          return makeAssistantResult({
+            stopReason: "toolUse",
+            content: [{ type: "toolCall", id: "tool_1", name: "gated_write", arguments: {} }],
+          });
+        }
+        if (modelTurnCount === 2) {
+          return makeAssistantResult({
+            stopReason: "toolUse",
+            content: [
+              {
+                type: "toolCall",
+                id: "tool_2",
+                name: "request_permissions",
+                arguments: {
+                  entries: [
+                    {
+                      resource: "filesystem",
+                      path: PROTECTED_FILE,
+                      scope: "exact",
+                      access: "write",
+                    },
+                  ],
+                  justification: "Need to write the requested output file.",
+                  retryToolCallId: "tool_1",
+                },
+              },
+            ],
+          });
+        }
+        return makeAssistantResult({
+          content: [{ type: "text", text: "done" }],
+        });
+      },
+    };
+
+    const loop = new AgentLoop({
+      sessions: new AgentSessionService(sessionsRepo, messagesRepo),
+      messages: messagesRepo,
+      models: new ProviderRegistry(createModelConfig()),
+      tools: new ToolRegistry([
+        defineTool({
+          name: "gated_write",
+          description: "Needs a write grant",
+          inputSchema: NO_ARGS_TOOL_SCHEMA,
+          execute(context) {
+            const hasWrite = context.approvalState?.ephemeralPermissionScopes?.some(
+              (scope) =>
+                scope.kind === "fs.write" && "path" in scope && scope.path === PROTECTED_FILE,
+            );
+            if (hasWrite !== true) {
+              throw toolRecoverableError("Write access is missing.", {
+                code: "permission_denied",
+                requestable: true,
+                failedToolCallId: "tool_1",
+                summary: "Write access is missing.",
+                entries: [
+                  {
+                    resource: "filesystem",
+                    path: PROTECTED_FILE,
+                    scope: "exact",
+                    access: "write",
+                  },
+                ],
+              });
+            }
+            return textToolResult("ok");
+          },
+        }),
+        createRequestPermissionsTool(),
+      ]),
+      cancel: new SessionRunAbortRegistry(),
+      modelRunner: runner,
+      storage: handle.storage.db,
+      securityConfig: DEFAULT_CONFIG.security,
+      compaction: DEFAULT_CONFIG.compaction,
+      runtimeModes,
+    });
+
+    const result = await loop.run({ sessionId: "sess_1", scenario: "chat" });
+    expect(result.events.some((event) => event.type === "approval_requested")).toBe(false);
+    expect(countBindings(handle, "approval_card")).toBe(0);
+
+    vi.useFakeTimers();
+    let cardCounter = 0;
+    const createCard = vi.fn(async () => {
+      cardCounter += 1;
+      return {
+        data: {
+          card_id: `card_${cardCounter}`,
+        },
+      };
+    });
+    const createMessage = vi.fn(async () => ({
+      data: {
+        message_id: "om_card_1",
+        open_message_id: "om_open_1",
+      },
+    }));
+    const bus = new RuntimeEventBus<OrchestratedOutboundEventEnvelope>();
+    const outbound = createLarkOutboundRuntime({
+      storage: handle.storage.db,
+      outboundEventBus: bus,
+      clients: {
+        getOrCreate: () =>
+          ({
+            sdk: {
+              cardkit: {
+                v1: {
+                  card: {
+                    create: createCard,
+                    update: vi.fn(async () => ({})),
+                  },
+                  cardElement: {
+                    content: vi.fn(async () => ({})),
+                  },
+                },
+              },
+              im: {
+                message: {
+                  create: createMessage,
+                },
+              },
+            },
+          }) as never,
+      },
+    });
+
+    outbound.start();
+    for (const event of result.events) {
+      bus.publish(projectRuntimeEvent({ db: handle.storage.db, event }));
+    }
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(countBindings(handle, "run_card")).toBeGreaterThan(0);
+    expect(countBindings(handle, "approval_card")).toBe(0);
+    await outbound.shutdown();
+  });
+});

--- a/tests/config/load.test.ts
+++ b/tests/config/load.test.ts
@@ -190,6 +190,7 @@ describe("config loader", () => {
       maxTurns: 60,
       approvalTimeoutMs: 180_000,
       approvalGrantTtlMs: 604_800_000,
+      autopilot: false,
     });
     expect(config.selfHarness).toEqual({
       meditation: {
@@ -494,6 +495,7 @@ describe("config loader", () => {
         "maxTurns = 24",
         "approvalTimeoutMs = 240000",
         "approvalGrantTtlMs = 172800000",
+        "autopilot = true",
         "",
       ].join("\n"),
       "utf8",
@@ -505,7 +507,17 @@ describe("config loader", () => {
       maxTurns: 24,
       approvalTimeoutMs: 240_000,
       approvalGrantTtlMs: 172_800_000,
+      autopilot: true,
     });
+  });
+
+  test("rejects invalid runtime autopilot config", async () => {
+    const configPath = path.join(tempDir, "config.toml");
+    await writeFile(configPath, ["[runtime]", 'autopilot = "yes"', ""].join("\n"), "utf8");
+
+    await expect(loadConfig({ configTomlPath: configPath })).rejects.toThrow(
+      "config.toml runtime.autopilot must be a boolean",
+    );
   });
 
   test("rejects enabled web tools without a provider", async () => {

--- a/tests/runtime/bootstrap.test.ts
+++ b/tests/runtime/bootstrap.test.ts
@@ -34,6 +34,7 @@ function createConfig(): AppConfig {
       maxTurns: 60,
       approvalTimeoutMs: 180_000,
       approvalGrantTtlMs: 604_800_000,
+      autopilot: false,
     },
     selfHarness: {
       meditation: {

--- a/tests/runtime/runtime-modes.test.ts
+++ b/tests/runtime/runtime-modes.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, test } from "vitest";
+
+import {
+  RuntimeModeService,
+  YOLO_MANUAL_DISABLE_SNOOZE_MS,
+  YOLO_SUGGESTION_DEBOUNCE_MS,
+  YOLO_SUGGESTION_MESSAGE,
+} from "@/src/runtime/runtime-modes.js";
+import { AgentRuntimeModesRepo } from "@/src/storage/repos/agent-runtime-modes.repo.js";
+import {
+  createTestDatabase,
+  destroyTestDatabase,
+  type TestDatabaseHandle,
+} from "@/tests/storage/helpers/test-db.js";
+
+function seedAgentFixture(handle: TestDatabaseHandle): void {
+  handle.storage.sqlite.exec(`
+    INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+    VALUES ('ci_1', 'lark', 'acct_a', '2026-03-22T00:00:00.000Z', '2026-03-22T00:00:00.000Z');
+    INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+    VALUES ('conv_1', 'ci_1', 'chat_1', 'dm', '2026-03-22T00:00:00.000Z', '2026-03-22T00:00:00.000Z');
+    INSERT INTO agents (id, conversation_id, kind, created_at)
+    VALUES ('agent_1', 'conv_1', 'main', '2026-03-22T00:00:00.000Z');
+  `);
+}
+
+describe("runtime mode service", () => {
+  let handle: TestDatabaseHandle | null = null;
+
+  afterEach(async () => {
+    if (handle != null) {
+      await destroyTestDatabase(handle);
+      handle = null;
+    }
+  });
+
+  test("suggests yolo after two user approvals within five minutes", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedAgentFixture(handle);
+    const service = new RuntimeModeService({
+      storage: handle.storage.db,
+      autopilotEnabled: false,
+    });
+
+    expect(YOLO_SUGGESTION_MESSAGE).toBe(
+      "💡 Too many approval stops? Send `/yolo` if you want this agent to keep going without asking each time.",
+    );
+    expect(
+      service.recordApprovalRequestForYoloSuggestion({
+        ownerAgentId: "agent_1",
+        approvalTarget: "user",
+        requestedAt: new Date("2026-03-22T00:00:00.000Z"),
+      }),
+    ).toBe(false);
+    expect(
+      service.recordApprovalRequestForYoloSuggestion({
+        ownerAgentId: "agent_1",
+        approvalTarget: "user",
+        requestedAt: new Date("2026-03-22T00:04:59.000Z"),
+      }),
+    ).toBe(true);
+
+    const row = new AgentRuntimeModesRepo(handle.storage.db).getByOwnerAgentId("agent_1");
+    expect(row).toMatchObject({
+      approvalStreakCount: 0,
+      approvalStreakStartedAt: null,
+      lastYoloPromptedAt: "2026-03-22T00:04:59.000Z",
+      yoloSnoozedUntil: null,
+    });
+  });
+
+  test("debounces automatic yolo suggestions for twelve hours", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedAgentFixture(handle);
+    const service = new RuntimeModeService({
+      storage: handle.storage.db,
+      autopilotEnabled: false,
+    });
+
+    expect(
+      service.recordApprovalRequestForYoloSuggestion({
+        ownerAgentId: "agent_1",
+        approvalTarget: "user",
+        requestedAt: new Date("2026-03-22T00:00:00.000Z"),
+      }),
+    ).toBe(false);
+    expect(
+      service.recordApprovalRequestForYoloSuggestion({
+        ownerAgentId: "agent_1",
+        approvalTarget: "user",
+        requestedAt: new Date("2026-03-22T00:01:00.000Z"),
+      }),
+    ).toBe(true);
+
+    const beforeDebounceEnds = new Date(
+      new Date("2026-03-22T00:01:00.000Z").getTime() + YOLO_SUGGESTION_DEBOUNCE_MS - 1,
+    );
+    expect(
+      service.recordApprovalRequestForYoloSuggestion({
+        ownerAgentId: "agent_1",
+        approvalTarget: "user",
+        requestedAt: beforeDebounceEnds,
+      }),
+    ).toBe(false);
+
+    expect(
+      service.recordApprovalRequestForYoloSuggestion({
+        ownerAgentId: "agent_1",
+        approvalTarget: "user",
+        requestedAt: new Date("2026-03-22T12:01:00.000Z"),
+      }),
+    ).toBe(false);
+    expect(
+      service.recordApprovalRequestForYoloSuggestion({
+        ownerAgentId: "agent_1",
+        approvalTarget: "user",
+        requestedAt: new Date("2026-03-22T12:02:00.000Z"),
+      }),
+    ).toBe(true);
+  });
+
+  test("does not suggest in autopilot or when yolo is enabled", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedAgentFixture(handle);
+    const service = new RuntimeModeService({
+      storage: handle.storage.db,
+      autopilotEnabled: false,
+    });
+
+    expect(
+      service.recordApprovalRequestForYoloSuggestion({
+        ownerAgentId: "agent_1",
+        approvalTarget: "user",
+        requestedAt: new Date("2026-03-22T00:00:00.000Z"),
+      }),
+    ).toBe(false);
+    expect(
+      service.recordApprovalRequestForYoloSuggestion({
+        ownerAgentId: "agent_1",
+        approvalTarget: "user",
+        requestedAt: new Date("2026-03-22T00:01:00.000Z"),
+      }),
+    ).toBe(true);
+    expect(
+      service.recordApprovalRequestForYoloSuggestion({
+        ownerAgentId: "agent_1",
+        approvalTarget: "user",
+        requestedAt: new Date("2026-03-23T00:01:00.000Z"),
+      }),
+    ).toBe(false);
+
+    const autopilotService = new RuntimeModeService({
+      storage: handle.storage.db,
+      autopilotEnabled: true,
+    });
+    expect(
+      autopilotService.recordApprovalRequestForYoloSuggestion({
+        ownerAgentId: "agent_1",
+        approvalTarget: "user",
+        requestedAt: new Date("2026-03-25T00:01:00.000Z"),
+      }),
+    ).toBe(false);
+
+    service.toggleYolo({
+      ownerAgentId: "agent_1",
+      updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+    });
+    expect(
+      service.recordApprovalRequestForYoloSuggestion({
+        ownerAgentId: "agent_1",
+        approvalTarget: "user",
+        requestedAt: new Date("2026-03-26T00:01:00.000Z"),
+      }),
+    ).toBe(false);
+  });
+
+  test("manual yolo disable snoozes automatic suggestions for three days", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedAgentFixture(handle);
+    const service = new RuntimeModeService({
+      storage: handle.storage.db,
+      autopilotEnabled: false,
+    });
+
+    service.toggleYolo({
+      ownerAgentId: "agent_1",
+      updatedAt: new Date("2026-03-22T00:00:00.000Z"),
+    });
+    service.toggleYolo({
+      ownerAgentId: "agent_1",
+      updatedAt: new Date("2026-03-22T00:10:00.000Z"),
+    });
+
+    const row = new AgentRuntimeModesRepo(handle.storage.db).getByOwnerAgentId("agent_1");
+    expect(row).toMatchObject({
+      yoloEnabled: false,
+      yoloSnoozedUntil: new Date(
+        new Date("2026-03-22T00:10:00.000Z").getTime() + YOLO_MANUAL_DISABLE_SNOOZE_MS,
+      ).toISOString(),
+    });
+  });
+});

--- a/tests/runtime/status.test.ts
+++ b/tests/runtime/status.test.ts
@@ -3,6 +3,7 @@ import { ProviderRegistry } from "@/src/agent/llm/provider-registry.js";
 import type { AppConfig } from "@/src/config/schema.js";
 import { SessionRunAbortRegistry } from "@/src/runtime/cancel.js";
 import { RuntimeControlService } from "@/src/runtime/control.js";
+import { RuntimeModeService } from "@/src/runtime/runtime-modes.js";
 import {
   buildConversationStatusPresentation,
   formatConversationStatusText,
@@ -79,6 +80,7 @@ function createConfig(): AppConfig {
       maxTurns: 60,
       approvalTimeoutMs: 180_000,
       approvalGrantTtlMs: 604_800_000,
+      autopilot: false,
     },
     selfHarness: {
       meditation: {
@@ -201,10 +203,20 @@ describe("runtime status service", () => {
         scenario: "chat",
       });
 
+      const runtimeModes = new RuntimeModeService({
+        storage: handle.storage.db,
+        autopilotEnabled: false,
+      });
+      runtimeModes.toggleYolo({
+        ownerAgentId: "agent_1",
+        updatedAt: new Date("2026-03-28T00:05:00.000Z"),
+      });
+
       const service = new RuntimeStatusService({
         storage: handle.storage.db,
         control,
         models: new ProviderRegistry(createConfig()),
+        runtimeModes,
       });
 
       const snapshot = service.getConversationStatus({
@@ -256,10 +268,17 @@ describe("runtime status service", () => {
           approvalTarget: "user",
         }),
       ]);
+      expect(snapshot.runtimeMode).toMatchObject({
+        source: "yolo",
+        yoloEnabled: true,
+        autopilotEnabled: false,
+      });
 
       const text = formatConversationStatusText(snapshot);
       expect(text).toContain("当前状态");
       expect(text).toContain("openrouter-gpt5.4 / openai/gpt-5.4 / openrouter / openai-responses");
+      expect(text).toContain("运行模式：🐯 YOLO");
+      expect(text.indexOf("Reasoning: 支持")).toBeLessThan(text.indexOf("运行模式：🐯 YOLO"));
       expect(text).toContain("- 最近 3 天 session");
       expect(text).not.toContain("- 当前 session 累计");
       expect(text).toContain("  总 65 / 输入 50 / 输出 10");
@@ -273,6 +292,11 @@ describe("runtime status service", () => {
       expect(presentation.summary).toBe("存在活跃 run");
       expect(presentation.markdownSections.join("\n")).toContain("**版本**");
       expect(presentation.markdownSections.join("\n")).toContain("openrouter-gpt5.4");
+      expect(presentation.markdownSections.join("\n")).toContain("**运行模式**：🐯 YOLO");
+      const overviewSection = presentation.markdownSections[0] ?? "";
+      expect(overviewSection.indexOf("**Reasoning**: 支持")).toBeLessThan(
+        overviewSection.indexOf("**运行模式**：🐯 YOLO"),
+      );
       expect(presentation.markdownSections.join("\n")).toContain("**最近 3 天 session**");
       expect(presentation.markdownSections.join("\n")).not.toContain("**当前 session 累计**");
       expect(presentation.markdownSections.join("\n")).toContain("- 总 65 / 输入 50 / 输出 10");
@@ -315,6 +339,10 @@ describe("runtime status service", () => {
         storage: handle.storage.db,
         control: new RuntimeControlService(new SessionRunAbortRegistry()),
         models: new ProviderRegistry(config),
+        runtimeModes: new RuntimeModeService({
+          storage: handle.storage.db,
+          autopilotEnabled: true,
+        }),
       });
 
       const snapshot = service.getConversationStatus({
@@ -324,6 +352,8 @@ describe("runtime status service", () => {
       });
 
       expect(snapshot.model.supportsReasoning).toBe(false);
+      expect(snapshot.runtimeMode.source).toBe("autopilot");
+      expect(formatConversationStatusText(snapshot)).toContain("运行模式：🛸 Autopilot");
       expect(formatConversationStatusText(snapshot)).toContain("Reasoning: 不支持");
     });
   });

--- a/tests/storage/agent-runtime-modes.repo.test.ts
+++ b/tests/storage/agent-runtime-modes.repo.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, test } from "vitest";
+
+import { AgentRuntimeModesRepo } from "@/src/storage/repos/agent-runtime-modes.repo.js";
+import {
+  createTestDatabase,
+  destroyTestDatabase,
+  type TestDatabaseHandle,
+} from "@/tests/storage/helpers/test-db.js";
+
+function seedAgentFixture(handle: TestDatabaseHandle): void {
+  handle.storage.sqlite.exec(`
+    INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+    VALUES ('ci_1', 'lark', 'acct_a', '2026-03-22T00:00:00.000Z', '2026-03-22T00:00:00.000Z');
+    INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+    VALUES ('conv_1', 'ci_1', 'chat_1', 'dm', '2026-03-22T00:00:00.000Z', '2026-03-22T00:00:00.000Z');
+    INSERT INTO agents (id, conversation_id, kind, created_at)
+    VALUES ('agent_1', 'conv_1', 'main', '2026-03-22T00:00:00.000Z');
+  `);
+}
+
+describe("agent runtime modes repo", () => {
+  let handle: TestDatabaseHandle | null = null;
+
+  afterEach(async () => {
+    if (handle != null) {
+      await destroyTestDatabase(handle);
+      handle = null;
+    }
+  });
+
+  test("missing rows default to yolo disabled without creating state", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedAgentFixture(handle);
+    const repo = new AgentRuntimeModesRepo(handle.storage.db);
+
+    expect(repo.getByOwnerAgentId("agent_1")).toBeNull();
+    expect(repo.isYoloEnabled("agent_1")).toBe(false);
+    expect(repo.getByOwnerAgentId("agent_1")).toBeNull();
+  });
+
+  test("toggleYolo creates and flips persisted yolo state", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedAgentFixture(handle);
+    const repo = new AgentRuntimeModesRepo(handle.storage.db);
+
+    const enabled = repo.toggleYolo({
+      ownerAgentId: "agent_1",
+      updatedAt: new Date("2026-03-22T00:00:01.000Z"),
+      updatedBy: "lark:default:ou_sender",
+    });
+
+    expect(enabled).toMatchObject({
+      ownerAgentId: "agent_1",
+      yoloEnabled: true,
+      yoloEnabledAt: "2026-03-22T00:00:01.000Z",
+      yoloUpdatedAt: "2026-03-22T00:00:01.000Z",
+      yoloUpdatedBy: "lark:default:ou_sender",
+    });
+
+    const disabled = repo.toggleYolo({
+      ownerAgentId: "agent_1",
+      updatedAt: new Date("2026-03-22T00:00:02.000Z"),
+      updatedBy: "lark:default:ou_sender",
+      disableSnoozedUntil: new Date("2026-03-23T00:00:02.000Z"),
+    });
+
+    expect(disabled).toMatchObject({
+      ownerAgentId: "agent_1",
+      yoloEnabled: false,
+      yoloEnabledAt: null,
+      yoloUpdatedAt: "2026-03-22T00:00:02.000Z",
+      yoloUpdatedBy: "lark:default:ou_sender",
+      yoloSnoozedUntil: "2026-03-23T00:00:02.000Z",
+    });
+  });
+
+  test("updateYoloPromptState creates a row and stores debounce fields", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedAgentFixture(handle);
+    const repo = new AgentRuntimeModesRepo(handle.storage.db);
+
+    const row = repo.updateYoloPromptState({
+      ownerAgentId: "agent_1",
+      updatedAt: new Date("2026-03-22T00:00:00.000Z"),
+      approvalStreakCount: 2,
+      approvalStreakStartedAt: new Date("2026-03-22T00:00:01.000Z"),
+      lastApprovalRequestedAt: new Date("2026-03-22T00:01:00.000Z"),
+      lastYoloPromptedAt: new Date("2026-03-22T00:01:01.000Z"),
+      yoloPromptCountToday: 1,
+      yoloPromptCountDay: "2026-03-22",
+    });
+
+    expect(row).toMatchObject({
+      ownerAgentId: "agent_1",
+      yoloEnabled: false,
+      approvalStreakCount: 2,
+      approvalStreakStartedAt: "2026-03-22T00:00:01.000Z",
+      lastApprovalRequestedAt: "2026-03-22T00:01:00.000Z",
+      lastYoloPromptedAt: "2026-03-22T00:01:01.000Z",
+      yoloPromptCountToday: 1,
+      yoloPromptCountDay: "2026-03-22",
+    });
+  });
+
+  test("runtime mode rows are removed when the owner agent is deleted", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedAgentFixture(handle);
+    const repo = new AgentRuntimeModesRepo(handle.storage.db);
+    repo.toggleYolo({
+      ownerAgentId: "agent_1",
+      updatedAt: new Date("2026-03-22T00:00:01.000Z"),
+    });
+
+    handle.storage.sqlite.exec("DELETE FROM agents WHERE id = 'agent_1'");
+
+    expect(repo.getByOwnerAgentId("agent_1")).toBeNull();
+  });
+});

--- a/tests/storage/db.test.ts
+++ b/tests/storage/db.test.ts
@@ -55,6 +55,7 @@ describe("storage db bootstrap", () => {
       expect(tableNames).toContain("channel_surfaces");
       expect(tableNames).toContain("channel_threads");
       expect(tableNames).toContain("agents");
+      expect(tableNames).toContain("agent_runtime_modes");
       expect(tableNames).toContain("sessions");
       expect(tableNames).toContain("messages");
       expect(tableNames).toContain("cron_jobs");
@@ -80,7 +81,10 @@ describe("storage db bootstrap", () => {
         .prepare("SELECT version, name FROM schema_migrations ORDER BY version ASC")
         .all() as Array<{ version: number; name: string }>;
 
-      expect(rows).toEqual([{ version: 1, name: "init" }]);
+      expect(rows).toEqual([
+        { version: 1, name: "init" },
+        { version: 2, name: "agent_runtime_modes" },
+      ]);
     } finally {
       await destroyTestDatabase(handle);
     }

--- a/tests/storage/migrations.test.ts
+++ b/tests/storage/migrations.test.ts
@@ -280,12 +280,17 @@ describe("storage migrations", () => {
       const result = runStorageMigrations(sqlite, { now: () => FIXED_NOW });
 
       expect(result).toEqual({
-        latestVersion: 1,
-        newlyAppliedVersions: [],
+        latestVersion: 2,
+        newlyAppliedVersions: [2],
         stampedBaseline: true,
       });
       expect(listLedgerRows(sqlite)).toEqual([
         { version: 1, name: "init", applied_at: "2026-04-27T00:00:00.000Z" },
+        {
+          version: 2,
+          name: "agent_runtime_modes",
+          applied_at: "2026-04-27T00:00:00.000Z",
+        },
       ]);
     } finally {
       sqlite.close();


### PR DESCRIPTION
## Summary
- add per-agent YOLO mode and global Autopilot approval mode
- auto-approve runtime permissions without user-visible approval cards in YOLO/Autopilot
- add anchored YOLO suggestion nudges on approval cards and /status runtime mode display
- add SQLite migration and focused regression coverage

## Tests
- pnpm preflight