### PR TITLE
Fix one-shot bash approval reuse

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -1514,12 +1514,13 @@ export class AgentLoop {
           input.toolCall.args,
         );
 
+        const nextRunApprovalState = buildSubsequentToolCallApprovalState(approvalState);
         return {
           result,
           isError: false,
           queuedSteer,
           stopRemainingToolBatch: false,
-          ...(approvalState == null ? {} : { approvalState }),
+          ...(nextRunApprovalState == null ? {} : { approvalState: nextRunApprovalState }),
         };
       } catch (error) {
         if (!isToolApprovalRequired(error)) {
@@ -1605,6 +1606,7 @@ export class AgentLoop {
           decidedAt: approval.decidedAt,
         });
 
+        const nextRunApprovalState = buildSubsequentToolCallApprovalState(approvalState);
         return {
           result:
             input.toolCall.name === "request_permissions"
@@ -1642,7 +1644,7 @@ export class AgentLoop {
           isError: true,
           queuedSteer: [...queuedSteer, ...approval.queuedSteer],
           stopRemainingToolBatch: approval.actor === "user:intervention",
-          ...(approvalState == null ? {} : { approvalState }),
+          ...(nextRunApprovalState == null ? {} : { approvalState: nextRunApprovalState }),
         };
       }
     }
@@ -1672,6 +1674,7 @@ export class AgentLoop {
         toolName: input.input.toolCall.name,
         runId: input.input.runId,
       });
