### PR TITLE
Fix full-access sandbox compatibility defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "vitest": "^4.1.0"
   },
   "dependencies": {
-    "@danielwpz/sandbox-runtime": "0.0.43-pokeclaw.1",
+    "@danielwpz/sandbox-runtime": "0.0.43-pokeclaw.2",
     "@larksuiteoapi/node-sdk": "^1.60.0",
     "@mariozechner/pi-agent-core": "0.70.2",
     "@mariozechner/pi-ai": "0.70.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@danielwpz/sandbox-runtime':
-        specifier: 0.0.43-pokeclaw.1
-        version: 0.0.43-pokeclaw.1
+        specifier: 0.0.43-pokeclaw.2
+        version: 0.0.43-pokeclaw.2
       '@larksuiteoapi/node-sdk':
         specifier: ^1.60.0
         version: 1.60.0
@@ -293,8 +293,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@danielwpz/sandbox-runtime@0.0.43-pokeclaw.1':
-    resolution: {integrity: sha512-mnYcIxD3BVS4vSEenLiyS1s3NS8GnhxM5v3AG4WPBTLSESUWii+mBjswi2FX/pkLpv60RKdnrayqsYi1vziYpA==}
+  '@danielwpz/sandbox-runtime@0.0.43-pokeclaw.2':
+    resolution: {integrity: sha512-sdR/4+fnXZqR/KGwATgOcAgda84808pCxskqDKobgaJE/xo3q3sR10udehvrrX0F9soaWFoIfA839s8S8+FrxA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2697,7 +2697,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.8':
     optional: true
 
-  '@danielwpz/sandbox-runtime@0.0.43-pokeclaw.1':
+  '@danielwpz/sandbox-runtime@0.0.43-pokeclaw.2':
     dependencies:
       '@pondwader/socks5-server': 1.0.10
       '@types/lodash-es': 4.17.12

--- a/src/security/sandbox.ts
+++ b/src/security/sandbox.ts
@@ -139,12 +139,16 @@ export function buildFullAccessSandboxConfigForAgent(
       writeMode: "deny_only",
       allowWrite: [],
       denyWrite: expandSandboxPathPatterns(hardDenyWritePatterns),
+      allowGitConfig: true,
     },
     network: {
       mode: "deny_only",
       allowedDomains: [],
       deniedDomains: dedupeStrings(systemPolicy.network.hardDenyHosts),
+      allowLocalBinding: true,
     },
+    allowPty: true,
+    enableWeakerNetworkIsolation: true,
   };
 }
 

