### PR TITLE
Fall back to workdir for project context when no git repo is found

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,11 +87,11 @@ If the user wants web search or web fetch, also configure a Tavily provider plus
 
 ## Project context files
 
-Pokoclaw loads project guidance files for agent runs that have a workdir inside a git repository:
+Pokoclaw loads project guidance files for agent runs from the configured workdir:
 
-- `<repo_root>/AGENTS.md`
-- `<repo_root>/CLAUDE.md`
-- `<workdir>/CLAUDE.md` when the workdir is nested below the repo root
+- when the workdir is inside a git repository, configured files load from the repo root, such as `<repo_root>/AGENTS.md` and `<repo_root>/CLAUDE.md`
+- when the workdir is not inside a git repository, configured files load from the workdir itself, such as `<workdir>/AGENTS.md` and `<workdir>/CLAUDE.md`
+- `<workdir>/CLAUDE.md` also loads when the workdir is nested below the repo root
 
 These files are injected into the model system prompt as project-specific context. The default maximum is 8192 bytes per file, with a truncation marker when a file is larger.
 

--- a/src/agent/project-context.ts
+++ b/src/agent/project-context.ts
@@ -81,12 +81,17 @@ export function loadAgentProjectContext(input: {
   }
 
   const repoRoot = findRepoRootFromGit(workdir);
-  if (repoRoot == null) {
-    return emptySnapshot(warnings);
-  }
+  const normalizedWorkdir = path.resolve(workdir);
 
-  const repoRootRealPath = tryRealpath(repoRoot);
-  if (repoRootRealPath == null) {
+  // Fall back to the workdir itself when not inside a git repo. This covers
+  // non-code project layouts (Obsidian vaults, document-only folders, etc.)
+  // where CLAUDE.md/AGENTS.md live next to the working files but no .git
+  // marker exists anywhere up the tree.
+  const effectiveRoot = repoRoot ?? normalizedWorkdir;
+  const rootSource: ProjectContextSource = repoRoot != null ? "repo_root" : "workdir";
+
+  const effectiveRootRealPath = tryRealpath(effectiveRoot);
+  if (effectiveRootRealPath == null) {
     return emptySnapshot(warnings);
   }
 
@@ -95,9 +100,9 @@ export function loadAgentProjectContext(input: {
 
   for (const fileName of input.config.files) {
     const entry = loadProjectContextFile({
-      source: "repo_root",
-      rootRealPath: repoRootRealPath,
-      baseDir: repoRoot,
+      source: rootSource,
+      rootRealPath: effectiveRootRealPath,
+      baseDir: effectiveRoot,
       fileName,
       maxBytes: input.config.maxBytes,
       warnings,
@@ -108,15 +113,15 @@ export function loadAgentProjectContext(input: {
     }
   }
 
-  const normalizedWorkdir = path.resolve(workdir);
   const shouldLoadWorkdirClaude =
+    repoRoot != null &&
     input.config.files.includes(WORKDIR_CLAUDE_FILE) &&
     normalizedWorkdir !== repoRoot &&
     isPathInside(repoRoot, normalizedWorkdir);
   if (shouldLoadWorkdirClaude) {
     const entry = loadProjectContextFile({
       source: "workdir",
-      rootRealPath: repoRootRealPath,
+      rootRealPath: effectiveRootRealPath,
       baseDir: normalizedWorkdir,
       fileName: WORKDIR_CLAUDE_FILE,
       maxBytes: input.config.maxBytes,

--- a/tests/agent/project-context.test.ts
+++ b/tests/agent/project-context.test.ts
@@ -47,7 +47,7 @@ describe("agent project context", () => {
     expect(snapshot.prompt).toContain("Package Claude guidance");
   });
 
-  test("returns empty context when disabled or no git root is found", async () => {
+  test("returns empty context when disabled or no context files exist", async () => {
     const dir = await createTempDir("pokoclaw-project-context-miss-");
 
     expect(
@@ -69,6 +69,27 @@ describe("agent project context", () => {
         },
       }).entries,
     ).toEqual([]);
+  });
+
+  test("falls back to workdir context files when not inside a git repo", async () => {
+    // Covers non-code project layouts (Obsidian vaults, document-only folders)
+    // where CLAUDE.md / AGENTS.md sit beside the working files but no .git
+    // marker exists anywhere up the tree.
+    const workdir = await createTempDir("pokoclaw-project-context-nogit-");
+    await writeFile(path.join(workdir, "CLAUDE.md"), "Vault project rules", "utf8");
+    await writeFile(path.join(workdir, "AGENTS.md"), "Vault agent guidance", "utf8");
+
+    const snapshot = loadAgentProjectContext({
+      workdir,
+      config: DEFAULT_CONFIG.projectContext,
+    });
+
+    expect(snapshot.entries.map((entry) => [entry.source, path.basename(entry.path)])).toEqual([
+      ["workdir", "AGENTS.md"],
+      ["workdir", "CLAUDE.md"],
+    ]);
+    expect(snapshot.prompt).toContain("Vault project rules");
+    expect(snapshot.prompt).toContain("Vault agent guidance");
   });
 
   test("truncates large files with a clear head and tail marker", async () => {


### PR DESCRIPTION
## Why

`#32` (closes #31) loads project context via `findRepoRootFromGit(workdir)` and bails out with an empty snapshot when no `.git` marker exists anywhere up the tree. That ties the entire feature to git-tracked code projects.

For non-code project layouts the marker file is right there but never gets read:

- Obsidian vaults (Markdown / docs)
- Document-only consulting / research projects under e.g. `~/Dropbox/Ethan Vault/01_Projects/<project>/CLAUDE.md`
- Anything where users keep `CLAUDE.md` next to working files but don't `git init` (because `.git` inside Dropbox-synced folders is a known anti-pattern).

Today these workdirs return empty even when `CLAUDE.md` literally sits in the workdir.

## What this changes

Single-pillar fallback in `loadAgentProjectContext`:

```ts
const repoRoot = findRepoRootFromGit(workdir);
const normalizedWorkdir = path.resolve(workdir);
const effectiveRoot = repoRoot ?? normalizedWorkdir;
const rootSource: ProjectContextSource = repoRoot != null ? "repo_root" : "workdir";
```

- Existing git-aware path is unchanged: when `findRepoRootFromGit` returns a root, files load from the repo root (and the existing nested-workdir CLAUDE.md path still kicks in for monorepos).
- New path: when there is no git, the workdir itself becomes the effective root. Files load from there with `source: "workdir"` so prompt consumers can still distinguish the case.
- Path-escape and truncation logic are unchanged — they now operate against `effectiveRootRealPath`.

No new config; the same `[project_context]` toggle and file list apply.

## Tests

- Renamed the existing "no git root" test to "no context files exist" to reflect the new semantics (an empty workdir still returns empty).
- Added a positive test: `falls back to workdir context files when not inside a git repo` — creates `CLAUDE.md` + `AGENTS.md` directly in a temp workdir with no `.git`, expects both loaded with `source: "workdir"`.
- Full preflight green: 138 files / 881 tests pass.

## Verified locally

Tested against a real Obsidian vault SubAgent (consulting project at `~/Dropbox/Ethan Vault/01_Projects/<project>/CLAUDE.md`). Before this patch the SubAgent's system prompt had no project context block; after the patch the file loads as a `<project_context_file source="workdir">` entry on the next run.

Linear: n/a (community PR). Closes the non-code-project gap surfaced in #31.