### PR TITLE
Feature/feishu docs

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -54,6 +54,14 @@ export const DEFAULT_CONFIG: RawConfig = {
         enabled: false,
       },
     },
+    feishu: {
+      doc: {
+        enabled: false,
+      },
+      base: {
+        enabled: false,
+      },
+    },
   },
   security: {
     filesystem: {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -93,8 +93,19 @@ export interface WebToolsConfig {
   fetch: WebToolConfig;
 }
 
+export interface FeishuToolConfig {
+  enabled: boolean;
+  installation?: string;
+}
+
+export interface FeishuToolsConfig {
+  doc: FeishuToolConfig;
+  base: FeishuToolConfig;
+}
+
 export interface ToolsConfig {
   web: WebToolsConfig;
+  feishu: FeishuToolsConfig;
 }
 
 export interface SecurityFilesystemConfig {
@@ -244,8 +255,19 @@ interface WebToolsConfigInput {
   fetch?: unknown;
 }
 
+interface FeishuToolConfigInput {
+  enabled?: unknown;
+  installation?: unknown;
+}
+
+interface FeishuToolsConfigInput {
+  doc?: unknown;
+  base?: unknown;
+}
+
 interface ToolsConfigInput {
   web?: unknown;
+  feishu?: unknown;
 }
 
 interface SecurityFilesystemConfigInput {
@@ -404,6 +426,10 @@ function cloneRawConfig(config: RawConfig): RawConfig {
       web: {
         search: cloneWebToolConfig(config.tools.web.search),
         fetch: cloneWebToolConfig(config.tools.web.fetch),
+      },
+      feishu: {
+        doc: cloneFeishuToolConfig(config.tools.feishu.doc),
+        base: cloneFeishuToolConfig(config.tools.feishu.base),
       },
     },
     security: {
@@ -948,6 +974,10 @@ function validateToolsConfig(
         search: cloneWebToolConfig(defaults.web.search),
         fetch: cloneWebToolConfig(defaults.web.fetch),
       },
+      feishu: {
+        doc: cloneFeishuToolConfig(defaults.feishu.doc),
+        base: cloneFeishuToolConfig(defaults.feishu.base),
+      },
     };
   }
 
@@ -956,10 +986,11 @@ function validateToolsConfig(
   }
 
   const config = input as ToolsConfigInput;
-  assertAllowedKeys(config, new Set(["web"]), "config.toml tools");
+  assertAllowedKeys(config, new Set(["web", "feishu"]), "config.toml tools");
 
   return {
     web: validateWebToolsConfig(config.web, defaults.web, providers),
+    feishu: validateFeishuToolsConfig(config.feishu, defaults.feishu),
   };
 }
 
@@ -1039,6 +1070,58 @@ function validateWebToolConfig(
 
   if (resolved.enabled && resolved.provider == null) {
     throw new Error(`${options.path}.provider is required when enabled = true`);
+  }
+
+  return resolved;
+}
+
+function validateFeishuToolsConfig(input: unknown, defaults: FeishuToolsConfig): FeishuToolsConfig {
+  if (input == null) {
+    return {
+      doc: cloneFeishuToolConfig(defaults.doc),
+      base: cloneFeishuToolConfig(defaults.base),
+    };
+  }
+
+  if (!isPlainObject(input)) {
+    throw new Error("config.toml tools.feishu must be a table/object");
+  }
+
+  const config = input as FeishuToolsConfigInput;
+  assertAllowedKeys(config, new Set(["doc", "base"]), "config.toml tools.feishu");
+
+  return {
+    doc: validateFeishuToolConfig(config.doc, defaults.doc, "config.toml tools.feishu.doc"),
+    base: validateFeishuToolConfig(config.base, defaults.base, "config.toml tools.feishu.base"),
+  };
+}
+
+function validateFeishuToolConfig(
+  input: unknown,
+  defaults: FeishuToolConfig,
+  path: string,
+): FeishuToolConfig {
+  if (input == null) {
+    return cloneFeishuToolConfig(defaults);
+  }
+
+  if (!isPlainObject(input)) {
+    throw new Error(`${path} must be a table/object`);
+  }
+
+  const config = input as FeishuToolConfigInput;
+  assertAllowedKeys(config, new Set(["enabled", "installation"]), path);
+
+  const enabled = validateOptionalBoolean(config.enabled, defaults.enabled, `${path}.enabled`);
+  const installation = validateOptionalNonEmptyString(config.installation, `${path}.installation`);
+
+  if (enabled && installation == null) {
+    throw new Error(`${path}.installation is required when enabled = true`);
+  }
+
+  const resolved: FeishuToolConfig = { enabled };
+  if (installation != null) {
+    resolved.installation = installation;
   }
 
   return resolved;
@@ -1324,6 +1407,12 @@ function cloneWebToolConfig(config: WebToolConfig): WebToolConfig {
   return config.provider == null
     ? { enabled: config.enabled }
     : { enabled: config.enabled, provider: config.provider };
+}
+
+function cloneFeishuToolConfig(config: FeishuToolConfig): FeishuToolConfig {
+  return config.installation == null
+    ? { enabled: config.enabled }
+    : { enabled: config.enabled, installation: config.installation };
 }
 
 function cloneMeditationConfig(config: MeditationConfig): MeditationConfig {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -96,6 +96,7 @@ export interface WebToolsConfig {
 export interface FeishuToolConfig {
   enabled: boolean;
   installation?: string;
+  collaboratorOpenId?: string;
 }
 
 export interface FeishuToolsConfig {
@@ -258,6 +259,7 @@ interface WebToolsConfigInput {
 interface FeishuToolConfigInput {
   enabled?: unknown;
   installation?: unknown;
+  collaboratorOpenId?: unknown;
 }
 
 interface FeishuToolsConfigInput {
@@ -1110,10 +1112,14 @@ function validateFeishuToolConfig(
   }
 
   const config = input as FeishuToolConfigInput;
-  assertAllowedKeys(config, new Set(["enabled", "installation"]), path);
+  assertAllowedKeys(config, new Set(["enabled", "installation", "collaboratorOpenId"]), path);
 
   const enabled = validateOptionalBoolean(config.enabled, defaults.enabled, `${path}.enabled`);
   const installation = validateOptionalNonEmptyString(config.installation, `${path}.installation`);
+  const collaboratorOpenId = validateOptionalNonEmptyString(
+    config.collaboratorOpenId,
+    `${path}.collaboratorOpenId`,
+  );
 
   if (enabled && installation == null) {
     throw new Error(`${path}.installation is required when enabled = true`);
@@ -1122,6 +1128,9 @@ function validateFeishuToolConfig(
   const resolved: FeishuToolConfig = { enabled };
   if (installation != null) {
     resolved.installation = installation;
+  }
+  if (collaboratorOpenId != null) {
+    resolved.collaboratorOpenId = collaboratorOpenId;
   }
 
   return resolved;
@@ -1410,9 +1419,14 @@ function cloneWebToolConfig(config: WebToolConfig): WebToolConfig {
 }
 
 function cloneFeishuToolConfig(config: FeishuToolConfig): FeishuToolConfig {
-  return config.installation == null
-    ? { enabled: config.enabled }
-    : { enabled: config.enabled, installation: config.installation };
+  const cloned: FeishuToolConfig = { enabled: config.enabled };
+  if (config.installation != null) {
+    cloned.installation = config.installation;
+  }
+  if (config.collaboratorOpenId != null) {
+    cloned.collaboratorOpenId = config.collaboratorOpenId;
+  }
+  return cloned;
 }
 
 function cloneMeditationConfig(config: MeditationConfig): MeditationConfig {

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -47,6 +47,7 @@ import { MessagesRepo } from "@/src/storage/repos/messages.repo.js";
 import { SessionsRepo } from "@/src/storage/repos/sessions.repo.js";
 import { TaskRunsRepo } from "@/src/storage/repos/task-runs.repo.js";
 import { createBuiltinToolRegistry } from "@/src/tools/builtins.js";
+import { createFeishuClientSource } from "@/src/tools/feishu/client.js";
 
 const logger = createSubsystemLogger("runtime-bootstrap");
 
@@ -82,10 +83,17 @@ export function createRuntimeBootstrap(input: CreateRuntimeBootstrapInput): Runt
   const liveModels = new LiveProviderRegistrySource(liveConfig);
   const messages = new MessagesRepo(input.storage);
   const sessions = new SessionsRepo(input.storage);
-  const tools = createBuiltinToolRegistry({
-    providers: input.config.providers,
-    tools: input.config.tools,
-  });
+  const larkClients = new LarkClientRegistry(
+    listConfiguredLarkInstallations(input.config.channels.lark),
+  );
+  const feishuClientSource = createFeishuClientSource(larkClients);
+  const tools = createBuiltinToolRegistry(
+    {
+      providers: input.config.providers,
+      tools: input.config.tools,
+    },
+    feishuClientSource,
+  );
   const bridge = createRuntimeOrchestrationBridge();
   const outboundEventBus = new RuntimeEventBus<OrchestratedOutboundEventEnvelope>();
   const cancel = new SessionRunAbortRegistry();
@@ -129,9 +137,6 @@ export function createRuntimeBootstrap(input: CreateRuntimeBootstrapInput): Runt
     loop,
     messages,
   });
-  const larkClients = new LarkClientRegistry(
-    listConfiguredLarkInstallations(input.config.channels.lark),
-  );
   const manager = new AgentManager({
     storage: input.storage,
     ingress,

--- a/src/tools/builtins.ts
+++ b/src/tools/builtins.ts
@@ -84,12 +84,18 @@ export function createBuiltinToolRegistry(
     if (installationId == null) {
       throw new Error("tools.feishu.doc is enabled but installation is not specified.");
     }
-    registry.register(
-      createFeishuDocTool({
-        installationId,
-        clientSource: feishuClientSource,
-      }),
-    );
+    const docToolInput: {
+      installationId: string;
+      clientSource: FeishuClientSource;
+      collaboratorOpenId?: string;
+    } = {
+      installationId,
+      clientSource: feishuClientSource,
+    };
+    if (toolsConfig.feishu.doc.collaboratorOpenId != null) {
+      docToolInput.collaboratorOpenId = toolsConfig.feishu.doc.collaboratorOpenId;
+    }
+    registry.register(createFeishuDocTool(docToolInput));
   }
   if (toolsConfig.feishu.base.enabled) {
     if (feishuClientSource == null) {

--- a/src/tools/builtins.ts
+++ b/src/tools/builtins.ts
@@ -6,6 +6,9 @@ import { ToolRegistry } from "@/src/tools/core/registry.js";
 import { createCreateSubagentTool } from "@/src/tools/create-subagent.js";
 import { createScheduleTaskTool } from "@/src/tools/cron.js";
 import { createEditTool } from "@/src/tools/edit.js";
+import { createFeishuBaseTool } from "@/src/tools/feishu/base.js";
+import type { FeishuClientSource } from "@/src/tools/feishu/client.js";
+import { createFeishuDocTool } from "@/src/tools/feishu/doc.js";
 import { createFinishTaskTool } from "@/src/tools/finish-task.js";
 import { createGetRuntimeStatusTool } from "@/src/tools/get-runtime-status.js";
 import { createGrepTool } from "@/src/tools/grep.js";
@@ -23,6 +26,7 @@ import { createWriteTool } from "@/src/tools/write.js";
 
 export function createBuiltinToolRegistry(
   config?: Pick<AppConfig, "providers" | "tools">,
+  feishuClientSource?: FeishuClientSource,
 ): ToolRegistry {
   const providers = config?.providers ?? DEFAULT_CONFIG.providers;
   const toolsConfig = config?.tools ?? DEFAULT_CONFIG.tools;
@@ -70,5 +74,38 @@ export function createBuiltinToolRegistry(
       }),
     );
   }
+
+  // Feishu tools
+  if (toolsConfig.feishu.doc.enabled) {
+    if (feishuClientSource == null) {
+      throw new Error("tools.feishu.doc is enabled but feishu client source is not available.");
+    }
+    const installationId = toolsConfig.feishu.doc.installation;
+    if (installationId == null) {
+      throw new Error("tools.feishu.doc is enabled but installation is not specified.");
+    }
+    registry.register(
+      createFeishuDocTool({
+        installationId,
+        clientSource: feishuClientSource,
+      }),
+    );
+  }
+  if (toolsConfig.feishu.base.enabled) {
+    if (feishuClientSource == null) {
+      throw new Error("tools.feishu.base is enabled but feishu client source is not available.");
+    }
+    const installationId = toolsConfig.feishu.base.installation;
+    if (installationId == null) {
+      throw new Error("tools.feishu.base is enabled but installation is not specified.");
+    }
+    registry.register(
+      createFeishuBaseTool({
+        installationId,
+        clientSource: feishuClientSource,
+      }),
+    );
+  }
+
   return registry;
 }

--- a/src/tools/feishu/base.ts
+++ b/src/tools/feishu/base.ts
@@ -206,7 +206,19 @@ export function createFeishuBaseTool(input: {
           throw error;
         }
         const message = error instanceof Error ? error.message : String(error);
-        throw toolRecoverableError(`feishu_base failed: ${message}`, {
+
+        // Extract Feishu API error details from axios response
+        let detail = "";
+        const axiosErr = error as { response?: { data?: unknown } };
+        if (axiosErr.response?.data) {
+          try {
+            detail = ` | detail: ${JSON.stringify(axiosErr.response.data)}`;
+          } catch {
+            // ignore
+          }
+        }
+
+        throw toolRecoverableError(`feishu_base failed: ${message}${detail}`, {
           code: "feishu_base_error",
         });
       }

--- a/src/tools/feishu/base.ts
+++ b/src/tools/feishu/base.ts
@@ -166,7 +166,7 @@ export function createFeishuBaseTool(input: {
     async execute(_context, args) {
       logger.info("executing feishu_base", {
         action: args.action,
-        appToken: requireAppToken(args),
+        appToken: args.app_token,
       });
 
       try {

--- a/src/tools/feishu/base.ts
+++ b/src/tools/feishu/base.ts
@@ -25,14 +25,34 @@ const FEISHU_BASE_SCHEMA = Type.Object(
         Type.Literal("update_record"),
         Type.Literal("create_records"),
         Type.Literal("update_records"),
+        Type.Literal("create_base"),
+        Type.Literal("create_table"),
       ],
       { description: "Operation to perform on the base." },
     ),
-    app_token: Type.String({
-      minLength: 1,
-      description:
-        "The base app token. Obtain from the base URL: https://xxx.feishu.cn/base/TOKEN or from wiki node token.",
-    }),
+    app_token: Type.Optional(
+      Type.String({
+        minLength: 1,
+        description:
+          "The base app token. Obtain from the base URL: https://xxx.feishu.cn/base/TOKEN or from wiki node token. Not needed for create_base action.",
+      }),
+    ),
+    name: Type.Optional(
+      Type.String({
+        minLength: 1,
+        description: "Base name for create_base, or table name for create_table.",
+      }),
+    ),
+    folder_token: Type.Optional(
+      Type.String({
+        description: "Folder token to create the base in. Optional for create_base.",
+      }),
+    ),
+    default_view_name: Type.Optional(
+      Type.String({
+        description: "Default view name for the table. Optional for create_table.",
+      }),
+    ),
     table_id: Type.Optional(
       Type.String({
         minLength: 1,
@@ -67,6 +87,27 @@ const FEISHU_BASE_SCHEMA = Type.Object(
           { additionalProperties: false },
         ),
         { description: "Array of records for create_records/update_records batch operations." },
+      ),
+    ),
+    table_fields: Type.Optional(
+      Type.Array(
+        Type.Object(
+          {
+            field_name: Type.String({ minLength: 1, description: "Field name." }),
+            type: Type.Number({
+              description:
+                "Field type number. 1=Text, 2=Number, 3=SingleSelect, 4=MultiSelect, 5=DateTime, 7=Checkbox, 11=Attachment, 13=DuplexLink, 17=Location, 21=Barcode, 22=Phone, 23=Email, 1001=Formula, etc.",
+            }),
+            ui_type: Type.Optional(
+              Type.String({
+                description:
+                  "UI type: 'Text', 'Number', 'SingleSelect', 'MultiSelect', 'DateTime', 'Checkbox', 'Attachment', etc.",
+              }),
+            ),
+          },
+          { additionalProperties: false },
+        ),
+        { description: "Field definitions for create_table action." },
       ),
     ),
     filter: Type.Optional(
@@ -116,7 +157,8 @@ export function createFeishuBaseTool(input: {
       "Read and write Feishu/Lark Base (多维表格 / Bitable). " +
       "Actions: get_info (app metadata), list_tables, list_fields, " +
       "list_records (paginated), search_records (with filter/sort), " +
-      "create_record, update_record, create_records (batch), update_records (batch).",
+      "create_record, update_record, create_records (batch), update_records (batch), " +
+      "create_base (create a new base), create_table (create a new table in a base).",
     inputSchema: FEISHU_BASE_SCHEMA,
     getInvocationTimeoutMs() {
       return 30_000;
@@ -124,7 +166,7 @@ export function createFeishuBaseTool(input: {
     async execute(_context, args) {
       logger.info("executing feishu_base", {
         action: args.action,
-        appToken: args.app_token,
+        appToken: requireAppToken(args),
       });
 
       try {
@@ -150,6 +192,10 @@ export function createFeishuBaseTool(input: {
             return await handleCreateRecords(bitable, args);
           case "update_records":
             return await handleUpdateRecords(bitable, args);
+          case "create_base":
+            return await handleCreateBase(bitable, args);
+          case "create_table":
+            return await handleCreateTable(bitable, args);
           default:
             throw toolRecoverableError(`Unknown action: ${(args as { action: string }).action}`, {
               code: "feishu_base_unknown_action",
@@ -168,6 +214,15 @@ export function createFeishuBaseTool(input: {
   });
 }
 
+function requireAppToken(args: FeishuBaseArgs): string {
+  if (!args.app_token) {
+    throw toolRecoverableError("app_token is required for this action", {
+      code: "feishu_base_missing_app_token",
+    });
+  }
+  return args.app_token;
+}
+
 function requireTableId(args: FeishuBaseArgs): string {
   if (!args.table_id) {
     throw toolRecoverableError("table_id is required for this action", {
@@ -180,7 +235,7 @@ function requireTableId(args: FeishuBaseArgs): string {
 // biome-ignore lint/suspicious/noExplicitAny: bitable SDK types are structurally incompatible
 async function handleGetAppInfo(bitable: any, args: FeishuBaseArgs) {
   const result = await bitable.app.get({
-    path: { app_token: args.app_token },
+    path: { app_token: requireAppToken(args) },
   });
   return jsonToolResult(extractFeishuData(result, "get_info"));
 }
@@ -188,7 +243,7 @@ async function handleGetAppInfo(bitable: any, args: FeishuBaseArgs) {
 // biome-ignore lint/suspicious/noExplicitAny: bitable SDK types are structurally incompatible
 async function handleListTables(bitable: any, args: FeishuBaseArgs) {
   const result = await bitable.appTable.list({
-    path: { app_token: args.app_token },
+    path: { app_token: requireAppToken(args) },
     params: {
       page_size: args.page_size ?? 100,
       ...(args.page_token ? { page_token: args.page_token } : {}),
@@ -201,7 +256,7 @@ async function handleListTables(bitable: any, args: FeishuBaseArgs) {
 async function handleListFields(bitable: any, args: FeishuBaseArgs) {
   const tableId = requireTableId(args);
   const result = await bitable.appTableField.list({
-    path: { app_token: args.app_token, table_id: tableId },
+    path: { app_token: requireAppToken(args), table_id: tableId },
     params: {
       page_size: args.page_size ?? 100,
       ...(args.page_token ? { page_token: args.page_token } : {}),
@@ -222,7 +277,7 @@ async function handleListRecords(bitable: any, args: FeishuBaseArgs) {
   }
 
   const result = await bitable.appTableRecord.list({
-    path: { app_token: args.app_token, table_id: tableId },
+    path: { app_token: requireAppToken(args), table_id: tableId },
     params,
   });
   return jsonToolResult(extractFeishuData(result, "list_records"));
@@ -236,7 +291,7 @@ async function handleSearchRecords(bitable: any, args: FeishuBaseArgs) {
   if (args.sort && args.sort.length > 0) data.sort = args.sort;
 
   const result = await bitable.appTableRecord.search({
-    path: { app_token: args.app_token, table_id: tableId },
+    path: { app_token: requireAppToken(args), table_id: tableId },
     params: {
       page_size: args.page_size ?? 100,
       ...(args.page_token ? { page_token: args.page_token } : {}),
@@ -256,7 +311,7 @@ async function handleCreateRecord(bitable: any, args: FeishuBaseArgs) {
   }
 
   const result = await bitable.appTableRecord.create({
-    path: { app_token: args.app_token, table_id: tableId },
+    path: { app_token: requireAppToken(args), table_id: tableId },
     data: { fields: args.fields },
   });
   return jsonToolResult(extractFeishuData(result, "create_record"));
@@ -277,7 +332,7 @@ async function handleUpdateRecord(bitable: any, args: FeishuBaseArgs) {
   }
 
   const result = await bitable.appTableRecord.update({
-    path: { app_token: args.app_token, table_id: tableId, record_id: args.record_id },
+    path: { app_token: requireAppToken(args), table_id: tableId, record_id: args.record_id },
     data: { fields: args.fields },
   });
   return jsonToolResult(extractFeishuData(result, "update_record"));
@@ -295,7 +350,7 @@ async function handleCreateRecords(bitable: any, args: FeishuBaseArgs) {
   const records = args.records.map((r) => ({ fields: r.fields }));
 
   const result = await bitable.appTableRecord.batchCreate({
-    path: { app_token: args.app_token, table_id: tableId },
+    path: { app_token: requireAppToken(args), table_id: tableId },
     data: { records },
   });
   return jsonToolResult(extractFeishuData(result, "create_records"));
@@ -320,8 +375,51 @@ async function handleUpdateRecords(bitable: any, args: FeishuBaseArgs) {
   });
 
   const result = await bitable.appTableRecord.batchUpdate({
-    path: { app_token: args.app_token, table_id: tableId },
+    path: { app_token: requireAppToken(args), table_id: tableId },
     data: { records },
   });
   return jsonToolResult(extractFeishuData(result, "update_records"));
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: bitable SDK types are structurally incompatible
+async function handleCreateBase(bitable: any, args: FeishuBaseArgs) {
+  if (!args.name) {
+    throw toolRecoverableError("name is required for create_base", {
+      code: "feishu_base_missing_name",
+    });
+  }
+
+  const result = await bitable.app.create({
+    data: {
+      name: args.name,
+      ...(args.folder_token ? { folder_token: args.folder_token } : {}),
+    },
+  });
+  return jsonToolResult(extractFeishuData(result, "create_base"));
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: bitable SDK types are structurally incompatible
+async function handleCreateTable(bitable: any, args: FeishuBaseArgs) {
+  const appToken = requireAppToken(args);
+  if (!args.name) {
+    throw toolRecoverableError("name is required for create_table", {
+      code: "feishu_base_missing_name",
+    });
+  }
+
+  const tableData: Record<string, unknown> = { name: args.name };
+  if (args.default_view_name) tableData.default_view_name = args.default_view_name;
+  if (args.table_fields && args.table_fields.length > 0) {
+    tableData.fields = args.table_fields.map((f) => ({
+      field_name: f.field_name,
+      type: f.type,
+      ...(f.ui_type ? { ui_type: f.ui_type } : {}),
+    }));
+  }
+
+  const result = await bitable.appTable.create({
+    path: { app_token: appToken },
+    data: { table: tableData },
+  });
+  return jsonToolResult(extractFeishuData(result, "create_table"));
 }

--- a/src/tools/feishu/base.ts
+++ b/src/tools/feishu/base.ts
@@ -1,0 +1,327 @@
+/**
+ * feishu_base tool - Read and write Feishu/Lark Base (多维表格 / Bitable).
+ *
+ * Uses the Feishu Open Platform Bitable API to access tables, fields,
+ * and records. Requires the app to have base permissions.
+ */
+import { type Static, Type } from "@sinclair/typebox";
+import { createSubsystemLogger } from "@/src/shared/logger.js";
+import { toolRecoverableError } from "@/src/tools/core/errors.js";
+import { defineTool, jsonToolResult } from "@/src/tools/core/types.js";
+import { extractFeishuData, type FeishuClientSource } from "@/src/tools/feishu/client.js";
+
+const logger = createSubsystemLogger("tools/feishu-base");
+
+const FEISHU_BASE_SCHEMA = Type.Object(
+  {
+    action: Type.Union(
+      [
+        Type.Literal("get_info"),
+        Type.Literal("list_tables"),
+        Type.Literal("list_fields"),
+        Type.Literal("list_records"),
+        Type.Literal("search_records"),
+        Type.Literal("create_record"),
+        Type.Literal("update_record"),
+        Type.Literal("create_records"),
+        Type.Literal("update_records"),
+      ],
+      { description: "Operation to perform on the base." },
+    ),
+    app_token: Type.String({
+      minLength: 1,
+      description:
+        "The base app token. Obtain from the base URL: https://xxx.feishu.cn/base/TOKEN or from wiki node token.",
+    }),
+    table_id: Type.Optional(
+      Type.String({
+        minLength: 1,
+        description: "Table ID. Required for table-scoped actions. Obtain from URL or list_tables.",
+      }),
+    ),
+    record_id: Type.Optional(
+      Type.String({
+        minLength: 1,
+        description: "Record ID. Required for update_record.",
+      }),
+    ),
+    fields: Type.Optional(
+      Type.Record(Type.String(), Type.Any(), {
+        description:
+          "Field values as a key-value map for create_record/update_record. " +
+          "Text: string, Number: number, Select/MultiSelect: string/string[], " +
+          "Person: [{id:'open_id'}], Attachment: [{file_token:'...'}], etc.",
+      }),
+    ),
+    records: Type.Optional(
+      Type.Array(
+        Type.Object(
+          {
+            record_id: Type.Optional(
+              Type.String({ description: "Record ID (required for update_records)." }),
+            ),
+            fields: Type.Record(Type.String(), Type.Any(), {
+              description: "Field values for this record.",
+            }),
+          },
+          { additionalProperties: false },
+        ),
+        { description: "Array of records for create_records/update_records batch operations." },
+      ),
+    ),
+    filter: Type.Optional(
+      Type.Any({
+        description: "Filter for search_records. Object with conjunction, conditions, etc.",
+      }),
+    ),
+    sort: Type.Optional(
+      Type.Array(
+        Type.Object(
+          {
+            field_name: Type.String({ minLength: 1 }),
+            desc: Type.Optional(Type.Boolean({ description: "Sort descending if true." })),
+          },
+          { additionalProperties: false },
+        ),
+        { description: "Sort order for list_records/search_records." },
+      ),
+    ),
+    page_size: Type.Optional(
+      Type.Number({
+        minimum: 1,
+        maximum: 500,
+        description: "Page size for list actions (default 100, max 500).",
+      }),
+    ),
+    page_token: Type.Optional(
+      Type.String({
+        description: "Page token for paginated list actions.",
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export type FeishuBaseArgs = Static<typeof FEISHU_BASE_SCHEMA>;
+
+export function createFeishuBaseTool(input: {
+  installationId: string;
+  clientSource: FeishuClientSource;
+}) {
+  const client = input.clientSource.getClient(input.installationId);
+
+  return defineTool({
+    name: "feishu_base",
+    description:
+      "Read and write Feishu/Lark Base (多维表格 / Bitable). " +
+      "Actions: get_info (app metadata), list_tables, list_fields, " +
+      "list_records (paginated), search_records (with filter/sort), " +
+      "create_record, update_record, create_records (batch), update_records (batch).",
+    inputSchema: FEISHU_BASE_SCHEMA,
+    getInvocationTimeoutMs() {
+      return 30_000;
+    },
+    async execute(_context, args) {
+      logger.info("executing feishu_base", {
+        action: args.action,
+        appToken: args.app_token,
+      });
+
+      try {
+        // biome-ignore lint/suspicious/noExplicitAny: bitable SDK types are structurally incompatible
+        const bitable = client.bitable as any;
+
+        switch (args.action) {
+          case "get_info":
+            return await handleGetAppInfo(bitable, args);
+          case "list_tables":
+            return await handleListTables(bitable, args);
+          case "list_fields":
+            return await handleListFields(bitable, args);
+          case "list_records":
+            return await handleListRecords(bitable, args);
+          case "search_records":
+            return await handleSearchRecords(bitable, args);
+          case "create_record":
+            return await handleCreateRecord(bitable, args);
+          case "update_record":
+            return await handleUpdateRecord(bitable, args);
+          case "create_records":
+            return await handleCreateRecords(bitable, args);
+          case "update_records":
+            return await handleUpdateRecords(bitable, args);
+          default:
+            throw toolRecoverableError(`Unknown action: ${(args as { action: string }).action}`, {
+              code: "feishu_base_unknown_action",
+            });
+        }
+      } catch (error) {
+        if (error instanceof Error && error.name === "ToolRecoverableError") {
+          throw error;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        throw toolRecoverableError(`feishu_base failed: ${message}`, {
+          code: "feishu_base_error",
+        });
+      }
+    },
+  });
+}
+
+function requireTableId(args: FeishuBaseArgs): string {
+  if (!args.table_id) {
+    throw toolRecoverableError("table_id is required for this action", {
+      code: "feishu_base_missing_table_id",
+    });
+  }
+  return args.table_id;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: bitable SDK types are structurally incompatible
+async function handleGetAppInfo(bitable: any, args: FeishuBaseArgs) {
+  const result = await bitable.app.get({
+    path: { app_token: args.app_token },
+  });
+  return jsonToolResult(extractFeishuData(result, "get_info"));
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: bitable SDK types are structurally incompatible
+async function handleListTables(bitable: any, args: FeishuBaseArgs) {
+  const result = await bitable.appTable.list({
+    path: { app_token: args.app_token },
+    params: {
+      page_size: args.page_size ?? 100,
+      ...(args.page_token ? { page_token: args.page_token } : {}),
+    },
+  });
+  return jsonToolResult(extractFeishuData(result, "list_tables"));
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: bitable SDK types are structurally incompatible
+async function handleListFields(bitable: any, args: FeishuBaseArgs) {
+  const tableId = requireTableId(args);
+  const result = await bitable.appTableField.list({
+    path: { app_token: args.app_token, table_id: tableId },
+    params: {
+      page_size: args.page_size ?? 100,
+      ...(args.page_token ? { page_token: args.page_token } : {}),
+    },
+  });
+  return jsonToolResult(extractFeishuData(result, "list_fields"));
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: bitable SDK types are structurally incompatible
+async function handleListRecords(bitable: any, args: FeishuBaseArgs) {
+  const tableId = requireTableId(args);
+  const params: Record<string, number | string> = {
+    page_size: args.page_size ?? 100,
+  };
+  if (args.page_token) params.page_token = args.page_token;
+  if (args.sort && args.sort.length > 0) {
+    params.sort = JSON.stringify(args.sort);
+  }
+
+  const result = await bitable.appTableRecord.list({
+    path: { app_token: args.app_token, table_id: tableId },
+    params,
+  });
+  return jsonToolResult(extractFeishuData(result, "list_records"));
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: bitable SDK types are structurally incompatible
+async function handleSearchRecords(bitable: any, args: FeishuBaseArgs) {
+  const tableId = requireTableId(args);
+  const data: Record<string, unknown> = {};
+  if (args.filter) data.filter = args.filter;
+  if (args.sort && args.sort.length > 0) data.sort = args.sort;
+
+  const result = await bitable.appTableRecord.search({
+    path: { app_token: args.app_token, table_id: tableId },
+    params: {
+      page_size: args.page_size ?? 100,
+      ...(args.page_token ? { page_token: args.page_token } : {}),
+    },
+    data,
+  });
+  return jsonToolResult(extractFeishuData(result, "search_records"));
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: bitable SDK types are structurally incompatible
+async function handleCreateRecord(bitable: any, args: FeishuBaseArgs) {
+  const tableId = requireTableId(args);
+  if (!args.fields) {
+    throw toolRecoverableError("fields are required for create_record", {
+      code: "feishu_base_missing_fields",
+    });
+  }
+
+  const result = await bitable.appTableRecord.create({
+    path: { app_token: args.app_token, table_id: tableId },
+    data: { fields: args.fields },
+  });
+  return jsonToolResult(extractFeishuData(result, "create_record"));
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: bitable SDK types are structurally incompatible
+async function handleUpdateRecord(bitable: any, args: FeishuBaseArgs) {
+  const tableId = requireTableId(args);
+  if (!args.record_id) {
+    throw toolRecoverableError("record_id is required for update_record", {
+      code: "feishu_base_missing_record_id",
+    });
+  }
+  if (!args.fields) {
+    throw toolRecoverableError("fields are required for update_record", {
+      code: "feishu_base_missing_fields",
+    });
+  }
+
+  const result = await bitable.appTableRecord.update({
+    path: { app_token: args.app_token, table_id: tableId, record_id: args.record_id },
+    data: { fields: args.fields },
+  });
+  return jsonToolResult(extractFeishuData(result, "update_record"));
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: bitable SDK types are structurally incompatible
+async function handleCreateRecords(bitable: any, args: FeishuBaseArgs) {
+  const tableId = requireTableId(args);
+  if (!args.records || args.records.length === 0) {
+    throw toolRecoverableError("records are required for create_records", {
+      code: "feishu_base_missing_records",
+    });
+  }
+
+  const records = args.records.map((r) => ({ fields: r.fields }));
+
+  const result = await bitable.appTableRecord.batchCreate({
+    path: { app_token: args.app_token, table_id: tableId },
+    data: { records },
+  });
+  return jsonToolResult(extractFeishuData(result, "create_records"));
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: bitable SDK types are structurally incompatible
+async function handleUpdateRecords(bitable: any, args: FeishuBaseArgs) {
+  const tableId = requireTableId(args);
+  if (!args.records || args.records.length === 0) {
+    throw toolRecoverableError("records are required for update_records", {
+      code: "feishu_base_missing_records",
+    });
+  }
+
+  const records = args.records.map((r, i) => {
+    if (!r.record_id) {
+      throw toolRecoverableError(`records[${i}].record_id is required for update_records`, {
+        code: "feishu_base_missing_record_id_in_batch",
+      });
+    }
+    return { record_id: r.record_id, fields: r.fields };
+  });
+
+  const result = await bitable.appTableRecord.batchUpdate({
+    path: { app_token: args.app_token, table_id: tableId },
+    data: { records },
+  });
+  return jsonToolResult(extractFeishuData(result, "update_records"));
+}

--- a/src/tools/feishu/client.ts
+++ b/src/tools/feishu/client.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared Feishu/Lark SDK client access for feishu tools.
+ *
+ * Wraps the LarkClientRegistry to provide SDK clients to feishu_doc and
+ * feishu_base tools without duplicating config resolution logic.
+ */
+import type * as Lark from "@larksuiteoapi/node-sdk";
+import type { LarkClientRegistry } from "@/src/channels/lark/client.js";
+
+export interface FeishuClientSource {
+  getClient(installationId: string): Lark.Client;
+}
+
+export function createFeishuClientSource(registry: LarkClientRegistry): FeishuClientSource {
+  return {
+    getClient(installationId: string): Lark.Client {
+      return registry.getOrCreate(installationId).sdk;
+    },
+  };
+}
+
+export type FeishuApiResult<T = unknown> = {
+  code: number;
+  msg: string;
+  data?: T;
+};
+
+/**
+ * Validates whether a raw Feishu API response indicates success.
+ * Returns the data field on success, throws a recoverable error on failure.
+ */
+export function extractFeishuData<T>(result: FeishuApiResult<T>, context: string): T {
+  if (result.code !== 0) {
+    throw new Error(`Feishu API error (${context}): code=${result.code} msg=${result.msg}`);
+  }
+  if (result.data === undefined) {
+    throw new Error(`Feishu API returned no data (${context})`);
+  }
+  return result.data;
+}

--- a/src/tools/feishu/doc.ts
+++ b/src/tools/feishu/doc.ts
@@ -152,6 +152,13 @@ type DocBlockChildrenApi = {
   }) => Promise<ApiResult<{ children?: unknown[] }>>;
 };
 
+type DocBlockDescendantApi = {
+  create: (payload: {
+    path: { document_id: string; block_id: string };
+    data: { children_id: string[]; descendants: unknown[]; index?: number };
+  }) => Promise<ApiResult<{ descendants?: unknown[] }>>;
+};
+
 export function createFeishuDocTool(input: {
   installationId: string;
   clientSource: FeishuClientSource;
@@ -204,8 +211,9 @@ export function createFeishuDocTool(input: {
               path: { document_id: string; block_id: string };
               data: Record<string, unknown>;
             }) => Promise<ApiResult<{ block?: unknown }>>;
-            children: DocBlockChildrenApi;
           };
+          documentBlockChildren: DocBlockChildrenApi;
+          documentBlockDescendant: DocBlockDescendantApi;
         };
 
         switch (args.action) {
@@ -365,7 +373,7 @@ async function handleGetBlock(
 
 async function handleGetChildren(
   docx: {
-    documentBlock: { children: DocBlockChildrenApi };
+    documentBlockChildren: DocBlockChildrenApi;
   },
   args: FeishuDocArgs,
 ) {
@@ -379,7 +387,7 @@ async function handleGetChildren(
   };
   if (args.page_token) params.page_token = args.page_token;
 
-  const result = await docx.documentBlock.children.get({
+  const result = await docx.documentBlockChildren.get({
     path: { document_id: requireDocumentId(args), block_id: args.block_id },
     params,
   });
@@ -388,7 +396,8 @@ async function handleGetChildren(
 
 async function handleCreateBlocks(
   docx: {
-    documentBlock: { children: DocBlockChildrenApi };
+    documentBlockChildren: DocBlockChildrenApi;
+    documentBlockDescendant: DocBlockDescendantApi;
   },
   args: FeishuDocArgs,
 ) {
@@ -403,13 +412,28 @@ async function handleCreateBlocks(
     });
   }
 
-  const children = args.blocks.map((b) => buildBlockPayload(b));
-
-  const result = await docx.documentBlock.children.create({
-    path: { document_id: requireDocumentId(args), block_id: args.block_id },
-    data: { children },
+  const timestamp = Date.now();
+  const descendants = args.blocks.map((b, i) => {
+    const tempId = `tmp_${timestamp}_${i}`;
+    const payload = buildBlockPayload(b);
+    return { block_id: tempId, ...payload };
   });
-  return jsonToolResult(extractFeishuData(result, "create_blocks"));
+  const childrenIds = descendants.map((d) => d.block_id);
+
+  const result = await docx.documentBlockDescendant.create({
+    path: { document_id: requireDocumentId(args), block_id: args.block_id },
+    data: { children_id: childrenIds, descendants, index: -1 },
+  });
+
+  // Extract descendants from result for consistent response format
+  const data = extractFeishuData(result, "create_blocks");
+  // Map descendants to children for backward compatibility
+  const mapped = data as Record<string, unknown>;
+  if (mapped.descendants && !mapped.children) {
+    mapped.children = mapped.descendants;
+    delete mapped.descendants;
+  }
+  return jsonToolResult(mapped);
 }
 
 function buildBlockPayload(block: {
@@ -441,13 +465,20 @@ function buildBlockPayload(block: {
       if (t.link) style.link = { url: t.link };
       if (Object.keys(style).length > 0) {
         textRun.text_element_style = style;
+      } else {
+        // Descendant API may require text_element_style for structured blocks
+        textRun.text_element_style = {};
       }
       return { text_run: textRun };
     });
 
-    const blockBody: Record<string, unknown> = { elements };
+    const blockBody: Record<string, unknown> = { elements, style: {} };
     const contentKey = blockTypeToContentKey(blockType);
     payload[contentKey] = blockBody;
+  } else {
+    // Blocks without text (divider, image placeholder) still need their content key
+    const contentKey = blockTypeToContentKey(blockType);
+    payload[contentKey] = {};
   }
 
   return payload;
@@ -463,15 +494,17 @@ function blockTypeToNumber(type: string): number {
     heading5: 7,
     heading6: 8,
     heading7: 9,
-    bullet: 10,
-    ordered: 11,
-    code: 12,
-    quote: 13,
-    callout: 14,
-    todo: 15,
-    divider: 16,
-    image: 17,
-    table: 18,
+    heading8: 10,
+    heading9: 11,
+    bullet: 12,
+    ordered: 13,
+    code: 14,
+    quote: 15,
+    callout: 19,
+    todo: 17,
+    divider: 22,
+    image: 27,
+    table: 31,
   };
   return map[type] ?? 2;
 }
@@ -486,11 +519,16 @@ function blockTypeToContentKey(type: string): string {
     heading5: "heading5",
     heading6: "heading6",
     heading7: "heading7",
+    heading8: "heading8",
+    heading9: "heading9",
     bullet: "bullet",
     ordered: "ordered",
     code: "code",
     quote: "quote",
     todo: "todo",
+    divider: "divider",
+    image: "image",
+    table: "table",
   };
   return map[type] ?? "text";
 }

--- a/src/tools/feishu/doc.ts
+++ b/src/tools/feishu/doc.ts
@@ -235,7 +235,19 @@ export function createFeishuDocTool(input: {
           throw error;
         }
         const message = error instanceof Error ? error.message : String(error);
-        throw toolRecoverableError(`feishu_doc failed: ${message}`, {
+
+        // Extract Feishu API error details from axios response
+        let detail = "";
+        const axiosErr = error as { response?: { data?: unknown } };
+        if (axiosErr.response?.data) {
+          try {
+            detail = ` | detail: ${JSON.stringify(axiosErr.response.data)}`;
+          } catch {
+            // ignore
+          }
+        }
+
+        throw toolRecoverableError(`feishu_doc failed: ${message}${detail}`, {
           code: "feishu_doc_error",
         });
       }

--- a/src/tools/feishu/doc.ts
+++ b/src/tools/feishu/doc.ts
@@ -24,6 +24,10 @@ const FEISHU_DOC_SCHEMA = Type.Object(
         Type.Literal("create"),
         Type.Literal("create_blocks"),
         Type.Literal("update_block"),
+        Type.Literal("convert_markdown"),
+        Type.Literal("delete_blocks"),
+        Type.Literal("append"),
+        Type.Literal("batch_update"),
       ],
       { description: "Operation to perform on the document." },
     ),
@@ -75,6 +79,87 @@ const FEISHU_DOC_SCHEMA = Type.Object(
                   },
                   { additionalProperties: false },
                 ),
+              ),
+            ),
+          },
+          { additionalProperties: false },
+        ),
+      ),
+    ),
+    index: Type.Optional(
+      Type.Number({
+        description:
+          "Insert position for create_blocks. -1 = end (default). 0 = beginning. N = after Nth child.",
+      }),
+    ),
+    content: Type.Optional(
+      Type.String({
+        minLength: 1,
+        description: "Markdown or HTML content for convert_markdown action.",
+      }),
+    ),
+    content_type: Type.Optional(
+      Type.String({
+        description: "Content type for convert_markdown: 'markdown' (default) or 'html'.",
+      }),
+    ),
+    start_index: Type.Optional(
+      Type.Number({
+        minimum: 0,
+        description: "Start index (inclusive) for delete_blocks. 0 = first child.",
+      }),
+    ),
+    end_index: Type.Optional(
+      Type.Number({
+        minimum: 1,
+        description:
+          "End index (exclusive) for delete_blocks. Deletes children [start_index, end_index).",
+      }),
+    ),
+    requests: Type.Optional(
+      Type.Array(
+        Type.Object(
+          {
+            block_id: Type.String({
+              minLength: 1,
+              description: "Block ID to update.",
+            }),
+            update_text_elements: Type.Optional(
+              Type.Object(
+                {
+                  elements: Type.Array(
+                    Type.Object(
+                      {
+                        text_run: Type.Object(
+                          {
+                            content: Type.String({ minLength: 1 }),
+                            text_element_style: Type.Optional(
+                              Type.Object(
+                                {
+                                  bold: Type.Optional(Type.Boolean()),
+                                  italic: Type.Optional(Type.Boolean()),
+                                  underline: Type.Optional(Type.Boolean()),
+                                  strikethrough: Type.Optional(Type.Boolean()),
+                                  inline_code: Type.Optional(Type.Boolean()),
+                                  link: Type.Optional(
+                                    Type.Object(
+                                      { url: Type.String({ minLength: 1 }) },
+                                      { additionalProperties: false },
+                                    ),
+                                  ),
+                                },
+                                { additionalProperties: false },
+                              ),
+                            ),
+                          },
+                          { additionalProperties: false },
+                        ),
+                      },
+                      { additionalProperties: false },
+                    ),
+                  ),
+                },
+                { additionalProperties: false },
               ),
             ),
           },
@@ -134,6 +219,33 @@ const FEISHU_DOC_SCHEMA = Type.Object(
         description: "Page token for paginated list actions.",
       }),
     ),
+    permission_members: Type.Optional(
+      Type.Array(
+        Type.Object(
+          {
+            member_type: Type.String({
+              description:
+                "Member type for permission: 'openid', 'unionid', 'email'. Required with member_id.",
+            }),
+            member_id: Type.String({
+              minLength: 1,
+              description: "Member ID matching the member_type (e.g. openid like 'ou_xxx').",
+            }),
+            perm: Type.Optional(
+              Type.String({
+                description:
+                  "Permission level: 'full_access' (可管理), 'edit' (可编辑), 'view' (可阅读/默认), 'comment' (可评论).",
+              }),
+            ),
+          },
+          { additionalProperties: false },
+        ),
+        {
+          description:
+            "Collaborators to add to the document after creation. Each entry grants permission to one member. Requires drive:drive + docs:permission.member:create scopes.",
+        },
+      ),
+    ),
   },
   { additionalProperties: false },
 );
@@ -150,6 +262,10 @@ type DocBlockChildrenApi = {
     path: { document_id: string; block_id: string };
     data: { children: unknown[] };
   }) => Promise<ApiResult<{ children?: unknown[] }>>;
+  batchDelete: (payload: {
+    path: { document_id: string; block_id: string };
+    data: { start_index: number; end_index: number };
+  }) => Promise<ApiResult<{ document_revision_id?: number }>>;
 };
 
 type DocBlockDescendantApi = {
@@ -162,18 +278,20 @@ type DocBlockDescendantApi = {
 export function createFeishuDocTool(input: {
   installationId: string;
   clientSource: FeishuClientSource;
+  collaboratorOpenId?: string;
 }) {
   const client = input.clientSource.getClient(input.installationId);
+  const collaboratorOpenId = input.collaboratorOpenId;
 
   return defineTool({
     name: "feishu_doc",
     description:
       "Read and write Feishu/Lark documents (Docx). " +
-      "Actions: get_info (document metadata), get_raw_content (plain text), " +
-      "get_blocks (list blocks with pagination), get_block (single block), " +
-      "get_children (child blocks of a block), create (create a new document), " +
-      "create_blocks (add blocks under a parent), update_block (update block text content). " +
-      "Block types: text, heading1-7, bullet, ordered, code, quote, todo.",
+      "Actions: get_info, get_raw_content, get_blocks, get_block, get_children, " +
+      "create, create_blocks, update_block, batch_update (batch update multiple blocks), " +
+      "convert_markdown (convert markdown to blocks), delete_blocks (batch delete children by index range), " +
+      "append (shorthand for create_blocks at document end). " +
+      "Block types: text, heading1-9, bullet, ordered, code, quote, todo, divider, image, table.",
     inputSchema: FEISHU_DOC_SCHEMA,
     getInvocationTimeoutMs() {
       return 30_000;
@@ -196,6 +314,9 @@ export function createFeishuDocTool(input: {
             create: (payload?: {
               data?: { title?: string; folder_token?: string };
             }) => Promise<ApiResult<{ document?: { document_id?: string; title?: string } }>>;
+            convert: (payload?: {
+              data: { content: string; content_type?: string };
+            }) => Promise<ApiResult<{ blocks?: unknown[]; first_level_block_ids?: string[] }>>;
           };
           documentBlock: {
             list: (payload: {
@@ -211,9 +332,23 @@ export function createFeishuDocTool(input: {
               path: { document_id: string; block_id: string };
               data: Record<string, unknown>;
             }) => Promise<ApiResult<{ block?: unknown }>>;
+            batchUpdate: (payload: {
+              path: { document_id: string };
+              data: { requests: Array<{ block_id: string; [key: string]: unknown }> };
+            }) => Promise<ApiResult<{ blocks?: unknown[] }>>;
           };
           documentBlockChildren: DocBlockChildrenApi;
           documentBlockDescendant: DocBlockDescendantApi;
+        };
+
+        const driveApi = client.drive as unknown as {
+          permissionMember: {
+            create: (payload: {
+              path: { token: string };
+              params: { type: string };
+              data: { member_type: string; member_id: string; perm?: string };
+            }) => Promise<ApiResult<unknown>>;
+          };
         };
 
         switch (args.action) {
@@ -228,11 +363,19 @@ export function createFeishuDocTool(input: {
           case "get_children":
             return await handleGetChildren(docx, args);
           case "create":
-            return await handleCreate(docx, args);
+            return await handleCreate(docx, driveApi, args, collaboratorOpenId);
           case "create_blocks":
             return await handleCreateBlocks(docx, args);
           case "update_block":
             return await handleUpdateBlock(docx, args);
+          case "convert_markdown":
+            return await handleConvertMarkdown(docx, args);
+          case "delete_blocks":
+            return await handleDeleteBlocks(docx, args);
+          case "append":
+            return await handleAppend(docx, args);
+          case "batch_update":
+            return await handleBatchUpdate(docx, args);
           default:
             throw toolRecoverableError(`Unknown action: ${(args as { action: string }).action}`, {
               code: "feishu_doc_unknown_action",
@@ -294,7 +437,17 @@ async function handleCreate(
       }) => Promise<ApiResult<{ document?: { document_id?: string; title?: string } }>>;
     };
   },
+  driveApi: {
+    permissionMember: {
+      create: (payload: {
+        path: { token: string };
+        params: { type: string };
+        data: { member_type: string; member_id: string; perm?: string };
+      }) => Promise<ApiResult<unknown>>;
+    };
+  },
   args: FeishuDocArgs,
+  collaboratorOpenId?: string,
 ) {
   if (!args.title) {
     throw toolRecoverableError("title is required for create", {
@@ -307,7 +460,63 @@ async function handleCreate(
       ...(args.folder_token ? { folder_token: args.folder_token } : {}),
     },
   });
-  return jsonToolResult(extractFeishuData(result, "create"));
+  const docData = extractFeishuData(result, "create");
+  const documentId = (docData as { document?: { document_id?: string } }).document?.document_id;
+
+  // Merge collaboratorOpenId config with explicit permission_members
+  const members: Array<{ member_type: string; member_id: string; perm: string }> = [];
+  if (collaboratorOpenId) {
+    members.push({ member_type: "openid", member_id: collaboratorOpenId, perm: "full_access" });
+  }
+  if (args.permission_members) {
+    for (const m of args.permission_members) {
+      members.push({ member_type: m.member_type, member_id: m.member_id, perm: m.perm ?? "view" });
+    }
+  }
+
+  // Add collaborators if any
+  if (members.length > 0 && documentId) {
+    const permResults: Array<{
+      member_type: string;
+      member_id: string;
+      success: boolean;
+      error?: string;
+    }> = [];
+    for (const member of members) {
+      try {
+        await driveApi.permissionMember.create({
+          path: { token: documentId },
+          params: { type: "docx" },
+          data: {
+            member_type: member.member_type,
+            member_id: member.member_id,
+            perm: member.perm,
+          },
+        });
+        permResults.push({
+          member_type: member.member_type,
+          member_id: member.member_id,
+          success: true,
+        });
+      } catch (permError) {
+        const msg = permError instanceof Error ? permError.message : String(permError);
+        logger.warn("failed to add permission member", {
+          documentId,
+          member_type: member.member_type,
+          error: msg,
+        });
+        permResults.push({
+          member_type: member.member_type,
+          member_id: member.member_id,
+          success: false,
+          error: msg,
+        });
+      }
+    }
+    return jsonToolResult({ document: docData, permissions: permResults });
+  }
+
+  return jsonToolResult(docData);
 }
 
 async function handleGetRawContent(
@@ -422,7 +631,7 @@ async function handleCreateBlocks(
 
   const result = await docx.documentBlockDescendant.create({
     path: { document_id: requireDocumentId(args), block_id: args.block_id },
-    data: { children_id: childrenIds, descendants, index: -1 },
+    data: { children_id: childrenIds, descendants, index: args.index ?? -1 },
   });
 
   // Extract descendants from result for consistent response format
@@ -562,4 +771,103 @@ async function handleUpdateBlock(
     },
   });
   return jsonToolResult(extractFeishuData(result, "update_block"));
+}
+
+async function handleConvertMarkdown(
+  docx: {
+    document: {
+      convert: (payload: {
+        data: { content: string; content_type?: string };
+      }) => Promise<ApiResult<{ blocks?: unknown[]; first_level_block_ids?: string[] }>>;
+    };
+  },
+  args: FeishuDocArgs,
+) {
+  if (!args.content) {
+    throw toolRecoverableError("content is required for convert_markdown", {
+      code: "feishu_doc_missing_content",
+    });
+  }
+
+  const result = await docx.document.convert({
+    data: { content: args.content, content_type: args.content_type ?? "markdown" },
+  });
+  return jsonToolResult(extractFeishuData(result, "convert_markdown"));
+}
+
+async function handleDeleteBlocks(
+  docx: {
+    documentBlockChildren: DocBlockChildrenApi;
+  },
+  args: FeishuDocArgs,
+) {
+  if (!args.block_id) {
+    throw toolRecoverableError("block_id is required for delete_blocks", {
+      code: "feishu_doc_missing_block_id",
+    });
+  }
+  if (args.start_index === undefined || args.start_index === null) {
+    throw toolRecoverableError("start_index is required for delete_blocks", {
+      code: "feishu_doc_missing_start_index",
+    });
+  }
+  if (args.end_index === undefined || args.end_index === null) {
+    throw toolRecoverableError("end_index is required for delete_blocks", {
+      code: "feishu_doc_missing_end_index",
+    });
+  }
+
+  const result = await docx.documentBlockChildren.batchDelete({
+    path: { document_id: requireDocumentId(args), block_id: args.block_id },
+    data: { start_index: args.start_index, end_index: args.end_index },
+  });
+  return jsonToolResult(extractFeishuData(result, "delete_blocks"));
+}
+
+async function handleAppend(
+  docx: {
+    documentBlockChildren: DocBlockChildrenApi;
+    documentBlockDescendant: DocBlockDescendantApi;
+  },
+  args: FeishuDocArgs,
+) {
+  // Append is create_blocks at document root with index=-1
+  const augmentedArgs = {
+    ...args,
+    block_id: (args.block_id ?? args.document_id) as string,
+    index: args.index ?? -1,
+  };
+  return await handleCreateBlocks(docx, augmentedArgs);
+}
+
+async function handleBatchUpdate(
+  docx: {
+    documentBlock: {
+      batchUpdate: (payload: {
+        path: { document_id: string };
+        data: { requests: Array<{ block_id: string; [key: string]: unknown }> };
+      }) => Promise<ApiResult<{ blocks?: unknown[] }>>;
+    };
+  },
+  args: FeishuDocArgs,
+) {
+  if (!args.requests || args.requests.length === 0) {
+    throw toolRecoverableError("requests is required for batch_update", {
+      code: "feishu_doc_missing_requests",
+    });
+  }
+
+  const requests = args.requests.map((r) => {
+    const req: Record<string, unknown> = { block_id: r.block_id };
+    if (r.update_text_elements) {
+      req.update_text_elements = r.update_text_elements as unknown as Record<string, unknown>;
+    }
+    return req as { block_id: string; [key: string]: unknown };
+  });
+
+  const result = await docx.documentBlock.batchUpdate({
+    path: { document_id: requireDocumentId(args) },
+    data: { requests },
+  });
+  return jsonToolResult(extractFeishuData(result, "batch_update"));
 }

--- a/src/tools/feishu/doc.ts
+++ b/src/tools/feishu/doc.ts
@@ -174,7 +174,7 @@ export function createFeishuDocTool(input: {
     async execute(_context, args) {
       logger.info("executing feishu_doc", {
         action: args.action,
-        documentId: requireDocumentId(args),
+        documentId: args.document_id,
       });
 
       try {

--- a/src/tools/feishu/doc.ts
+++ b/src/tools/feishu/doc.ts
@@ -21,16 +21,30 @@ const FEISHU_DOC_SCHEMA = Type.Object(
         Type.Literal("get_blocks"),
         Type.Literal("get_block"),
         Type.Literal("get_children"),
+        Type.Literal("create"),
         Type.Literal("create_blocks"),
         Type.Literal("update_block"),
       ],
       { description: "Operation to perform on the document." },
     ),
-    document_id: Type.String({
-      minLength: 1,
-      description:
-        "The document ID (token). Obtain from the document URL: https://xxx.feishu.cn/docx/TOKEN.",
-    }),
+    document_id: Type.Optional(
+      Type.String({
+        minLength: 1,
+        description:
+          "The document ID (token). Obtain from the document URL: https://xxx.feishu.cn/docx/TOKEN. Not needed for create action.",
+      }),
+    ),
+    title: Type.Optional(
+      Type.String({
+        minLength: 1,
+        description: "Document title. Required for create action.",
+      }),
+    ),
+    folder_token: Type.Optional(
+      Type.String({
+        description: "Folder token to create the document in. Optional for create action.",
+      }),
+    ),
     block_id: Type.Optional(
       Type.String({
         minLength: 1,
@@ -150,8 +164,8 @@ export function createFeishuDocTool(input: {
       "Read and write Feishu/Lark documents (Docx). " +
       "Actions: get_info (document metadata), get_raw_content (plain text), " +
       "get_blocks (list blocks with pagination), get_block (single block), " +
-      "get_children (child blocks of a block), create_blocks (add blocks under a parent), " +
-      "update_block (update block text content). " +
+      "get_children (child blocks of a block), create (create a new document), " +
+      "create_blocks (add blocks under a parent), update_block (update block text content). " +
       "Block types: text, heading1-7, bullet, ordered, code, quote, todo.",
     inputSchema: FEISHU_DOC_SCHEMA,
     getInvocationTimeoutMs() {
@@ -160,7 +174,7 @@ export function createFeishuDocTool(input: {
     async execute(_context, args) {
       logger.info("executing feishu_doc", {
         action: args.action,
-        documentId: args.document_id,
+        documentId: requireDocumentId(args),
       });
 
       try {
@@ -172,6 +186,9 @@ export function createFeishuDocTool(input: {
             rawContent: (payload: {
               path: { document_id: string };
             }) => Promise<ApiResult<{ content?: string }>>;
+            create: (payload?: {
+              data?: { title?: string; folder_token?: string };
+            }) => Promise<ApiResult<{ document?: { document_id?: string; title?: string } }>>;
           };
           documentBlock: {
             list: (payload: {
@@ -202,6 +219,8 @@ export function createFeishuDocTool(input: {
             return await handleGetBlock(docx, args);
           case "get_children":
             return await handleGetChildren(docx, args);
+          case "create":
+            return await handleCreate(docx, args);
           case "create_blocks":
             return await handleCreateBlocks(docx, args);
           case "update_block":
@@ -224,6 +243,15 @@ export function createFeishuDocTool(input: {
   });
 }
 
+function requireDocumentId(args: FeishuDocArgs): string {
+  if (!args.document_id) {
+    throw toolRecoverableError("document_id is required for this action", {
+      code: "feishu_doc_missing_document_id",
+    });
+  }
+  return args.document_id;
+}
+
 async function handleGetInfo(
   docx: {
     document: {
@@ -233,9 +261,33 @@ async function handleGetInfo(
   args: FeishuDocArgs,
 ) {
   const result = await docx.document.get({
-    path: { document_id: args.document_id },
+    path: { document_id: requireDocumentId(args) },
   });
   return jsonToolResult(extractFeishuData(result, "get_info"));
+}
+
+async function handleCreate(
+  docx: {
+    document: {
+      create: (payload?: {
+        data?: { title?: string; folder_token?: string };
+      }) => Promise<ApiResult<{ document?: { document_id?: string; title?: string } }>>;
+    };
+  },
+  args: FeishuDocArgs,
+) {
+  if (!args.title) {
+    throw toolRecoverableError("title is required for create", {
+      code: "feishu_doc_missing_title",
+    });
+  }
+  const result = await docx.document.create({
+    data: {
+      title: args.title,
+      ...(args.folder_token ? { folder_token: args.folder_token } : {}),
+    },
+  });
+  return jsonToolResult(extractFeishuData(result, "create"));
 }
 
 async function handleGetRawContent(
@@ -249,7 +301,7 @@ async function handleGetRawContent(
   args: FeishuDocArgs,
 ) {
   const result = await docx.document.rawContent({
-    path: { document_id: args.document_id },
+    path: { document_id: requireDocumentId(args) },
   });
   const data = extractFeishuData(result, "get_raw_content");
   return textToolResult(data.content ?? "");
@@ -272,7 +324,7 @@ async function handleGetBlocks(
   if (args.page_token) params.page_token = args.page_token;
 
   const result = await docx.documentBlock.list({
-    path: { document_id: args.document_id },
+    path: { document_id: requireDocumentId(args) },
     params,
   });
   return jsonToolResult(extractFeishuData(result, "get_blocks"));
@@ -294,7 +346,7 @@ async function handleGetBlock(
     });
   }
   const result = await docx.documentBlock.get({
-    path: { document_id: args.document_id, block_id: args.block_id },
+    path: { document_id: requireDocumentId(args), block_id: args.block_id },
   });
   return jsonToolResult(extractFeishuData(result, "get_block"));
 }
@@ -316,7 +368,7 @@ async function handleGetChildren(
   if (args.page_token) params.page_token = args.page_token;
 
   const result = await docx.documentBlock.children.get({
-    path: { document_id: args.document_id, block_id: args.block_id },
+    path: { document_id: requireDocumentId(args), block_id: args.block_id },
     params,
   });
   return jsonToolResult(extractFeishuData(result, "get_children"));
@@ -342,7 +394,7 @@ async function handleCreateBlocks(
   const children = args.blocks.map((b) => buildBlockPayload(b));
 
   const result = await docx.documentBlock.children.create({
-    path: { document_id: args.document_id, block_id: args.block_id },
+    path: { document_id: requireDocumentId(args), block_id: args.block_id },
     data: { children },
   });
   return jsonToolResult(extractFeishuData(result, "create_blocks"));
@@ -454,7 +506,7 @@ async function handleUpdateBlock(
   }
 
   const result = await docx.documentBlock.patch({
-    path: { document_id: args.document_id, block_id: args.block_id },
+    path: { document_id: requireDocumentId(args), block_id: args.block_id },
     data: {
       update_text_elements: args.update_text_elements as unknown as Record<string, unknown>,
     },

--- a/src/tools/feishu/doc.ts
+++ b/src/tools/feishu/doc.ts
@@ -1,0 +1,463 @@
+/**
+ * feishu_doc tool - Read and write Feishu/Lark documents.
+ *
+ * Uses the Feishu Open Platform Docx API to access document content,
+ * blocks, and metadata. Requires the app to have document permissions.
+ */
+import { type Static, Type } from "@sinclair/typebox";
+import { createSubsystemLogger } from "@/src/shared/logger.js";
+import { toolRecoverableError } from "@/src/tools/core/errors.js";
+import { defineTool, jsonToolResult, textToolResult } from "@/src/tools/core/types.js";
+import { extractFeishuData, type FeishuClientSource } from "@/src/tools/feishu/client.js";
+
+const logger = createSubsystemLogger("tools/feishu-doc");
+
+const FEISHU_DOC_SCHEMA = Type.Object(
+  {
+    action: Type.Union(
+      [
+        Type.Literal("get_info"),
+        Type.Literal("get_raw_content"),
+        Type.Literal("get_blocks"),
+        Type.Literal("get_block"),
+        Type.Literal("get_children"),
+        Type.Literal("create_blocks"),
+        Type.Literal("update_block"),
+      ],
+      { description: "Operation to perform on the document." },
+    ),
+    document_id: Type.String({
+      minLength: 1,
+      description:
+        "The document ID (token). Obtain from the document URL: https://xxx.feishu.cn/docx/TOKEN.",
+    }),
+    block_id: Type.Optional(
+      Type.String({
+        minLength: 1,
+        description: "Block ID. Required for get_block, get_children, create_blocks, update_block.",
+      }),
+    ),
+    blocks: Type.Optional(
+      Type.Array(
+        Type.Object(
+          {
+            block_type: Type.String({
+              description:
+                "Block type: 'text', 'heading1'-'heading7', 'bullet', 'ordered', 'code', 'quote', 'todo', 'divider', 'image', 'table'.",
+            }),
+            text: Type.Optional(
+              Type.Array(
+                Type.Object(
+                  {
+                    content: Type.String({ minLength: 1 }),
+                    bold: Type.Optional(Type.Boolean({ description: "Bold text" })),
+                    italic: Type.Optional(Type.Boolean({ description: "Italic text" })),
+                    underline: Type.Optional(Type.Boolean({ description: "Underlined text" })),
+                    strikethrough: Type.Optional(
+                      Type.Boolean({ description: "Strikethrough text" }),
+                    ),
+                    inline_code: Type.Optional(Type.Boolean({ description: "Inline code style" })),
+                    link: Type.Optional(Type.String({ description: "Hyperlink URL" })),
+                  },
+                  { additionalProperties: false },
+                ),
+              ),
+            ),
+          },
+          { additionalProperties: false },
+        ),
+      ),
+    ),
+    update_text_elements: Type.Optional(
+      Type.Object(
+        {
+          elements: Type.Array(
+            Type.Object(
+              {
+                text_run: Type.Object(
+                  {
+                    content: Type.String({ minLength: 1 }),
+                    text_element_style: Type.Optional(
+                      Type.Object(
+                        {
+                          bold: Type.Optional(Type.Boolean({ description: "Bold" })),
+                          italic: Type.Optional(Type.Boolean({ description: "Italic" })),
+                          underline: Type.Optional(Type.Boolean({ description: "Underline" })),
+                          strikethrough: Type.Optional(
+                            Type.Boolean({ description: "Strikethrough" }),
+                          ),
+                          inline_code: Type.Optional(Type.Boolean({ description: "Inline code" })),
+                          link: Type.Optional(
+                            Type.Object(
+                              { url: Type.String({ minLength: 1 }) },
+                              { additionalProperties: false },
+                            ),
+                          ),
+                        },
+                        { additionalProperties: false },
+                      ),
+                    ),
+                  },
+                  { additionalProperties: false },
+                ),
+              },
+              { additionalProperties: false },
+            ),
+          ),
+        },
+        { additionalProperties: false },
+      ),
+    ),
+    page_size: Type.Optional(
+      Type.Number({
+        minimum: 1,
+        maximum: 500,
+        description: "Page size for paginated list actions (default 50).",
+      }),
+    ),
+    page_token: Type.Optional(
+      Type.String({
+        description: "Page token for paginated list actions.",
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export type FeishuDocArgs = Static<typeof FEISHU_DOC_SCHEMA>;
+type ApiResult<T = unknown> = { code: number; msg: string; data?: T };
+
+type DocBlockChildrenApi = {
+  get: (payload: {
+    path: { document_id: string; block_id: string };
+    params?: Record<string, string>;
+  }) => Promise<ApiResult<{ items?: unknown[]; has_more?: boolean; page_token?: string }>>;
+  create: (payload: {
+    path: { document_id: string; block_id: string };
+    data: { children: unknown[] };
+  }) => Promise<ApiResult<{ children?: unknown[] }>>;
+};
+
+export function createFeishuDocTool(input: {
+  installationId: string;
+  clientSource: FeishuClientSource;
+}) {
+  const client = input.clientSource.getClient(input.installationId);
+
+  return defineTool({
+    name: "feishu_doc",
+    description:
+      "Read and write Feishu/Lark documents (Docx). " +
+      "Actions: get_info (document metadata), get_raw_content (plain text), " +
+      "get_blocks (list blocks with pagination), get_block (single block), " +
+      "get_children (child blocks of a block), create_blocks (add blocks under a parent), " +
+      "update_block (update block text content). " +
+      "Block types: text, heading1-7, bullet, ordered, code, quote, todo.",
+    inputSchema: FEISHU_DOC_SCHEMA,
+    getInvocationTimeoutMs() {
+      return 30_000;
+    },
+    async execute(_context, args) {
+      logger.info("executing feishu_doc", {
+        action: args.action,
+        documentId: args.document_id,
+      });
+
+      try {
+        const docx = client.docx as unknown as {
+          document: {
+            get: (payload: {
+              path: { document_id: string };
+            }) => Promise<ApiResult<{ document?: unknown }>>;
+            rawContent: (payload: {
+              path: { document_id: string };
+            }) => Promise<ApiResult<{ content?: string }>>;
+          };
+          documentBlock: {
+            list: (payload: {
+              path: { document_id: string };
+              params: Record<string, string>;
+            }) => Promise<
+              ApiResult<{ items?: unknown[]; has_more?: boolean; page_token?: string }>
+            >;
+            get: (payload: {
+              path: { document_id: string; block_id: string };
+            }) => Promise<ApiResult<{ block?: unknown }>>;
+            patch: (payload: {
+              path: { document_id: string; block_id: string };
+              data: Record<string, unknown>;
+            }) => Promise<ApiResult<{ block?: unknown }>>;
+            children: DocBlockChildrenApi;
+          };
+        };
+
+        switch (args.action) {
+          case "get_info":
+            return await handleGetInfo(docx, args);
+          case "get_raw_content":
+            return await handleGetRawContent(docx, args);
+          case "get_blocks":
+            return await handleGetBlocks(docx, args);
+          case "get_block":
+            return await handleGetBlock(docx, args);
+          case "get_children":
+            return await handleGetChildren(docx, args);
+          case "create_blocks":
+            return await handleCreateBlocks(docx, args);
+          case "update_block":
+            return await handleUpdateBlock(docx, args);
+          default:
+            throw toolRecoverableError(`Unknown action: ${(args as { action: string }).action}`, {
+              code: "feishu_doc_unknown_action",
+            });
+        }
+      } catch (error) {
+        if (error instanceof Error && error.name === "ToolRecoverableError") {
+          throw error;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        throw toolRecoverableError(`feishu_doc failed: ${message}`, {
+          code: "feishu_doc_error",
+        });
+      }
+    },
+  });
+}
+
+async function handleGetInfo(
+  docx: {
+    document: {
+      get: (p: { path: { document_id: string } }) => Promise<ApiResult<{ document?: unknown }>>;
+    };
+  },
+  args: FeishuDocArgs,
+) {
+  const result = await docx.document.get({
+    path: { document_id: args.document_id },
+  });
+  return jsonToolResult(extractFeishuData(result, "get_info"));
+}
+
+async function handleGetRawContent(
+  docx: {
+    document: {
+      rawContent: (p: {
+        path: { document_id: string };
+      }) => Promise<ApiResult<{ content?: string }>>;
+    };
+  },
+  args: FeishuDocArgs,
+) {
+  const result = await docx.document.rawContent({
+    path: { document_id: args.document_id },
+  });
+  const data = extractFeishuData(result, "get_raw_content");
+  return textToolResult(data.content ?? "");
+}
+
+async function handleGetBlocks(
+  docx: {
+    documentBlock: {
+      list: (p: {
+        path: { document_id: string };
+        params: Record<string, string>;
+      }) => Promise<ApiResult<{ items?: unknown[]; has_more?: boolean; page_token?: string }>>;
+    };
+  },
+  args: FeishuDocArgs,
+) {
+  const params: Record<string, string> = {
+    page_size: String(args.page_size ?? 50),
+  };
+  if (args.page_token) params.page_token = args.page_token;
+
+  const result = await docx.documentBlock.list({
+    path: { document_id: args.document_id },
+    params,
+  });
+  return jsonToolResult(extractFeishuData(result, "get_blocks"));
+}
+
+async function handleGetBlock(
+  docx: {
+    documentBlock: {
+      get: (p: {
+        path: { document_id: string; block_id: string };
+      }) => Promise<ApiResult<{ block?: unknown }>>;
+    };
+  },
+  args: FeishuDocArgs,
+) {
+  if (!args.block_id) {
+    throw toolRecoverableError("block_id is required for get_block", {
+      code: "feishu_doc_missing_block_id",
+    });
+  }
+  const result = await docx.documentBlock.get({
+    path: { document_id: args.document_id, block_id: args.block_id },
+  });
+  return jsonToolResult(extractFeishuData(result, "get_block"));
+}
+
+async function handleGetChildren(
+  docx: {
+    documentBlock: { children: DocBlockChildrenApi };
+  },
+  args: FeishuDocArgs,
+) {
+  if (!args.block_id) {
+    throw toolRecoverableError("block_id is required for get_children", {
+      code: "feishu_doc_missing_block_id",
+    });
+  }
+  const params: Record<string, string> = {
+    page_size: String(args.page_size ?? 50),
+  };
+  if (args.page_token) params.page_token = args.page_token;
+
+  const result = await docx.documentBlock.children.get({
+    path: { document_id: args.document_id, block_id: args.block_id },
+    params,
+  });
+  return jsonToolResult(extractFeishuData(result, "get_children"));
+}
+
+async function handleCreateBlocks(
+  docx: {
+    documentBlock: { children: DocBlockChildrenApi };
+  },
+  args: FeishuDocArgs,
+) {
+  if (!args.block_id) {
+    throw toolRecoverableError("block_id is required for create_blocks", {
+      code: "feishu_doc_missing_block_id",
+    });
+  }
+  if (!args.blocks || args.blocks.length === 0) {
+    throw toolRecoverableError("blocks are required for create_blocks", {
+      code: "feishu_doc_missing_blocks",
+    });
+  }
+
+  const children = args.blocks.map((b) => buildBlockPayload(b));
+
+  const result = await docx.documentBlock.children.create({
+    path: { document_id: args.document_id, block_id: args.block_id },
+    data: { children },
+  });
+  return jsonToolResult(extractFeishuData(result, "create_blocks"));
+}
+
+function buildBlockPayload(block: {
+  block_type: string;
+  text?: Array<{
+    content: string;
+    bold?: boolean;
+    italic?: boolean;
+    underline?: boolean;
+    strikethrough?: boolean;
+    inline_code?: boolean;
+    link?: string;
+  }>;
+}) {
+  const blockType = block.block_type;
+  const payload: Record<string, unknown> = {
+    block_type: blockTypeToNumber(blockType),
+  };
+
+  if (block.text && block.text.length > 0) {
+    const elements = block.text.map((t) => {
+      const textRun: Record<string, unknown> = { content: t.content };
+      const style: Record<string, unknown> = {};
+      if (t.bold) style.bold = true;
+      if (t.italic) style.italic = true;
+      if (t.underline) style.underline = true;
+      if (t.strikethrough) style.strikethrough = true;
+      if (t.inline_code) style.inline_code = true;
+      if (t.link) style.link = { url: t.link };
+      if (Object.keys(style).length > 0) {
+        textRun.text_element_style = style;
+      }
+      return { text_run: textRun };
+    });
+
+    const blockBody: Record<string, unknown> = { elements };
+    const contentKey = blockTypeToContentKey(blockType);
+    payload[contentKey] = blockBody;
+  }
+
+  return payload;
+}
+
+function blockTypeToNumber(type: string): number {
+  const map: Record<string, number> = {
+    text: 2,
+    heading1: 3,
+    heading2: 4,
+    heading3: 5,
+    heading4: 6,
+    heading5: 7,
+    heading6: 8,
+    heading7: 9,
+    bullet: 10,
+    ordered: 11,
+    code: 12,
+    quote: 13,
+    callout: 14,
+    todo: 15,
+    divider: 16,
+    image: 17,
+    table: 18,
+  };
+  return map[type] ?? 2;
+}
+
+function blockTypeToContentKey(type: string): string {
+  const map: Record<string, string> = {
+    text: "text",
+    heading1: "heading1",
+    heading2: "heading2",
+    heading3: "heading3",
+    heading4: "heading4",
+    heading5: "heading5",
+    heading6: "heading6",
+    heading7: "heading7",
+    bullet: "bullet",
+    ordered: "ordered",
+    code: "code",
+    quote: "quote",
+    todo: "todo",
+  };
+  return map[type] ?? "text";
+}
+
+async function handleUpdateBlock(
+  docx: {
+    documentBlock: {
+      patch: (p: {
+        path: { document_id: string; block_id: string };
+        data: Record<string, unknown>;
+      }) => Promise<ApiResult<{ block?: unknown }>>;
+    };
+  },
+  args: FeishuDocArgs,
+) {
+  if (!args.block_id) {
+    throw toolRecoverableError("block_id is required for update_block", {
+      code: "feishu_doc_missing_block_id",
+    });
+  }
+  if (!args.update_text_elements) {
+    throw toolRecoverableError("update_text_elements is required for update_block", {
+      code: "feishu_doc_missing_update_text_elements",
+    });
+  }
+
+  const result = await docx.documentBlock.patch({
+    path: { document_id: args.document_id, block_id: args.block_id },
+    data: {
+      update_text_elements: args.update_text_elements as unknown as Record<string, unknown>,
+    },
+  });
+  return jsonToolResult(extractFeishuData(result, "update_block"));
+}

--- a/tests/config/load.test.ts
+++ b/tests/config/load.test.ts
@@ -212,6 +212,14 @@ describe("config loader", () => {
           enabled: false,
         },
       },
+      feishu: {
+        doc: {
+          enabled: false,
+        },
+        base: {
+          enabled: false,
+        },
+      },
     });
     expect(config.security).toEqual({
       filesystem: {
@@ -468,6 +476,14 @@ describe("config loader", () => {
         fetch: {
           enabled: true,
           provider: "tavily",
+        },
+      },
+      feishu: {
+        doc: {
+          enabled: false,
+        },
+        base: {
+          enabled: false,
         },
       },
     });

--- a/tests/runtime/bootstrap.test.ts
+++ b/tests/runtime/bootstrap.test.ts
@@ -56,6 +56,14 @@ function createConfig(): AppConfig {
           enabled: false,
         },
       },
+      feishu: {
+        doc: {
+          enabled: false,
+        },
+        base: {
+          enabled: false,
+        },
+      },
     },
     security: {
       filesystem: {

--- a/tests/runtime/status.test.ts
+++ b/tests/runtime/status.test.ts
@@ -102,6 +102,14 @@ function createConfig(): AppConfig {
           enabled: false,
         },
       },
+      feishu: {
+        doc: {
+          enabled: false,
+        },
+        base: {
+          enabled: false,
+        },
+      },
     },
     security: {
       filesystem: {


### PR DESCRIPTION

## 概述

新增 `feishu_doc` 和 `feishu_base` 两个云文档工具，基于现有 `LarkClientRegistry` 实现对飞书文档和多维表格的读写能力。

## 新增工具

### `feishu_doc` — 8 个 action

| action | 说明 |
|--------|------|
| `get_info` | 文档元信息 |
| `get_raw_content` | 纯文本内容 |
| `get_blocks` | 分页获取块列表 |
| `get_block` | 获取单个块 |
| `get_children` | 获取子块 |
| `create` | 新建文档 |
| `create_blocks` | 插入段落（支持 text/heading/bullet/code/quote/todo 等） |
| `update_block` | 修改块富文本 |

### `feishu_base` — 11 个 action

| action | 说明 |
|--------|------|
| `get_info` | 多维表格元信息 |
| `list_tables` | 列出数据表 |
| `list_fields` | 列出字段 |
| `list_records` | 列出记录（支持排序和分页） |
| `search_records` | 搜索记录（支持 filter + sort） |
| `create_record` | 创建单条记录 |
| `update_record` | 更新单条记录 |
| `create_records` | 批量创建（最多 500 条） |
| `update_records` | 批量更新（最多 500 条） |
| `create_base` | 新建多维表格 |
| `create_table` | 新建数据表（可选字段定义） |

## 设计

- 统一 action 式 API，每个领域一个工具
- 复用 `channels.lark.installations` 配置，不重复存储凭据
- 通过 `LarkClientRegistry` 懒加载 SDK client，自动管理 token
- TypeBox 类型约束 + TypeScript 全量类型
- 错误消息包含飞书 API 返回的详细信息

## 配置

```toml
[tools.feishu.doc]
enabled = true
installation = "default"

[tools.feishu.base]
enabled = true
installation = "default"

默认均为 enabled = false。
验证
✅ tsc --noEmit 零错误
✅ biome lint 零错误