--- a/tests/security/full-access-sandbox-runtime.test.ts
+++ b/tests/security/full-access-sandbox-runtime.test.ts
@@ -1,0 +1,86 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import { DEFAULT_CONFIG } from "@/src/config/defaults.js";
+import { normalizeFilesystemTargetPath } from "@/src/security/permissions.js";
+import { executeFullAccessSandboxedBash } from "@/src/security/sandbox.js";
+import {
+  createTestDatabase,
+  destroyTestDatabase,
+  type TestDatabaseHandle,
+} from "@/tests/storage/helpers/test-db.js";
+
+function seedAgentFixture(handle: TestDatabaseHandle): void {
+  handle.storage.sqlite.exec(`
+    INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+    VALUES ('ci_1', 'lark', 'acct_a', '2026-03-22T00:00:00.000Z', '2026-03-22T00:00:00.000Z');
+    INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+    VALUES ('conv_1', 'ci_1', 'chat_1', 'dm', '2026-03-22T00:00:00.000Z', '2026-03-22T00:00:00.000Z');
+    INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+    VALUES ('branch_1', 'conv_1', 'dm_main', 'main', '2026-03-22T00:00:00.000Z', '2026-03-22T00:00:00.000Z');
+    INSERT INTO agents (id, conversation_id, kind, created_at)
+    VALUES ('agent_main', 'conv_1', 'main', '2026-03-22T00:00:00.000Z');
+  `);
+}
+
+describe("full-access sandbox runtime", () => {
+  let handle: TestDatabaseHandle | null = null;
+  let tempDir: string | null = null;
+
+  afterEach(async () => {
+    if (handle != null) {
+      await destroyTestDatabase(handle);
+      handle = null;
+    }
+    if (tempDir != null) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  test("allows binding a random localhost port in full-access sandbox", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedAgentFixture(handle);
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "pokoclaw-full-access-sandbox-"));
+
+    const script = [
+      'const http = require("node:http");',
+      'const server = http.createServer((request, response) => response.end("ok"));',
+      'server.on("error", error => { console.error(error.stack || error.message); process.exit(1); });',
+      'server.listen(0, "127.0.0.1", () => {',
+      "  const address = server.address();",
+      '  if (address === null || address === undefined || typeof address === "string" || address.port <= 0) {',
+      '    console.error("missing port");',
+      "    process.exit(1);",
+      "  }",
+      '  console.log("listening:" + address.port);',
+      "  server.close(() => process.exit(0));",
+      "});",
+      'setTimeout(() => { console.error("timeout"); process.exit(2); }, 5000).unref();',
+    ].join(" ");
+
+    const result = await executeFullAccessSandboxedBash({
+      context: {
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        ownerAgentId: "agent_main",
+        cwd: tempDir,
+        securityConfig: DEFAULT_CONFIG.security,
+        storage: handle.storage.db,
+        toolCallId: "tool_1",
+      },
+      command: `node -e '${script}'`,
+      cwd: tempDir,
+      timeoutMs: 10_000,
+    });
+
+    expect(result.cwd).toBe(normalizeFilesystemTargetPath(tempDir));
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(result.signal).toBeNull();
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toMatch(/^listening:\d+\n$/);
+  });
+});

