### PR TITLE
Allow safe bash helper chains after approved prefixes

### DIFF
--- a/src/security/bash-approval-helpers.ts
+++ b/src/security/bash-approval-helpers.ts
@@ -31,10 +31,8 @@ const JQ_ALLOWED_FLAG_OPTIONS = new Set([
   "-a",
 ]);
 
-const JQ_ALLOWED_VALUE_OPTIONS = new Map<string, number>([
-  ["--arg", 2],
-  ["--argjson", 2],
-  ["--indent", 1],
+const JQ_ALLOWED_VALUE_OPTIONS = new Map<string, (values: string[]) => boolean>([
+  ["--indent", ([value]) => value != null && /^[0-7]$/.test(value)],
 ]);
 
 const WC_ALLOWED_LONG_OPTIONS = new Set([
@@ -184,9 +182,11 @@ function isStdinJq(segment: BashCommandSegment): boolean {
       return false;
     }
 
-    const valueOptionArity = JQ_ALLOWED_VALUE_OPTIONS.get(arg);
-    if (valueOptionArity != null) {
-      if (index + valueOptionArity >= segment.argv.length) {
+    const valueOptionValidator = JQ_ALLOWED_VALUE_OPTIONS.get(arg);
+    if (valueOptionValidator != null) {
+      const valueOptionArity = 1;
+      const values = segment.argv.slice(index + 1, index + 1 + valueOptionArity);
+      if (values.length !== valueOptionArity || !valueOptionValidator(values)) {
         return false;
       }
       index += valueOptionArity;
@@ -234,12 +234,25 @@ function isCountValue(value: string): boolean {
 }
 
 function isLiteralEchoArgument(arg: string): boolean {
-  return !(
-    arg.startsWith("~") ||
-    arg.includes("=~") ||
-    /[*?[\]{}]/.test(arg) ||
-    /^[!@+]\(/.test(arg)
-  );
+  return !hasBashTildeExpansion(arg) && !hasBashPatternExpansion(arg);
+}
+
+function hasBashTildeExpansion(arg: string): boolean {
+  if (arg.startsWith("~")) {
+    return true;
+  }
+
+  const assignmentMatch = arg.match(/^[A-Za-z_][A-Za-z0-9_]*=(.*)$/);
+  if (assignmentMatch == null) {
+    return false;
+  }
+
+  const value = assignmentMatch[1] ?? "";
+  return value.split(":").some((entry) => entry.startsWith("~"));
+}
+
+function hasBashPatternExpansion(arg: string): boolean {
+  return /[*?[\]{}]/.test(arg) || /[!@+]\(/.test(arg);
 }
 
 // jq helper mode intentionally accepts selectors, not jq programs. That keeps

--- a/src/security/bash-approval-helpers.ts
+++ b/src/security/bash-approval-helpers.ts
@@ -234,7 +234,12 @@ function isCountValue(value: string): boolean {
 }
 
 function isLiteralEchoArgument(arg: string): boolean {
-  return !(arg.startsWith("~") || /[*?[\]{}]/.test(arg) || /^[!@+]\(/.test(arg));
+  return !(
+    arg.startsWith("~") ||
+    arg.includes("=~") ||
+    /[*?[\]{}]/.test(arg) ||
+    /^[!@+]\(/.test(arg)
+  );
 }
 
 // jq helper mode intentionally accepts selectors, not jq programs. That keeps

--- a/src/security/bash-approval-helpers.ts
+++ b/src/security/bash-approval-helpers.ts
@@ -1,0 +1,215 @@
+import type { BashCommandSegment } from "@/src/security/bash-prefix.js";
+
+const JQ_FORBIDDEN_OPTIONS = new Set([
+  "-f",
+  "--from-file",
+  "-L",
+  "--rawfile",
+  "--slurpfile",
+  "--argfile",
+]);
+
+const JQ_ALLOWED_FLAG_OPTIONS = new Set([
+  "-r",
+  "--raw-output",
+  "-c",
+  "--compact-output",
+  "-M",
+  "--monochrome-output",
+  "-S",
+  "--sort-keys",
+  "-e",
+  "--exit-status",
+  "-s",
+  "--slurp",
+  "-R",
+  "--raw-input",
+  "-j",
+  "--join-output",
+  "--tab",
+  "--ascii-output",
+  "-a",
+]);
+
+const JQ_ALLOWED_VALUE_OPTIONS = new Map<string, number>([
+  ["--arg", 2],
+  ["--argjson", 2],
+  ["--indent", 1],
+]);
+
+const WC_ALLOWED_LONG_OPTIONS = new Set([
+  "--bytes",
+  "--chars",
+  "--lines",
+  "--max-line-length",
+  "--words",
+]);
+
+export type BashApprovalHelperKind = "standalone" | "pipeline";
+
+export function classifyBashApprovalHelper(
+  segment: BashCommandSegment,
+): BashApprovalHelperKind | null {
+  const commandName = segment.argv[0];
+  if (commandName == null || hasExecutionContext(segment)) {
+    return null;
+  }
+
+  switch (commandName) {
+    case "echo":
+      return isLiteralEcho(segment) ? "standalone" : null;
+    case "head":
+      return isStdinHeadOrTail(segment) ? "pipeline" : null;
+    case "tail":
+      return isStdinHeadOrTail(segment) ? "pipeline" : null;
+    case "wc":
+      return isStdinWc(segment) ? "pipeline" : null;
+    case "jq":
+      return isStdinJq(segment) ? "pipeline" : null;
+    default:
+      return null;
+  }
+}
+
+function hasExecutionContext(segment: BashCommandSegment): boolean {
+  return segment.envAssignments.length > 0 || segment.redirects.length > 0;
+}
+
+function isLiteralEcho(segment: BashCommandSegment): boolean {
+  return segment.argv.length >= 1;
+}
+
+function isStdinHeadOrTail(segment: BashCommandSegment): boolean {
+  if (!segment.stdinFromPipe) {
+    return false;
+  }
+
+  for (let index = 1; index < segment.argv.length; index += 1) {
+    const arg = segment.argv[index];
+    if (arg == null) {
+      return false;
+    }
+
+    if (arg === "-n" || arg === "-c") {
+      const value = segment.argv[index + 1];
+      if (value == null || !isCountValue(value)) {
+        return false;
+      }
+      index += 1;
+      continue;
+    }
+
+    if (
+      /^-[0-9]+$/.test(arg) ||
+      /^-[nc][0-9]+$/.test(arg) ||
+      /^--(?:lines|bytes)=\+?[0-9]+$/.test(arg)
+    ) {
+      continue;
+    }
+
+    return false;
+  }
+
+  return true;
+}
+
+function isStdinWc(segment: BashCommandSegment): boolean {
+  if (!segment.stdinFromPipe) {
+    return false;
+  }
+
+  for (let index = 1; index < segment.argv.length; index += 1) {
+    const arg = segment.argv[index];
+    if (arg == null) {
+      return false;
+    }
+
+    if (WC_ALLOWED_LONG_OPTIONS.has(arg) || /^-[clLmw]+$/.test(arg)) {
+      continue;
+    }
+
+    return false;
+  }
+
+  return true;
+}
+
+function isStdinJq(segment: BashCommandSegment): boolean {
+  if (!segment.stdinFromPipe) {
+    return false;
+  }
+
+  let filterSeen = false;
+  let endOfOptions = false;
+  for (let index = 1; index < segment.argv.length; index += 1) {
+    const arg = segment.argv[index];
+    if (arg == null) {
+      return false;
+    }
+
+    if (filterSeen) {
+      return false;
+    }
+
+    if (endOfOptions || !arg.startsWith("-") || arg === "-") {
+      filterSeen = true;
+      continue;
+    }
+
+    if (arg === "--") {
+      endOfOptions = true;
+      continue;
+    }
+
+    if (isForbiddenJqOption(arg)) {
+      return false;
+    }
+
+    const valueOptionArity = JQ_ALLOWED_VALUE_OPTIONS.get(arg);
+    if (valueOptionArity != null) {
+      if (index + valueOptionArity >= segment.argv.length) {
+        return false;
+      }
+      index += valueOptionArity;
+      continue;
+    }
+
+    if (JQ_ALLOWED_FLAG_OPTIONS.has(arg) || isAllowedJqShortFlagCluster(arg)) {
+      continue;
+    }
+
+    return false;
+  }
+
+  return true;
+}
+
+function isForbiddenJqOption(arg: string): boolean {
+  if (JQ_FORBIDDEN_OPTIONS.has(arg)) {
+    return true;
+  }
+
+  return (
+    arg.startsWith("--rawfile=") ||
+    arg.startsWith("--slurpfile=") ||
+    arg.startsWith("--argfile=") ||
+    arg.startsWith("--from-file=")
+  );
+}
+
+function isAllowedJqShortFlagCluster(arg: string): boolean {
+  if (!arg.startsWith("-") || arg.startsWith("--") || arg.length < 2) {
+    return false;
+  }
+
+  const flags = arg.slice(1);
+  if (flags.includes("f") || flags.includes("L")) {
+    return false;
+  }
+
+  return /^[rcMSeRsRja]+$/.test(flags);
+}
+
+function isCountValue(value: string): boolean {
+  return /^\+?[0-9]+$/.test(value);
+}

--- a/src/security/bash-approval-helpers.ts
+++ b/src/security/bash-approval-helpers.ts
@@ -45,6 +45,8 @@ const WC_ALLOWED_LONG_OPTIONS = new Set([
   "--words",
 ]);
 
+const HEAD_TAIL_QUIET_OPTIONS = new Set(["-q", "--quiet", "--silent"]);
+
 export type BashApprovalHelperKind = "standalone" | "pipeline";
 
 export function classifyBashApprovalHelper(
@@ -99,9 +101,23 @@ function isStdinHeadOrTail(segment: BashCommandSegment): boolean {
       continue;
     }
 
+    if (HEAD_TAIL_QUIET_OPTIONS.has(arg)) {
+      continue;
+    }
+
+    if (arg === "-qn" || arg === "-qc") {
+      const value = segment.argv[index + 1];
+      if (value == null || !isCountValue(value)) {
+        return false;
+      }
+      index += 1;
+      continue;
+    }
+
     if (
       /^-[0-9]+$/.test(arg) ||
       /^-[nc][0-9]+$/.test(arg) ||
+      /^-q(?:[0-9]+|[nc][0-9]+)$/.test(arg) ||
       /^--(?:lines|bytes)=\+?[0-9]+$/.test(arg)
     ) {
       continue;
@@ -152,6 +168,9 @@ function isStdinJq(segment: BashCommandSegment): boolean {
     }
 
     if (endOfOptions || !arg.startsWith("-") || arg === "-") {
+      if (!isSafeJqPathFilter(arg)) {
+        return false;
+      }
       filterSeen = true;
       continue;
     }
@@ -181,7 +200,7 @@ function isStdinJq(segment: BashCommandSegment): boolean {
     return false;
   }
 
-  return true;
+  return filterSeen;
 }
 
 function isForbiddenJqOption(arg: string): boolean {
@@ -212,4 +231,199 @@ function isAllowedJqShortFlagCluster(arg: string): boolean {
 
 function isCountValue(value: string): boolean {
   return /^\+?[0-9]+$/.test(value);
+}
+
+// jq helper mode intentionally accepts selectors, not jq programs. That keeps
+// common JSON inspection useful while rejecting host-readable features such as
+// env/$ENV, import/include, rawfile/slurpfile, and arbitrary builtin calls.
+function isSafeJqPathFilter(filter: string): boolean {
+  const stages = splitJqSelectorPipeline(filter.trim());
+  return stages != null && stages.length > 0 && stages.every(isSafeJqSelectorStage);
+}
+
+function splitJqSelectorPipeline(filter: string): string[] | null {
+  if (filter.length === 0) {
+    return null;
+  }
+
+  const stages: string[] = [];
+  let stageStart = 0;
+  let inString = false;
+  let escaping = false;
+
+  for (let index = 0; index < filter.length; index += 1) {
+    const char = filter[index];
+
+    if (inString) {
+      if (escaping) {
+        escaping = false;
+        continue;
+      }
+      if (char === "\\") {
+        escaping = true;
+        continue;
+      }
+      if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+
+    if (char === "|") {
+      const stage = filter.slice(stageStart, index).trim();
+      if (stage.length === 0) {
+        return null;
+      }
+      stages.push(stage);
+      stageStart = index + 1;
+    }
+  }
+
+  if (inString || escaping) {
+    return null;
+  }
+
+  const finalStage = filter.slice(stageStart).trim();
+  if (finalStage.length === 0) {
+    return null;
+  }
+  stages.push(finalStage);
+  return stages;
+}
+
+function isSafeJqSelectorStage(stage: string): boolean {
+  if (stage === ".") {
+    return true;
+  }
+  if (!stage.startsWith(".")) {
+    return false;
+  }
+
+  let index = 1;
+  if (index >= stage.length) {
+    return true;
+  }
+
+  if (isJqIdentifierStart(stage[index])) {
+    index = consumeJqIdentifier(stage, index);
+    index = consumeOptionalJqMarker(stage, index);
+  } else if (stage[index] === "[") {
+    const nextIndex = consumeJqBracketSelector(stage, index);
+    if (nextIndex == null) {
+      return false;
+    }
+    index = consumeOptionalJqMarker(stage, nextIndex);
+  } else {
+    return false;
+  }
+
+  while (index < stage.length) {
+    if (stage[index] === ".") {
+      index += 1;
+      if (!isJqIdentifierStart(stage[index])) {
+        return false;
+      }
+      index = consumeJqIdentifier(stage, index);
+      index = consumeOptionalJqMarker(stage, index);
+      continue;
+    }
+
+    if (stage[index] === "[") {
+      const nextIndex = consumeJqBracketSelector(stage, index);
+      if (nextIndex == null) {
+        return false;
+      }
+      index = consumeOptionalJqMarker(stage, nextIndex);
+      continue;
+    }
+
+    return false;
+  }
+
+  return true;
+}
+
+function consumeJqBracketSelector(stage: string, startIndex: number): number | null {
+  let inString = false;
+  let escaping = false;
+
+  for (let index = startIndex + 1; index < stage.length; index += 1) {
+    const char = stage[index];
+    if (inString) {
+      if (escaping) {
+        escaping = false;
+        continue;
+      }
+      if (char === "\\") {
+        escaping = true;
+        continue;
+      }
+      if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+
+    if (char !== "]") {
+      continue;
+    }
+
+    const content = stage.slice(startIndex + 1, index).trim();
+    return isSafeJqBracketSelectorContent(content) ? index + 1 : null;
+  }
+
+  return null;
+}
+
+function isSafeJqBracketSelectorContent(content: string): boolean {
+  if (content.length === 0) {
+    return true;
+  }
+  if (/^-?[0-9]+$/.test(content)) {
+    return true;
+  }
+  if (isSafeJqNumericSliceContent(content)) {
+    return true;
+  }
+
+  try {
+    return typeof JSON.parse(content) === "string";
+  } catch {
+    return false;
+  }
+}
+
+function isSafeJqNumericSliceContent(content: string): boolean {
+  const match = content.match(/^(-?[0-9]+)?:(-?[0-9]+)?$/);
+  return match != null && (match[1] != null || match[2] != null);
+}
+
+function consumeJqIdentifier(stage: string, startIndex: number): number {
+  let index = startIndex + 1;
+  while (index < stage.length && isJqIdentifierPart(stage[index])) {
+    index += 1;
+  }
+  return index;
+}
+
+function consumeOptionalJqMarker(stage: string, index: number): number {
+  return stage[index] === "?" ? index + 1 : index;
+}
+
+function isJqIdentifierStart(char: string | undefined): boolean {
+  return char != null && /^[A-Za-z_]$/.test(char);
+}
+
+function isJqIdentifierPart(char: string | undefined): boolean {
+  return char != null && /^[A-Za-z0-9_]$/.test(char);
 }

--- a/src/security/bash-approval-helpers.ts
+++ b/src/security/bash-approval-helpers.ts
@@ -78,7 +78,7 @@ function hasExecutionContext(segment: BashCommandSegment): boolean {
 }
 
 function isLiteralEcho(segment: BashCommandSegment): boolean {
-  return segment.argv.length >= 1;
+  return segment.argv.slice(1).every(isLiteralEchoArgument);
 }
 
 function isStdinHeadOrTail(segment: BashCommandSegment): boolean {
@@ -231,6 +231,10 @@ function isAllowedJqShortFlagCluster(arg: string): boolean {
 
 function isCountValue(value: string): boolean {
   return /^\+?[0-9]+$/.test(value);
+}
+
+function isLiteralEchoArgument(arg: string): boolean {
+  return !(arg.startsWith("~") || /[*?[\]{}]/.test(arg) || /^[!@+]\(/.test(arg));
 }
 
 // jq helper mode intentionally accepts selectors, not jq programs. That keeps

--- a/src/security/bash-prefix.ts
+++ b/src/security/bash-prefix.ts
@@ -18,9 +18,20 @@ export interface SimpleBashCommand {
   argv: string[];
 }
 
+export interface BashCommandRedirect {
+  operator: string;
+  destination: string;
+}
+
+export interface BashCommandSegment extends SimpleBashCommand {
+  redirects: BashCommandRedirect[];
+  stdinFromPipe: boolean;
+  stdoutToPipe: boolean;
+}
+
 export interface ParsedBashCommandSequence {
   kind: "simple" | "compound";
-  commands: SimpleBashCommand[];
+  commands: BashCommandSegment[];
 }
 
 type BashParserState =
@@ -52,7 +63,11 @@ export function parseConservativeBashCommandSequence(
     }
 
     try {
-      const commands = extractCommandSequence(tree.rootNode);
+      const commands = extractCommandSequence(tree.rootNode, {
+        inheritedRedirects: [],
+        stdinFromPipe: false,
+        stdoutToPipe: false,
+      });
       if (commands == null || commands.length === 0) {
         return null;
       }
@@ -75,7 +90,7 @@ export function parseConservativeBashCommandSequence(
   }
 }
 
-export function parseSimpleBashCommand(command: string): SimpleBashCommand | null {
+export function parseSimpleBashCommand(command: string): BashCommandSegment | null {
   const parsed = parseConservativeBashCommandSequence(command);
   if (parsed?.kind !== "simple") {
     return null;
@@ -129,14 +144,34 @@ async function initializeBashParserState(): Promise<BashParserState> {
   }
 }
 
-function extractCommandSequence(node: Node): SimpleBashCommand[] | null {
+interface BashCommandExtractContext {
+  inheritedRedirects: BashCommandRedirect[];
+  stdinFromPipe: boolean;
+  stdoutToPipe: boolean;
+}
+
+function extractCommandSequence(
+  node: Node,
+  context: BashCommandExtractContext,
+): BashCommandSegment[] | null {
   switch (node.type) {
     case "program":
-    case "list":
+    case "list": {
+      return extractFlatCommandSequence(node.namedChildren, context);
+    }
     case "pipeline": {
-      const commands: SimpleBashCommand[] = [];
-      for (const child of node.namedChildren) {
-        const extracted = extractCommandSequence(child);
+      const commands: BashCommandSegment[] = [];
+      const children = node.namedChildren;
+      for (let index = 0; index < children.length; index += 1) {
+        const child = children[index];
+        if (child == null) {
+          return null;
+        }
+        const extracted = extractCommandSequence(child, {
+          ...context,
+          stdinFromPipe: context.stdinFromPipe || index > 0,
+          stdoutToPipe: context.stdoutToPipe || index < children.length - 1,
+        });
         if (extracted == null) {
           return null;
         }
@@ -145,15 +180,39 @@ function extractCommandSequence(node: Node): SimpleBashCommand[] | null {
       return commands;
     }
     case "redirected_statement": {
-      return extractRedirectedStatement(node);
+      return extractRedirectedStatement(node, context);
     }
     case "command": {
       const command = extractPlainCommand(node);
-      return command == null ? null : [command];
+      return command == null
+        ? null
+        : [
+            {
+              ...command,
+              redirects: [...context.inheritedRedirects],
+              stdinFromPipe: context.stdinFromPipe,
+              stdoutToPipe: context.stdoutToPipe,
+            },
+          ];
     }
     default:
       return null;
   }
+}
+
+function extractFlatCommandSequence(
+  nodes: readonly Node[],
+  context: BashCommandExtractContext,
+): BashCommandSegment[] | null {
+  const commands: BashCommandSegment[] = [];
+  for (const child of nodes) {
+    const extracted = extractCommandSequence(child, context);
+    if (extracted == null) {
+      return null;
+    }
+    commands.push(...extracted);
+  }
+  return commands;
 }
 
 function extractPlainCommand(node: Node): SimpleBashCommand | null {
@@ -197,24 +256,33 @@ function extractPlainCommand(node: Node): SimpleBashCommand | null {
   };
 }
 
-function extractRedirectedStatement(node: Node): SimpleBashCommand[] | null {
+function extractRedirectedStatement(
+  node: Node,
+  context: BashCommandExtractContext,
+): BashCommandSegment[] | null {
   const body = node.childForFieldName("body");
   if (body == null) {
     return null;
   }
 
-  const redirects = node.childrenForFieldName("redirect");
+  const redirects = node.namedChildren.filter((child) => child.type === "file_redirect");
   if (redirects.length === 0) {
     return null;
   }
 
+  const parsedRedirects: BashCommandRedirect[] = [];
   for (const redirect of redirects) {
-    if (!isSupportedOutputRedirect(redirect)) {
+    const parsedRedirect = extractSupportedOutputRedirect(redirect);
+    if (parsedRedirect == null) {
       return null;
     }
+    parsedRedirects.push(parsedRedirect);
   }
 
-  return extractCommandSequence(body);
+  return extractCommandSequence(body, {
+    ...context,
+    inheritedRedirects: [...context.inheritedRedirects, ...parsedRedirects],
+  });
 }
 
 function extractVariableAssignment(node: Node): string | null {
@@ -284,14 +352,14 @@ function extractStringLiteral(node: Node): string | null {
   return node.namedChildren.map((child) => child.text).join("");
 }
 
-function isSupportedOutputRedirect(node: Node): boolean {
+function extractSupportedOutputRedirect(node: Node): BashCommandRedirect | null {
   if (node.type !== "file_redirect") {
-    return false;
+    return null;
   }
 
   const operator = readRedirectOperator(node);
   if (operator == null) {
-    return false;
+    return null;
   }
 
   switch (operator) {
@@ -299,12 +367,14 @@ function isSupportedOutputRedirect(node: Node): boolean {
     case ">>":
     case ">|":
     case "&>":
-    case "&>>":
-      return hasLiteralRedirectDestination(node);
+    case "&>>": {
+      const destination = readLiteralRedirectDestination(node);
+      return destination == null ? null : { operator, destination };
+    }
     case ">&":
-      return isFileDescriptorDuplication(node);
+      return readFileDescriptorDuplicationDestination(node, operator);
     default:
-      return false;
+      return null;
   }
 }
 
@@ -321,22 +391,41 @@ function readRedirectOperator(node: Node): string | null {
   return null;
 }
 
-function hasLiteralRedirectDestination(node: Node): boolean {
-  const destination = node.childrenForFieldName("destination");
+function readLiteralRedirectDestination(node: Node): string | null {
+  const destination = readRedirectDestinationNodes(node);
   if (destination.length === 0) {
-    return false;
+    return null;
   }
 
-  return destination.every((entry) => extractLiteralWord(entry) != null);
+  const literalDestinations = destination.map((entry) => extractLiteralWord(entry));
+  if (literalDestinations.some((entry) => entry == null)) {
+    return null;
+  }
+
+  return literalDestinations.join(" ");
 }
 
-function isFileDescriptorDuplication(node: Node): boolean {
-  const destination = node.childrenForFieldName("destination");
+function readFileDescriptorDuplicationDestination(
+  node: Node,
+  operator: string,
+): BashCommandRedirect | null {
+  const destination = readRedirectDestinationNodes(node);
   if (destination.length !== 1) {
-    return false;
+    return null;
   }
 
-  return destination[0]?.type === "number";
+  const [entry] = destination;
+  return entry?.type === "number" ? { operator, destination: entry.text } : null;
+}
+
+function readRedirectDestinationNodes(node: Node): Node[] {
+  const destination = node.childrenForFieldName("destination");
+  if (destination.length > 0) {
+    return destination;
+  }
+
+  const lastNamedChild = node.namedChildren.at(-1);
+  return lastNamedChild == null ? [] : [lastNamedChild];
 }
 
 function containsUnsupportedExpansion(node: Node): boolean {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -1,6 +1,8 @@
 import { type Static, Type } from "@sinclair/typebox";
 
+import { classifyBashApprovalHelper } from "@/src/security/bash-approval-helpers.js";
 import {
+  type BashCommandSegment,
   bashPrefixMatchesCommand,
   normalizeBashCommandPrefix,
   type ParsedBashCommandSequence,
@@ -230,16 +232,15 @@ async function executeBashWithFullAccessIfAllowed(input: {
   }
 
   if (input.parsedCommandSequence != null) {
-    const hasFullAccess = input.parsedCommandSequence.commands.every((command) => {
-      const access = input.security.checkBashFullAccess({
+    const segmentApprovals = input.parsedCommandSequence.commands.map((command) =>
+      classifyBashFullAccessSegment({
+        context: input.context,
         ownerAgentId,
-        commandPrefix: command.argv,
-        ...(input.context.approvalState?.ephemeralPermissionScopes == null
-          ? {}
-          : { ephemeralScopes: input.context.approvalState.ephemeralPermissionScopes }),
-      });
-      return access.result === "allow";
-    });
+        security: input.security,
+        command,
+      }),
+    );
+    const hasFullAccess = segmentApprovals.every((approval) => approval !== "denied");
     if (hasFullAccess) {
       return await executeUnsandboxedBash({
         context: input.context,
@@ -275,6 +276,40 @@ async function executeBashWithFullAccessIfAllowed(input: {
         }
       : {}),
   });
+}
+
+type BashFullAccessSegmentApproval =
+  | "approved"
+  | "standalone_helper"
+  | "pipeline_helper"
+  | "denied";
+
+function classifyBashFullAccessSegment(input: {
+  context: ToolExecutionContext;
+  ownerAgentId: string;
+  security: SecurityService;
+  command: BashCommandSegment;
+}): BashFullAccessSegmentApproval {
+  const access = input.security.checkBashFullAccess({
+    ownerAgentId: input.ownerAgentId,
+    commandPrefix: input.command.argv,
+    ...(input.context.approvalState?.ephemeralPermissionScopes == null
+      ? {}
+      : { ephemeralScopes: input.context.approvalState.ephemeralPermissionScopes }),
+  });
+  if (access.result === "allow") {
+    return "approved";
+  }
+
+  const helperKind = classifyBashApprovalHelper(input.command);
+  if (helperKind === "standalone") {
+    return "standalone_helper";
+  }
+  if (helperKind === "pipeline") {
+    return "pipeline_helper";
+  }
+
+  return "denied";
 }
 
 function detectUnsupportedBackgroundSyntax(command: string): string | null {

--- a/tests/security/bash-approval-helpers.test.ts
+++ b/tests/security/bash-approval-helpers.test.ts
@@ -7,6 +7,25 @@ import {
 } from "@/src/security/bash-prefix.js";
 
 describe("classifyBashApprovalHelper", () => {
+  test("allows echo helpers only for literal output markers", () => {
+    for (const command of ["echo", "echo foo", "echo '--- status ---'", "echo ==== done ===="]) {
+      expect(classifyOnlySegment(command)).toBe("standalone");
+    }
+  });
+
+  test("rejects echo helpers with shell-expanded argument shapes", () => {
+    for (const command of [
+      "echo *",
+      "echo file?.txt",
+      "echo [abc]",
+      "echo ~",
+      "echo ~/workspace",
+      "echo {a,b}",
+    ]) {
+      expect(classifyOnlySegment(command)).toBeNull();
+    }
+  });
+
   test("allows jq stdin selectors that preserve the common JSON inspection workflow", () => {
     for (const command of [
       "near view contract method '{}' | jq .result",
@@ -56,6 +75,19 @@ describe("classifyBashApprovalHelper", () => {
 
 function classifyLastSegment(command: string) {
   return classifyBashApprovalHelper(lastSegment(command));
+}
+
+function classifyOnlySegment(command: string) {
+  const sequence = parseConservativeBashCommandSequence(command);
+  if (sequence == null) {
+    return null;
+  }
+
+  const segment = sequence?.commands[0];
+  if (sequence.commands.length !== 1 || segment == null) {
+    throw new Error(`Expected exactly one parsed command: ${command}`);
+  }
+  return classifyBashApprovalHelper(segment);
 }
 
 function lastSegment(command: string): BashCommandSegment {

--- a/tests/security/bash-approval-helpers.test.ts
+++ b/tests/security/bash-approval-helpers.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "vitest";
+
+import { classifyBashApprovalHelper } from "@/src/security/bash-approval-helpers.js";
+import {
+  type BashCommandSegment,
+  parseConservativeBashCommandSequence,
+} from "@/src/security/bash-prefix.js";
+
+describe("classifyBashApprovalHelper", () => {
+  test("allows jq stdin selectors that preserve the common JSON inspection workflow", () => {
+    for (const command of [
+      "near view contract method '{}' | jq .result",
+      "near view contract method '{}' | jq -r .result",
+      "near view contract method '{}' | jq '.result[]'",
+      "near view contract method '{}' | jq '.result.items[0].name'",
+      "near view contract method '{}' | jq '.[\"result-key\"]'",
+      "near view contract method '{}' | jq '.result.items[:10]'",
+      "near view contract method '{}' | jq '.result.items[-3:]'",
+      "near view contract method '{}' | jq '.optional?[]? | .name?'",
+      "near view contract method '{}' | jq '.result[] | .name'",
+      "near view contract method '{}' | jq '.[] | .id'",
+    ]) {
+      expect(classifyLastSegment(command)).toBe("pipeline");
+    }
+  });
+
+  test("rejects jq filters with host-readable or general program capability", () => {
+    for (const command of [
+      "git pull | jq 'env.TEST_JQ_SECRET'",
+      "git pull | jq '$ENV'",
+      "git pull | jq 'import \"secrets\" as $s; .'",
+      "git pull | jq 'include \"secrets\"; .'",
+      "git pull | jq 'map(select(.x == 1))'",
+      "git pull | jq '.result | select(.enabled)'",
+      "git pull | jq '.result | length'",
+      "git pull | jq '.result, .other'",
+      "git pull | jq '.items[:]'",
+    ]) {
+      expect(classifyLastSegment(command)).toBeNull();
+    }
+  });
+
+  test("allows quiet head and tail helpers that still only consume stdin", () => {
+    for (const command of [
+      "git log --oneline | tail -q -n 5",
+      "git log --oneline | tail --quiet -n 5",
+      "git log --oneline | tail --silent -n 5",
+      "git log --oneline | tail -qn 5",
+      "git log --oneline | tail -q5",
+      "git log --oneline | head --quiet -n 5",
+    ]) {
+      expect(classifyLastSegment(command)).toBe("pipeline");
+    }
+  });
+});
+
+function classifyLastSegment(command: string) {
+  return classifyBashApprovalHelper(lastSegment(command));
+}
+
+function lastSegment(command: string): BashCommandSegment {
+  const sequence = parseConservativeBashCommandSequence(command);
+  const segment = sequence?.commands.at(-1);
+  if (segment == null) {
+    throw new Error(`Expected command to parse: ${command}`);
+  }
+  return segment;
+}

--- a/tests/security/bash-approval-helpers.test.ts
+++ b/tests/security/bash-approval-helpers.test.ts
@@ -20,6 +20,8 @@ describe("classifyBashApprovalHelper", () => {
       "echo [abc]",
       "echo ~",
       "echo ~/workspace",
+      "echo HOME=~",
+      "echo X=~root",
       "echo {a,b}",
     ]) {
       expect(classifyOnlySegment(command)).toBeNull();

--- a/tests/security/bash-approval-helpers.test.ts
+++ b/tests/security/bash-approval-helpers.test.ts
@@ -8,7 +8,14 @@ import {
 
 describe("classifyBashApprovalHelper", () => {
   test("allows echo helpers only for literal output markers", () => {
-    for (const command of ["echo", "echo foo", "echo '--- status ---'", "echo ==== done ===="]) {
+    for (const command of [
+      "echo",
+      "echo foo",
+      "echo '--- status ---'",
+      "echo ==== done ====",
+      "echo plain:~root",
+      "echo A-B=~",
+    ]) {
       expect(classifyOnlySegment(command)).toBe("standalone");
     }
   });
@@ -22,6 +29,11 @@ describe("classifyBashApprovalHelper", () => {
       "echo ~/workspace",
       "echo HOME=~",
       "echo X=~root",
+      "echo PATH=a:~",
+      "echo PATH=a:~root",
+      "echo foo@(bar)",
+      "echo foo!(bar)",
+      "echo foo+(bar)",
       "echo {a,b}",
     ]) {
       expect(classifyOnlySegment(command)).toBeNull();
@@ -56,8 +68,23 @@ describe("classifyBashApprovalHelper", () => {
       "git pull | jq '.result | length'",
       "git pull | jq '.result, .other'",
       "git pull | jq '.items[:]'",
+      "git pull | jq --arg home ~ .result",
+      "git pull | jq --arg key value .result",
+      "git pull | jq --argjson key 1 .result",
+      "git pull | jq --indent ~ .result",
+      "git pull | jq --indent 8 .result",
     ]) {
       expect(classifyLastSegment(command)).toBeNull();
+    }
+  });
+
+  test("allows jq formatting options that cannot read host context", () => {
+    for (const command of [
+      "near view contract method '{}' | jq --indent 0 .result",
+      "near view contract method '{}' | jq --indent 2 .result",
+      "near view contract method '{}' | jq --indent 7 .result",
+    ]) {
+      expect(classifyLastSegment(command)).toBe("pipeline");
     }
   });
 

--- a/tests/security/bash-command-parser.test.ts
+++ b/tests/security/bash-command-parser.test.ts
@@ -14,6 +14,9 @@ describe("parseConservativeBashCommandSequence", () => {
         {
           envAssignments: ["FOO=1", "BAR=two"],
           argv: ["python", "-m", "agent_browser_cli", "--url", "https://example.com"],
+          redirects: [],
+          stdinFromPipe: false,
+          stdoutToPipe: false,
         },
       ],
     });
@@ -30,6 +33,9 @@ describe("parseConservativeBashCommandSequence", () => {
         {
           envAssignments: [],
           argv: ["python", "-m", "agent_browser_cli", "--url", "https://example.com"],
+          redirects: [],
+          stdinFromPipe: false,
+          stdoutToPipe: false,
         },
       ],
     });
@@ -42,20 +48,29 @@ describe("parseConservativeBashCommandSequence", () => {
         {
           envAssignments: [],
           argv: ["npm", "test"],
+          redirects: [],
+          stdinFromPipe: false,
+          stdoutToPipe: false,
         },
         {
           envAssignments: [],
           argv: ["echo", "done"],
+          redirects: [],
+          stdinFromPipe: false,
+          stdoutToPipe: true,
         },
         {
           envAssignments: [],
           argv: ["cat"],
+          redirects: [],
+          stdinFromPipe: true,
+          stdoutToPipe: false,
         },
       ],
     });
   });
 
-  test("accepts supported output redirections without changing argv extraction", () => {
+  test("accepts supported output redirections and preserves redirect metadata", () => {
     expect(
       parseConservativeBashCommandSequence(
         "agent-browser snapshot -s main > /tmp/browser.txt 2>&1",
@@ -66,6 +81,80 @@ describe("parseConservativeBashCommandSequence", () => {
         {
           envAssignments: [],
           argv: ["agent-browser", "snapshot", "-s", "main"],
+          redirects: [
+            { operator: ">", destination: "/tmp/browser.txt" },
+            { operator: ">&", destination: "1" },
+          ],
+          stdinFromPipe: false,
+          stdoutToPipe: false,
+        },
+      ],
+    });
+  });
+
+  test("preserves pipe and redirection metadata for approval checks", () => {
+    expect(parseConservativeBashCommandSequence("git pull | tail -n 5")).toEqual({
+      kind: "compound",
+      commands: [
+        {
+          envAssignments: [],
+          argv: ["git", "pull"],
+          redirects: [],
+          stdinFromPipe: false,
+          stdoutToPipe: true,
+        },
+        {
+          envAssignments: [],
+          argv: ["tail", "-n", "5"],
+          redirects: [],
+          stdinFromPipe: true,
+          stdoutToPipe: false,
+        },
+      ],
+    });
+
+    expect(parseConservativeBashCommandSequence("echo '---' > /tmp/marker")).toEqual({
+      kind: "simple",
+      commands: [
+        {
+          envAssignments: [],
+          argv: ["echo", "---"],
+          redirects: [{ operator: ">", destination: "/tmp/marker" }],
+          stdinFromPipe: false,
+          stdoutToPipe: false,
+        },
+      ],
+    });
+  });
+
+  test("conservatively attaches statement redirection to every command in a redirected list", () => {
+    expect(
+      parseConservativeBashCommandSequence(
+        "git status && echo '---' > /tmp/marker && git diff --stat",
+      ),
+    ).toEqual({
+      kind: "compound",
+      commands: [
+        {
+          envAssignments: [],
+          argv: ["git", "status"],
+          redirects: [{ operator: ">", destination: "/tmp/marker" }],
+          stdinFromPipe: false,
+          stdoutToPipe: false,
+        },
+        {
+          envAssignments: [],
+          argv: ["echo", "---"],
+          redirects: [{ operator: ">", destination: "/tmp/marker" }],
+          stdinFromPipe: false,
+          stdoutToPipe: false,
+        },
+        {
+          envAssignments: [],
+          argv: ["git", "diff", "--stat"],
+          redirects: [],
+          stdinFromPipe: false,
+          stdoutToPipe: false,
         },
       ],
     });

--- a/tests/security/bash-prefix.test.ts
+++ b/tests/security/bash-prefix.test.ts
@@ -15,6 +15,9 @@ describe("bash prefix normalization", () => {
     expect(parseSimpleBashCommand("FOO=1 BAR=2 npm run dev")).toEqual({
       envAssignments: ["FOO=1", "BAR=2"],
       argv: ["npm", "run", "dev"],
+      redirects: [],
+      stdinFromPipe: false,
+      stdoutToPipe: false,
     });
   });
 

--- a/tests/tools/bash.test.ts
+++ b/tests/tools/bash.test.ts
@@ -1043,6 +1043,9 @@ Use this exact bash argument object on the next retry if full access is warrante
       "git pull && echo '---' > /tmp/marker",
       "git pull && echo $TOKEN",
       'git pull && echo "$(cat ~/.ssh/id_rsa)"',
+      "git pull && echo *",
+      "git pull && echo ~",
+      "git pull && echo {a,b}",
     ]) {
       await expect(
         registry.execute("bash", context, {

--- a/tests/tools/bash.test.ts
+++ b/tests/tools/bash.test.ts
@@ -1038,6 +1038,8 @@ Use this exact bash argument object on the next retry if full access is warrante
       "git pull | jq 'env.TEST_JQ_SECRET'",
       "git pull | jq 'import \"secrets\" as $s; .'",
       "git pull | jq 'include \"secrets\"; .'",
+      "git pull | jq --arg home ~ .result",
+      "git pull | jq --indent ~ .result",
       "git pull | tee out.txt",
       "git pull | xargs rm",
       "git pull && echo '---' > /tmp/marker",
@@ -1046,6 +1048,8 @@ Use this exact bash argument object on the next retry if full access is warrante
       "git pull && echo *",
       "git pull && echo ~",
       "git pull && echo HOME=~",
+      "git pull && echo PATH=a:~",
+      "git pull && echo foo@(bar)",
       "git pull && echo {a,b}",
     ]) {
       await expect(

--- a/tests/tools/bash.test.ts
+++ b/tests/tools/bash.test.ts
@@ -6,6 +6,7 @@ const { executeSandboxedBashMock, executeUnsandboxedBashMock } = vi.hoisted(() =
 }));
 
 import { DEFAULT_CONFIG } from "@/src/config/defaults.js";
+import type { ExecuteUnsandboxedBashInput } from "@/src/security/sandbox.js";
 import { SecurityService } from "@/src/security/service.js";
 import { createBashTool } from "@/src/tools/bash.js";
 import { type ToolFailure, toolRecoverableError } from "@/src/tools/core/errors.js";
@@ -816,7 +817,7 @@ Use this exact bash argument object on the next retry if full access is warrante
     expect(executeUnsandboxedBashMock).not.toHaveBeenCalled();
   });
 
-  test("still requests approval for a git compound workflow when it includes an ungranted echo command", async () => {
+  test("allows a literal echo separator inside an otherwise approved compound workflow", async () => {
     handle = await createTestDatabase(import.meta.url);
     seedConversationAndAgentFixture(handle);
     new SecurityService(handle.storage.db).grantScopes({
@@ -824,9 +825,250 @@ Use this exact bash argument object on the next retry if full access is warrante
       grantedBy: "user",
       scopes: [{ kind: "bash.full_access", prefix: ["git"] }],
     });
+    executeUnsandboxedBashMock.mockResolvedValue({
+      command:
+        "git fetch --prune origin && git checkout main && git pull --ff-only origin main && git status --short && echo '---' && git branch -vv",
+      cwd: "/tmp/work",
+      timeoutMs: 10_000,
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    });
 
     const registry = new ToolRegistry([createBashTool()]);
+    const result = await registry.execute(
+      "bash",
+      {
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        ownerAgentId: "agent_1",
+        cwd: "/tmp/work",
+        securityConfig: DEFAULT_CONFIG.security,
+        storage: handle.storage.db,
+      },
+      {
+        command:
+          "git fetch --prune origin && git checkout main && git pull --ff-only origin main && git status --short && echo '---' && git branch -vv",
+        sandboxMode: "full_access",
+        justification:
+          "Need to sync the branch, inspect status, and print a separator before branch output.",
+      },
+    );
 
+    expect(executeUnsandboxedBashMock).toHaveBeenCalledTimes(1);
+    expect(executeSandboxedBashMock).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({
+      command:
+        "git fetch --prune origin && git checkout main && git pull --ff-only origin main && git status --short && echo '---' && git branch -vv",
+      cwd: "/tmp/work",
+      exitCode: 0,
+    });
+  });
+
+  test("allows stdin-only output helpers after an approved full-access command", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+    new SecurityService(handle.storage.db).grantScopes({
+      ownerAgentId: "agent_1",
+      grantedBy: "user",
+      scopes: [{ kind: "bash.full_access", prefix: ["git", "pull"] }],
+    });
+    executeUnsandboxedBashMock.mockResolvedValue({
+      command: "git pull | tail -n 5 | wc -l",
+      cwd: "/tmp/work",
+      timeoutMs: 10_000,
+      stdout: "5\n",
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    });
+
+    const registry = new ToolRegistry([createBashTool()]);
+    const result = await registry.execute(
+      "bash",
+      {
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        ownerAgentId: "agent_1",
+        cwd: "/tmp/work",
+        securityConfig: DEFAULT_CONFIG.security,
+        storage: handle.storage.db,
+      },
+      {
+        command: "git pull | tail -n 5 | wc -l",
+        sandboxMode: "full_access",
+        justification: "Need to update the branch and inspect the summarized output.",
+      },
+    );
+
+    expect(executeUnsandboxedBashMock).toHaveBeenCalledTimes(1);
+    expect(executeSandboxedBashMock).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({
+      command: "git pull | tail -n 5 | wc -l",
+      cwd: "/tmp/work",
+      exitCode: 0,
+    });
+  });
+
+  test("allows jq stdin filtering after an approved full-access command", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+    new SecurityService(handle.storage.db).grantScopes({
+      ownerAgentId: "agent_1",
+      grantedBy: "user",
+      scopes: [{ kind: "bash.full_access", prefix: ["near", "view"] }],
+    });
+    executeUnsandboxedBashMock.mockResolvedValue({
+      command: "near view contract method '{}' | jq -r .result",
+      cwd: "/tmp/work",
+      timeoutMs: 10_000,
+      stdout: "ok\n",
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    });
+
+    const registry = new ToolRegistry([createBashTool()]);
+    const result = await registry.execute(
+      "bash",
+      {
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        ownerAgentId: "agent_1",
+        cwd: "/tmp/work",
+        securityConfig: DEFAULT_CONFIG.security,
+        storage: handle.storage.db,
+      },
+      {
+        command: "near view contract method '{}' | jq -r .result",
+        sandboxMode: "full_access",
+        justification: "Need to query the contract and extract the result field.",
+      },
+    );
+
+    expect(executeUnsandboxedBashMock).toHaveBeenCalledTimes(1);
+    expect(executeSandboxedBashMock).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({
+      command: "near view contract method '{}' | jq -r .result",
+      cwd: "/tmp/work",
+      exitCode: 0,
+    });
+  });
+
+  test("allows mixed approved commands and output helpers in realistic chained workflows", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+    new SecurityService(handle.storage.db).grantScopes({
+      ownerAgentId: "agent_1",
+      grantedBy: "user",
+      scopes: [
+        { kind: "bash.full_access", prefix: ["git"] },
+        { kind: "bash.full_access", prefix: ["near", "view"] },
+      ],
+    });
+    executeUnsandboxedBashMock.mockImplementation(async (input: ExecuteUnsandboxedBashInput) => ({
+      command: input.command,
+      cwd: input.cwd ?? input.context.cwd ?? "/tmp/work",
+      timeoutMs: input.timeoutMs,
+      stdout: "ok\n",
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    }));
+
+    const registry = new ToolRegistry([createBashTool()]);
+    const context = {
+      sessionId: "sess_1",
+      conversationId: "conv_1",
+      ownerAgentId: "agent_1",
+      cwd: "/tmp/work",
+      securityConfig: DEFAULT_CONFIG.security,
+      storage: handle.storage.db,
+    };
+
+    for (const command of [
+      "git log --oneline -50 | head -n 5 && echo '--- status ---' && git status --short",
+      "git diff --stat | tail -n 20 && echo '--- branches ---' && git branch -vv | head -n 10",
+      "near view contract method '{}' | jq -r .result | head -n 20 && echo '--- repo ---' && git status --short",
+      "git status --short && echo '--- recent ---' && git log --oneline -20 | tail -n 5 | wc -l",
+    ]) {
+      const result = await registry.execute("bash", context, {
+        command,
+        sandboxMode: "full_access",
+        justification: "Need to run the approved workflow and format the output.",
+      });
+      expect(result.details).toMatchObject({
+        command,
+        cwd: "/tmp/work",
+        exitCode: 0,
+      });
+    }
+
+    expect(executeUnsandboxedBashMock).toHaveBeenCalledTimes(4);
+    expect(executeSandboxedBashMock).not.toHaveBeenCalled();
+  });
+
+  test("still requests approval when helper-shaped commands introduce file or execution capability", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+    new SecurityService(handle.storage.db).grantScopes({
+      ownerAgentId: "agent_1",
+      grantedBy: "user",
+      scopes: [{ kind: "bash.full_access", prefix: ["git", "pull"] }],
+    });
+
+    const registry = new ToolRegistry([createBashTool()]);
+    const context = {
+      sessionId: "sess_1",
+      conversationId: "conv_1",
+      ownerAgentId: "agent_1",
+      cwd: "/tmp/work",
+      securityConfig: DEFAULT_CONFIG.security,
+      storage: handle.storage.db,
+    };
+
+    for (const command of [
+      "git pull | tail ~/.ssh/id_rsa",
+      "git pull | tail -f",
+      "git pull | head file.txt",
+      "git pull | jq --rawfile k ~/.ssh/id_rsa .",
+      "git pull | jq . file.json",
+      "git pull | tee out.txt",
+      "git pull | xargs rm",
+      "git pull && echo '---' > /tmp/marker",
+      "git pull && echo $TOKEN",
+      'git pull && echo "$(cat ~/.ssh/id_rsa)"',
+    ]) {
+      await expect(
+        registry.execute("bash", context, {
+          command,
+          sandboxMode: "full_access",
+          justification: "Need to run the requested compound workflow.",
+        }),
+      ).rejects.toMatchObject({
+        name: "ToolApprovalRequired",
+        grantOnApprove: false,
+        approvalTitle: "Approval required: run bash command with full access",
+        request: {
+          scopes: [{ kind: "bash.full_access", prefix: ["bash", "-lc"] }],
+        },
+      });
+    }
+
+    expect(executeUnsandboxedBashMock).not.toHaveBeenCalled();
+  });
+
+  test("still requests approval when an unapproved command remains after helper allowance", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+    new SecurityService(handle.storage.db).grantScopes({
+      ownerAgentId: "agent_1",
+      grantedBy: "user",
+      scopes: [{ kind: "bash.full_access", prefix: ["git", "fetch"] }],
+    });
+
+    const registry = new ToolRegistry([createBashTool()]);
     await expect(
       registry.execute(
         "bash",
@@ -839,11 +1081,9 @@ Use this exact bash argument object on the next retry if full access is warrante
           storage: handle.storage.db,
         },
         {
-          command:
-            "git fetch --prune origin && git checkout main && git pull --ff-only origin main && git status --short && echo '---' && git branch -vv",
+          command: "git fetch --prune origin && echo '---' && git status --short",
           sandboxMode: "full_access",
-          justification:
-            "Need to sync the branch, inspect status, and print a separator before branch output.",
+          justification: "Need to fetch and inspect the repository state.",
         },
       ),
     ).rejects.toMatchObject({
@@ -854,6 +1094,85 @@ Use this exact bash argument object on the next retry if full access is warrante
         scopes: [{ kind: "bash.full_access", prefix: ["bash", "-lc"] }],
       },
     });
+
+    expect(executeUnsandboxedBashMock).not.toHaveBeenCalled();
+  });
+
+  test("allows standalone literal echo helpers without an existing prefix grant", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+    executeUnsandboxedBashMock.mockImplementation(async (input: ExecuteUnsandboxedBashInput) => ({
+      command: input.command,
+      cwd: input.cwd ?? input.context.cwd ?? "/tmp/work",
+      timeoutMs: input.timeoutMs,
+      stdout: "ok\n",
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    }));
+
+    const registry = new ToolRegistry([createBashTool()]);
+    const context = {
+      sessionId: "sess_1",
+      conversationId: "conv_1",
+      ownerAgentId: "agent_1",
+      cwd: "/tmp/work",
+      securityConfig: DEFAULT_CONFIG.security,
+      storage: handle.storage.db,
+    };
+
+    for (const command of ["echo '---'", "echo foo && echo bar", "echo foo | tail -n 1"]) {
+      const result = await registry.execute("bash", context, {
+        command,
+        sandboxMode: "full_access",
+        justification: "Need to print literal output markers.",
+      });
+      expect(result.details).toMatchObject({
+        command,
+        cwd: "/tmp/work",
+        exitCode: 0,
+      });
+    }
+
+    expect(executeUnsandboxedBashMock).toHaveBeenCalledTimes(3);
+    expect(executeSandboxedBashMock).not.toHaveBeenCalled();
+  });
+
+  test("does not allow stdin-only helpers by name without a pipeline input", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+
+    const registry = new ToolRegistry([createBashTool()]);
+    const context = {
+      sessionId: "sess_1",
+      conversationId: "conv_1",
+      ownerAgentId: "agent_1",
+      cwd: "/tmp/work",
+      securityConfig: DEFAULT_CONFIG.security,
+      storage: handle.storage.db,
+    };
+
+    for (const [command, prefix] of [
+      ["jq .result", ["jq", ".result"]],
+      ["tail -n 5", ["tail", "-n", "5"]],
+      ["head -n 5", ["head", "-n", "5"]],
+      ["wc -l", ["wc", "-l"]],
+    ] as const) {
+      await expect(
+        registry.execute("bash", context, {
+          command,
+          sandboxMode: "full_access",
+          justification: "Need to run the requested helper command.",
+        }),
+      ).rejects.toMatchObject({
+        name: "ToolApprovalRequired",
+        grantOnApprove: false,
+        approvalTitle: "Approval required: run bash command with full access",
+        request: {
+          scopes: [{ kind: "bash.full_access", prefix }],
+        },
+      });
+    }
 
     expect(executeUnsandboxedBashMock).not.toHaveBeenCalled();
   });

--- a/tests/tools/bash.test.ts
+++ b/tests/tools/bash.test.ts
@@ -1045,6 +1045,7 @@ Use this exact bash argument object on the next retry if full access is warrante
       'git pull && echo "$(cat ~/.ssh/id_rsa)"',
       "git pull && echo *",
       "git pull && echo ~",
+      "git pull && echo HOME=~",
       "git pull && echo {a,b}",
     ]) {
       await expect(

--- a/tests/tools/bash.test.ts
+++ b/tests/tools/bash.test.ts
@@ -988,9 +988,10 @@ Use this exact bash argument object on the next retry if full access is warrante
     };
 
     for (const command of [
-      "git log --oneline -50 | head -n 5 && echo '--- status ---' && git status --short",
-      "git diff --stat | tail -n 20 && echo '--- branches ---' && git branch -vv | head -n 10",
+      "git log --oneline -50 | head --quiet -n 5 && echo '--- status ---' && git status --short",
+      "git diff --stat | tail -q -n 20 && echo '--- branches ---' && git branch -vv | head -n 10",
       "near view contract method '{}' | jq -r .result | head -n 20 && echo '--- repo ---' && git status --short",
+      "near view contract method '{}' | jq '.result[] | .name' | head -n 20",
       "git status --short && echo '--- recent ---' && git log --oneline -20 | tail -n 5 | wc -l",
     ]) {
       const result = await registry.execute("bash", context, {
@@ -1005,7 +1006,7 @@ Use this exact bash argument object on the next retry if full access is warrante
       });
     }
 
-    expect(executeUnsandboxedBashMock).toHaveBeenCalledTimes(4);
+    expect(executeUnsandboxedBashMock).toHaveBeenCalledTimes(5);
     expect(executeSandboxedBashMock).not.toHaveBeenCalled();
   });
 
@@ -1034,6 +1035,9 @@ Use this exact bash argument object on the next retry if full access is warrante
       "git pull | head file.txt",
       "git pull | jq --rawfile k ~/.ssh/id_rsa .",
       "git pull | jq . file.json",
+      "git pull | jq 'env.TEST_JQ_SECRET'",
+      "git pull | jq 'import \"secrets\" as $s; .'",
+      "git pull | jq 'include \"secrets\"; .'",
       "git pull | tee out.txt",
       "git pull | xargs rm",
       "git pull && echo '---' > /tmp/marker",


### PR DESCRIPTION
Linear: POK-29

## Summary
- Upgrade the conservative bash command sequence parser so each segment keeps pipe and redirection metadata.
- Add a focused bash approval helper classifier for literal `echo` and stdin-only output helpers (`head`, `tail`, `wc`, `jq`).
- Reuse existing `full_access` prefix grants for compound bash commands when every other segment is a safe helper segment.
- Address review feedback by restricting `jq` helper mode to a selector-only subset instead of arbitrary jq programs.
- Address review feedback by keeping `echo` helper mode literal-only and rejecting shell-expanded argument shapes, including tilde, glob, brace, extglob, and assignment-style tilde expansion.
- Audit the other helper option surfaces in the same pass: `head` / `tail` / `wc` accept only fixed flags or numeric values; `jq` rejects variable/file-like option surfaces and validates `--indent` as a numeric formatting option.

## Expected behavior after this change
Allowed without additional approval:
- Existing approved prefix segments still pass, e.g. `git pull` when the matching `git` prefix has already been approved.
- Literal stdout markers can run alone or inside chains:
  - `echo`
  - `echo foo`
  - `echo '---'`
  - `echo ==== done ====`
  - `echo plain:~root` (not an assignment-style tilde expansion)
- Approved commands can be combined with literal echo separators:
  - `git status --short && echo '--- diff ---' && git diff --stat` when `git` is granted.
- Stdin-only output helpers are allowed only when consuming pipeline input:
  - `git pull | tail -n 5`
  - `git pull | tail -q -n 5`
  - `git pull | tail -n 5 | wc -l`
  - `git log --oneline -20 | head -n 5`
  - `git log --oneline -20 | head --quiet -n 5`
- `jq` helper mode is allowed for selector-only JSON inspection and safe formatting options:
  - `near view contract method '{}' | jq .result`
  - `near view contract method '{}' | jq -r .result`
  - `near view contract method '{}' | jq '.result[]'`
  - `near view contract method '{}' | jq '.result[] | .name'`
  - `near view contract method '{}' | jq '.["result-key"]'`
  - `near view contract method '{}' | jq '.result.items[:10]'`
  - `near view contract method '{}' | jq --indent 2 .result`

Still requires approval:
- Stdin-oriented helpers without pipeline input:
  - `jq .result`
  - `tail -n 5`
  - `head -n 5`
  - `wc -l`
- File-reading or execution-capable shapes:
  - `tail ~/.ssh/id_rsa`
  - `head file.txt`
  - `jq --rawfile k ~/.ssh/id_rsa .`
  - `jq . file.json`
  - `tee out.txt`
  - `xargs rm`
- jq filters or options that use host-readable, variable, file, or general jq program capability:
  - `jq 'env.TOKEN'`
  - `jq '$ENV'`
  - `jq 'import "secrets" as $s; .'`
  - `jq 'include "secrets"; .'`
  - `jq 'map(select(.x == 1))'`
  - `jq '.result | length'`
  - `jq --arg home ~ .result`
  - `jq --arg key value .result`
  - `jq --argjson key 1 .result`
  - `jq --indent ~ .result`
- Literal helpers with shell expansion or redirection:
  - `echo $TOKEN`
  - `echo "$(cat ~/.ssh/id_rsa)"`
  - `echo *`
  - `echo ~`
  - `echo HOME=~`
  - `echo PATH=a:~`
  - `echo foo@(bar)`
  - `echo {a,b}`
  - `echo '---' > /tmp/marker`

## Reviewer notes
- This changes `full_access` approval reuse only. Sandboxed bash execution behavior is unchanged.
- `parseConservativeBashCommandSequence()` is now the canonical rich parser; `normalizeBashCommandPrefix()` keeps the previous prefix-normalization surface for compatibility.
- Redirection metadata is parsed conservatively. Unsupported input-side redirection shapes still fail closed.
- `jq` remains useful for common CLI JSON inspection, but helper mode intentionally accepts selectors rather than arbitrary jq programs.
- `echo` remains useful for separators/markers, but helper mode intentionally rejects argv that bash can expand against host filesystem or user context.

## Tests
- `pnpm exec vitest run tests/security/bash-prefix.test.ts tests/security/bash-command-parser.test.ts tests/security/bash-approval-helpers.test.ts tests/tools/bash.test.ts`
- `pnpm preflight`