+      const approvalState = buildSubsequentToolCallApprovalState(input.approvalState);
       return {
         result: textToolResult(
           renderPermissionRequestResultBlock({
@@ -1686,7 +1689,7 @@ export class AgentLoop {
         isError: false,
         queuedSteer: input.queuedSteer,
         stopRemainingToolBatch: false,
-        ...(input.approvalState == null ? {} : { approvalState: input.approvalState }),
+        ...(approvalState == null ? {} : { approvalState }),
       };
     }
 
@@ -1698,6 +1701,7 @@ export class AgentLoop {
         retryToolCallId: input.retryToolCallId,
         runId: input.input.runId,
       });
+      const approvalState = buildSubsequentToolCallApprovalState(input.approvalState);
       return {
         result: textToolResult(
           `${renderPermissionRequestResultBlock({
@@ -1713,7 +1717,7 @@ export class AgentLoop {
         isError: true,
         queuedSteer: input.queuedSteer,
         stopRemainingToolBatch: false,
-        ...(input.approvalState == null ? {} : { approvalState: input.approvalState }),
+        ...(approvalState == null ? {} : { approvalState }),
       };
     }
 
@@ -1755,6 +1759,7 @@ export class AgentLoop {
         runId: input.input.runId,
       });
 
+      const approvalState = buildSubsequentToolCallApprovalState(input.approvalState);
       return {
         result: {
           content: [
@@ -1778,7 +1783,7 @@ export class AgentLoop {
         isError: false,
         queuedSteer: input.queuedSteer,
         stopRemainingToolBatch: false,
-        ...(input.approvalState == null ? {} : { approvalState: input.approvalState }),
+        ...(approvalState == null ? {} : { approvalState }),
       };
     } catch (error) {
       const failure = normalizeToolFailure(error);
@@ -1795,6 +1800,7 @@ export class AgentLoop {
         runId: input.input.runId,
       });
 
+      const approvalState = buildSubsequentToolCallApprovalState(input.approvalState);
       return {
         result: {
           content: [
@@ -1826,7 +1832,7 @@ export class AgentLoop {
         isError: true,
         queuedSteer: input.queuedSteer,
         stopRemainingToolBatch: false,
-        ...(input.approvalState == null ? {} : { approvalState: input.approvalState }),
+        ...(approvalState == null ? {} : { approvalState }),
       };
     }
   }
@@ -2259,6 +2265,23 @@ function collectAgentToolCalls(content: AgentAssistantContentBlock[]): AgentTool
         ]
       : [],
   );
+}
+
+function buildSubsequentToolCallApprovalState(
+  state: ToolExecutionApprovalState | undefined,
+): ToolExecutionApprovalState | undefined {
+  if (state == null) {
+    return undefined;
+  }
+
+  return {
+    ...(state.runtimeModeAutoApproval == null
+      ? {}
+      : { runtimeModeAutoApproval: state.runtimeModeAutoApproval }),
+    ...(state.ephemeralPermissionScopes == null
+      ? {}
+      : { ephemeralPermissionScopes: state.ephemeralPermissionScopes }),
+  };
 }
 
 function findAssistantToolCallById(messages: Message[], toolCallId: string): AgentToolCall | null {

--- a/src/agent/tool-approval-state.ts
+++ b/src/agent/tool-approval-state.ts
@@ -42,6 +42,9 @@ export function buildApprovedToolExecutionState(input: {
       approved: true,
       mode: "one_shot",
       approvalId: input.approvalId,
+      ...(input.baseState?.bashFullAccess?.toolCallId == null
+        ? {}
+        : { toolCallId: input.baseState.bashFullAccess.toolCallId }),
     };
   }
 

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -220,7 +220,7 @@ async function executeBashWithFullAccessIfAllowed(input: {
   }
 
   if (
-    input.context.approvalState?.bashFullAccess?.approved === true ||
+    hasCurrentToolCallOneShotBashApproval(input.context) ||
     input.context.approvalState?.runtimeModeAutoApproval != null
   ) {
     return await executeUnsandboxedBash({
@@ -271,11 +271,21 @@ async function executeBashWithFullAccessIfAllowed(input: {
               approved: true,
               mode: "one_shot" as const,
               approvalId: 0,
+              ...(input.context.toolCallId == null ? {} : { toolCallId: input.context.toolCallId }),
             },
           },
         }
       : {}),
   });
+}
+
+function hasCurrentToolCallOneShotBashApproval(context: ToolExecutionContext): boolean {
+  const approval = context.approvalState?.bashFullAccess;
+  return (
+    approval?.approved === true &&
+    approval.toolCallId != null &&
+    approval.toolCallId === context.toolCallId
+  );
 }
 
 type BashFullAccessSegmentApproval =

--- a/src/tools/core/types.ts
+++ b/src/tools/core/types.ts
@@ -106,6 +106,7 @@ export interface ToolExecutionApprovalState {
     approved: true;
     mode: "one_shot";
     approvalId: number;
+    toolCallId?: string;
   };
   ephemeralPermissionScopes?: PermissionScope[];
 }

--- a/tests/agent/bash-approval.test.ts
+++ b/tests/agent/bash-approval.test.ts
@@ -1,3 +1,4 @@
+import { Type } from "@sinclair/typebox";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const { executeSandboxedBashMock, executeUnsandboxedBashMock } = vi.hoisted(() => ({
@@ -12,11 +13,13 @@ import { AgentSessionService } from "@/src/agent/session.js";
 import { DEFAULT_CONFIG } from "@/src/config/defaults.js";
 import type { AppConfig } from "@/src/config/schema.js";
 import { SessionRunAbortRegistry } from "@/src/runtime/cancel.js";
+import type { ExecuteUnsandboxedBashInput } from "@/src/security/sandbox.js";
 import { MessagesRepo } from "@/src/storage/repos/messages.repo.js";
 import { SessionsRepo } from "@/src/storage/repos/sessions.repo.js";
 import { createBashTool } from "@/src/tools/bash.js";
 import { toolRecoverableError } from "@/src/tools/core/errors.js";
 import { ToolRegistry } from "@/src/tools/core/registry.js";
+import { defineTool, textToolResult } from "@/src/tools/core/types.js";
 import {
   createTestDatabase,
   destroyTestDatabase,
@@ -113,6 +116,26 @@ async function waitForApprovalRequested(
 
     await new Promise((resolve) => setTimeout(resolve, 5));
   }
+}
+
+async function waitForApprovalRequestCount(
+  events: Array<{ type: string; approvalId?: string }>,
+  count: number,
+): Promise<string[]> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const approvalIds = events
+      .filter((event) => event.type === "approval_requested")
+      .map((event) => event.approvalId)
+      .filter((approvalId): approvalId is string => approvalId != null);
+    if (approvalIds.length >= count) {
+      return approvalIds;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+
+  throw new Error(`Timed out waiting for ${count} approval request(s)`);
 }
 
 describe("agent loop bash approval flow", () => {
@@ -305,5 +328,247 @@ describe("agent loop bash approval flow", () => {
         },
       ]),
     });
+  });
+
+  test("clears one-shot bash approval before subsequent tool calls", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+
+    const sessionsRepo = new SessionsRepo(handle.storage.db);
+    const messagesRepo = new MessagesRepo(handle.storage.db);
+    sessionsRepo.create({
+      id: "sess_1",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      ownerAgentId: "agent_1",
+      purpose: "chat",
+      createdAt: new Date("2026-03-22T00:00:00.000Z"),
+    });
+    messagesRepo.append({
+      id: "msg_user",
+      sessionId: "sess_1",
+      seq: 1,
+      role: "user",
+      payloadJson: '{"content":"open and wait"}',
+      createdAt: new Date("2026-03-22T00:00:01.000Z"),
+    });
+
+    let modelTurnCount = 0;
+    const runner: AgentModelRunner = {
+      async runTurn() {
+        modelTurnCount += 1;
+        if (modelTurnCount === 1) {
+          return makeAssistantResult({
+            stopReason: "toolUse",
+            content: [
+              {
+                type: "toolCall",
+                id: "tool_1",
+                name: "bash",
+                arguments: {
+                  command: "agent-browser open https://example.com",
+                  sandboxMode: "full_access",
+                  justification: "Open the page for inspection.",
+                },
+              },
+              {
+                type: "toolCall",
+                id: "tool_1",
+                name: "bash",
+                arguments: {
+                  command: "agent-browser wait 5000",
+                  sandboxMode: "full_access",
+                  justification: "Wait for the page to finish loading.",
+                },
+              },
+            ],
+          });
+        }
+
+        return makeAssistantResult({
+          content: [{ type: "text", text: "done" }],
+        });
+      },
+    };
+
+    executeUnsandboxedBashMock.mockImplementation(async (input: ExecuteUnsandboxedBashInput) => ({
+      command: input.command,
+      cwd: input.cwd,
+      timeoutMs: input.timeoutMs,
+      stdout: "ok\n",
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    }));
+
+    const tools = new ToolRegistry([createBashTool()]);
+    const emittedEvents: Array<{ type: string; approvalId?: string; decision?: string }> = [];
+    const loop = new AgentLoop({
+      sessions: new AgentSessionService(sessionsRepo, messagesRepo),
+      messages: messagesRepo,
+      models: new ProviderRegistry(createModelConfig()),
+      tools,
+      cancel: new SessionRunAbortRegistry(),
+      modelRunner: runner,
+      storage: handle.storage.db,
+      securityConfig: DEFAULT_CONFIG.security,
+      compaction: DEFAULT_CONFIG.compaction,
+      emitEvent(event) {
+        emittedEvents.push(event);
+      },
+    });
+
+    const runPromise = loop.run({ sessionId: "sess_1", scenario: "chat" });
+    const firstApprovalId = Number((await waitForApprovalRequestCount(emittedEvents, 1))[0]);
+
+    expect(
+      loop.submitApprovalResponse({
+        approvalId: firstApprovalId,
+        decision: "approve",
+        actor: "user",
+        rawInput: "approve",
+        grantedBy: "user",
+        expiresAt: null,
+      }),
+    ).toBe(true);
+
+    const secondApprovalId = Number((await waitForApprovalRequestCount(emittedEvents, 2))[1]);
+    expect(executeUnsandboxedBashMock).toHaveBeenCalledTimes(1);
+
+    expect(
+      loop.submitApprovalResponse({
+        approvalId: secondApprovalId,
+        decision: "approve",
+        actor: "user",
+        rawInput: "approve",
+        grantedBy: "user",
+        expiresAt: null,
+      }),
+    ).toBe(true);
+
+    await runPromise;
+
+    expect(executeUnsandboxedBashMock).toHaveBeenCalledTimes(2);
+    expect(executeUnsandboxedBashMock.mock.calls.map((call) => call[0].command)).toEqual([
+      "agent-browser open https://example.com",
+      "agent-browser wait 5000",
+    ]);
+    expect(emittedEvents.filter((event) => event.type === "approval_requested")).toHaveLength(2);
+  });
+
+  test("does not expose consumed one-shot bash approval to the following tool", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+
+    const sessionsRepo = new SessionsRepo(handle.storage.db);
+    const messagesRepo = new MessagesRepo(handle.storage.db);
+    sessionsRepo.create({
+      id: "sess_1",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      ownerAgentId: "agent_1",
+      purpose: "chat",
+      createdAt: new Date("2026-03-22T00:00:00.000Z"),
+    });
+    messagesRepo.append({
+      id: "msg_user",
+      sessionId: "sess_1",
+      seq: 1,
+      role: "user",
+      payloadJson: '{"content":"open then inspect"}',
+      createdAt: new Date("2026-03-22T00:00:01.000Z"),
+    });
+
+    let modelTurnCount = 0;
+    const runner: AgentModelRunner = {
+      async runTurn() {
+        modelTurnCount += 1;
+        if (modelTurnCount === 1) {
+          return makeAssistantResult({
+            stopReason: "toolUse",
+            content: [
+              {
+                type: "toolCall",
+                id: "tool_1",
+                name: "bash",
+                arguments: {
+                  command: "agent-browser open https://example.com",
+                  sandboxMode: "full_access",
+                  justification: "Open the page for inspection.",
+                },
+              },
+              {
+                type: "toolCall",
+                id: "tool_2",
+                name: "inspect_approval_state",
+                arguments: {},
+              },
+            ],
+          });
+        }
+
+        return makeAssistantResult({
+          content: [{ type: "text", text: "done" }],
+        });
+      },
+    };
+
+    executeUnsandboxedBashMock.mockResolvedValueOnce({
+      command: "agent-browser open https://example.com",
+      cwd: "/tmp",
+      timeoutMs: 10_000,
+      stdout: "ok\n",
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    });
+
+    let followingToolSawOneShotApproval = false;
+    const tools = new ToolRegistry([
+      createBashTool(),
+      defineTool({
+        name: "inspect_approval_state",
+        description: "Inspects approval state propagation",
+        inputSchema: Type.Object({}, { additionalProperties: false }),
+        execute(context) {
+          followingToolSawOneShotApproval =
+            context.approvalState?.bashFullAccess?.approved === true;
+          return textToolResult("ok");
+        },
+      }),
+    ]);
+    const emittedEvents: Array<{ type: string; approvalId?: string; decision?: string }> = [];
+    const loop = new AgentLoop({
+      sessions: new AgentSessionService(sessionsRepo, messagesRepo),
+      messages: messagesRepo,
+      models: new ProviderRegistry(createModelConfig()),
+      tools,
+      cancel: new SessionRunAbortRegistry(),
+      modelRunner: runner,
+      storage: handle.storage.db,
+      securityConfig: DEFAULT_CONFIG.security,
+      compaction: DEFAULT_CONFIG.compaction,
+      emitEvent(event) {
+        emittedEvents.push(event);
+      },
+    });
+
+    const runPromise = loop.run({ sessionId: "sess_1", scenario: "chat" });
+    const approvalId = Number((await waitForApprovalRequestCount(emittedEvents, 1))[0]);
+
+    expect(
+      loop.submitApprovalResponse({
+        approvalId,
+        decision: "approve",
+        actor: "user",
+        rawInput: "approve",
+        grantedBy: "user",
+        expiresAt: null,
+      }),
+    ).toBe(true);
+
+    await runPromise;
+
+    expect(followingToolSawOneShotApproval).toBe(false);
   });
 });

--- a/tests/agent/tool-approval-state.test.ts
+++ b/tests/agent/tool-approval-state.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  buildApprovedToolExecutionState,
+  buildRuntimeModeToolExecutionState,
+} from "@/src/agent/tool-approval-state.js";
+
+describe("tool approval state", () => {
+  test("builds runtime-mode auto approval state only for non-normal skip-human modes", () => {
+    expect(buildRuntimeModeToolExecutionState(undefined)).toBeUndefined();
+    expect(
+      buildRuntimeModeToolExecutionState({
+        autopilotEnabled: false,
+        yoloEnabled: false,
+        source: "normal",
+        skipHumanApproval: false,
+      }),
+    ).toBeUndefined();
+    expect(
+      buildRuntimeModeToolExecutionState({
+        autopilotEnabled: true,
+        yoloEnabled: false,
+        source: "autopilot",
+        skipHumanApproval: true,
+      }),
+    ).toEqual({
+      runtimeModeAutoApproval: {
+        source: "autopilot",
+      },
+    });
+  });
+
+  test("returns the base approval state unchanged for explicit human approvals", () => {
+    const baseState = {
+      bashFullAccess: {
+        approved: true as const,
+        mode: "one_shot" as const,
+        approvalId: 0,
+        toolCallId: "tool_1",
+      },
+    };
+
+    expect(
+      buildApprovedToolExecutionState({
+        baseState,
+        request: {
+          scopes: [{ kind: "bash.full_access", prefix: ["agent-browser", "open"] }],
+        },
+        approvalId: 43,
+        skippedHumanApproval: false,
+      }),
+    ).toBe(baseState);
+  });
+
+  test("preserves bash one-shot toolCallId when rebuilding skipped-human approval state", () => {
+    const state = buildApprovedToolExecutionState({
+      baseState: {
+        bashFullAccess: {
+          approved: true,
+          mode: "one_shot",
+          approvalId: 0,
+          toolCallId: "tool_1",
+        },
+      },
+      request: {
+        scopes: [{ kind: "bash.full_access", prefix: ["agent-browser", "wait"] }],
+      },
+      approvalId: 43,
+      skippedHumanApproval: true,
+    });
+
+    expect(state?.bashFullAccess).toEqual({
+      approved: true,
+      mode: "one_shot",
+      approvalId: 43,
+      toolCallId: "tool_1",
+    });
+  });
+
+  test("deduplicates ephemeral scopes when rebuilding skipped-human approval state", () => {
+    const state = buildApprovedToolExecutionState({
+      baseState: {
+        ephemeralPermissionScopes: [{ kind: "fs.write", path: "/tmp/report.md" }],
+      },
+      request: {
+        scopes: [
+          { kind: "fs.write", path: "/tmp/report.md" },
+          { kind: "fs.read", path: "/tmp/report.md" },
+        ],
+      },
+      approvalId: 44,
+      skippedHumanApproval: true,
+    });
+
+    expect(state?.ephemeralPermissionScopes).toEqual([
+      { kind: "fs.write", path: "/tmp/report.md" },
+      { kind: "fs.read", path: "/tmp/report.md" },
+    ]);
+  });
+});

--- a/tests/tools/bash.test.ts
+++ b/tests/tools/bash.test.ts
@@ -636,6 +636,106 @@ Use this exact bash argument object on the next retry if full access is warrante
     });
   });
 
+  test("does not reuse a one-shot bash full-access approval for a later tool call", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+    executeUnsandboxedBashMock.mockResolvedValue({
+      command: "agent-browser wait 5000 2>&1",
+      cwd: "/tmp/work",
+      timeoutMs: 10_000,
+      stdout: "done\n",
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    });
+
+    const registry = new ToolRegistry([createBashTool()]);
+
+    await expect(
+      registry.execute(
+        "bash",
+        {
+          sessionId: "sess_1",
+          conversationId: "conv_1",
+          ownerAgentId: "agent_1",
+          cwd: "/tmp/work",
+          securityConfig: DEFAULT_CONFIG.security,
+          storage: handle.storage.db,
+          toolCallId: "tool_2",
+          approvalState: {
+            bashFullAccess: {
+              approved: true,
+              mode: "one_shot",
+              approvalId: 43,
+            },
+          },
+        },
+        {
+          command: "agent-browser wait 5000 2>&1",
+          sandboxMode: "full_access",
+          justification: "Wait for the browser page to finish rendering.",
+        },
+      ),
+    ).rejects.toMatchObject({
+      name: "ToolApprovalRequired",
+      grantOnApprove: false,
+      request: {
+        scopes: [{ kind: "bash.full_access", prefix: ["agent-browser", "wait", "5000"] }],
+      },
+    });
+
+    expect(executeUnsandboxedBashMock).not.toHaveBeenCalled();
+  });
+
+  test("uses a one-shot bash full-access approval for the matching tool call retry", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+    executeUnsandboxedBashMock.mockResolvedValue({
+      command: "agent-browser wait 5000 2>&1",
+      cwd: "/tmp/work",
+      timeoutMs: 10_000,
+      stdout: "done\n",
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    });
+
+    const registry = new ToolRegistry([createBashTool()]);
+    const result = await registry.execute(
+      "bash",
+      {
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        ownerAgentId: "agent_1",
+        cwd: "/tmp/work",
+        securityConfig: DEFAULT_CONFIG.security,
+        storage: handle.storage.db,
+        toolCallId: "tool_1",
+        approvalState: {
+          bashFullAccess: {
+            approved: true,
+            mode: "one_shot",
+            approvalId: 43,
+            toolCallId: "tool_1",
+          },
+        },
+      },
+      {
+        command: "agent-browser wait 5000 2>&1",
+        sandboxMode: "full_access",
+        justification: "Wait for the browser page to finish rendering.",
+      },
+    );
+
+    expect(executeUnsandboxedBashMock).toHaveBeenCalledTimes(1);
+    expect(executeSandboxedBashMock).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({
+      command: "agent-browser wait 5000 2>&1",
+      cwd: "/tmp/work",
+      exitCode: 0,
+    });
+  });
+
   test("uses existing bash full-access grants for every parsed subcommand in a compound command", async () => {
     handle = await createTestDatabase(import.meta.url);
     seedConversationAndAgentFixture(handle);


### PR DESCRIPTION
## Summary
- Bind one-shot bash full_access approvals to the originating toolCallId.
- Preserve runtime-mode auto approval and persisted prefix grants.
- Add regression coverage for approval leakage plus the matching retry path.

## Linear
- POK-36: https://linear.app/pokoclaw/issue/POK-36/fix-one-shot-bash-full-access-approval-leaking-to-later-tool-calls

## Test plan
- pnpm preflight