--- a/tests/security/full-access-sandbox-runtime.test.ts
+++ b/tests/security/full-access-sandbox-runtime.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -26,9 +26,34 @@ function seedAgentFixture(handle: TestDatabaseHandle): void {
   `);
 }
 
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
 describe("full-access sandbox runtime", () => {
   let handle: TestDatabaseHandle | null = null;
   let tempDir: string | null = null;
+
+  async function runFullAccessCommand(command: string, timeoutMs = 10_000) {
+    handle = await createTestDatabase(import.meta.url);
+    seedAgentFixture(handle);
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "pokoclaw-full-access-sandbox-"));
+
+    return await executeFullAccessSandboxedBash({
+      context: {
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        ownerAgentId: "agent_main",
+        cwd: tempDir,
+        securityConfig: DEFAULT_CONFIG.security,
+        storage: handle.storage.db,
+        toolCallId: "tool_1",
+      },
+      command,
+      cwd: tempDir,
+      timeoutMs,
+    });
+  }
 
   afterEach(async () => {
     if (handle != null) {
@@ -42,10 +67,6 @@ describe("full-access sandbox runtime", () => {
   });
 
   test("allows binding a random localhost port in full-access sandbox", async () => {
-    handle = await createTestDatabase(import.meta.url);
-    seedAgentFixture(handle);
-    tempDir = await mkdtemp(path.join(os.tmpdir(), "pokoclaw-full-access-sandbox-"));
-
     const script = [
       'const http = require("node:http");',
       'const server = http.createServer((request, response) => response.end("ok"));',
@@ -62,6 +83,46 @@ describe("full-access sandbox runtime", () => {
       'setTimeout(() => { console.error("timeout"); process.exit(2); }, 5000).unref();',
     ].join(" ");
 
+    const result = await runFullAccessCommand(`node -e '${script}'`);
+
+    if (tempDir == null) {
+      throw new Error("full-access sandbox test did not create a temporary directory");
+    }
+    expect(result.cwd).toBe(normalizeFilesystemTargetPath(tempDir));
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(result.signal).toBeNull();
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toMatch(/^listening:\d+\n$/);
+  });
+
+  test("allows writing git config in full-access sandbox", async () => {
+    const result = await runFullAccessCommand(
+      [
+        "mkdir -p .git",
+        "printf '%s\\n' '[core]' 'repositoryformatversion = 0' > .git/config",
+        "cat .git/config",
+      ].join(" && "),
+    );
+
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(result.signal).toBeNull();
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("[core]");
+    expect(result.stdout).toContain("repositoryformatversion = 0");
+  });
+
+  test("allows PTY allocation in full-access sandbox on macOS", async () => {
+    if (process.platform !== "darwin") {
+      return;
+    }
+
+    handle = await createTestDatabase(import.meta.url);
+    seedAgentFixture(handle);
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "pokoclaw-full-access-sandbox-"));
+
+    const outputFile = path.join(tempDir, "pty-output.txt");
+    await mkdir(path.dirname(outputFile), { recursive: true });
+
     const result = await executeFullAccessSandboxedBash({
       context: {
         sessionId: "sess_1",
@@ -72,15 +133,15 @@ describe("full-access sandbox runtime", () => {
         storage: handle.storage.db,
         toolCallId: "tool_1",
       },
-      command: `node -e '${script}'`,
+      command: `script -q ${shellQuote(outputFile)} echo pty-works`,
       cwd: tempDir,
       timeoutMs: 10_000,
     });
 
-    expect(result.cwd).toBe(normalizeFilesystemTargetPath(tempDir));
     expect(result.exitCode, result.stderr).toBe(0);
     expect(result.signal).toBeNull();
-    expect(result.stderr).toBe("");
-    expect(result.stdout).toMatch(/^listening:\d+\n$/);
+
+    const output = await readFile(outputFile, "utf8");
+    expect(output).toContain("pty-works");
   });
 });

--- a/tests/security/sandbox.test.ts
+++ b/tests/security/sandbox.test.ts
@@ -209,7 +209,7 @@ describe("sandbox config compilation", () => {
     expect(config.network.deniedDomains).toContain("internal.example.com");
   });
 
-  test("builds full-access sandbox config as read, write, and network deny-only", async () => {
+  test("builds full-access sandbox config as deny-only with host-like compatibility defaults", async () => {
     handle = await createTestDatabase(import.meta.url);
     seedAgentFixture(handle);
     tempDir = await mkdtemp(path.join(os.tmpdir(), "pokoclaw-sandbox-test-"));
@@ -251,10 +251,14 @@ describe("sandbox config compilation", () => {
     expect(config.filesystem.denyWrite).toContain(
       `${normalizeFilesystemTargetPath(extraHardWrite)}/**`,
     );
+    expect(config.filesystem.allowGitConfig).toBe(true);
     expect(config.network.mode).toBe("deny_only");
     expect(config.network.allowedDomains).toEqual([]);
     expect(config.network.deniedDomains).toContain("169.254.169.254");
     expect(config.network.deniedDomains).toContain("internal.example.com");
+    expect(config.network.allowLocalBinding).toBe(true);
+    expect(config.allowPty).toBe(true);
+    expect(config.enableWeakerNetworkIsolation).toBe(true);
   });
 
   test("executes bash through the sandbox with sanitized env and compiled config", async () => {
@@ -422,7 +426,11 @@ describe("sandbox config compilation", () => {
     expect(options?.customConfig?.filesystem?.allowRead).toEqual([]);
     expect(options?.customConfig?.filesystem?.writeMode).toBe("deny_only");
     expect(options?.customConfig?.filesystem?.allowWrite).toEqual([]);
+    expect(options?.customConfig?.filesystem?.allowGitConfig).toBe(true);
     expect(options?.customConfig?.network?.mode).toBe("deny_only");
+    expect(options?.customConfig?.network?.allowLocalBinding).toBe(true);
+    expect(options?.customConfig?.allowPty).toBe(true);
+    expect(options?.customConfig?.enableWeakerNetworkIsolation).toBe(true);
   });
 
   test("rejects full-access sandbox cwd when it is hard denied", async () => {


### PR DESCRIPTION
## Summary
- enable full-access sandbox compatibility defaults for git config writes, local port binding, PTY, and weaker network isolation
- upgrade @danielwpz/sandbox-runtime to 0.0.43-pokeclaw.2
- add a runtime regression test that binds a random localhost port inside full-access sandbox

## Validation
- pnpm exec vitest run tests/security/full-access-sandbox-runtime.test.ts
- pnpm preflight

Linear: POK-22