### PR TITLE
Fix runtime starvation diagnostics and Lark flush loop

### DIFF
--- a/src/agent/llm/pi-ai-openai-responses-shared.ts
+++ b/src/agent/llm/pi-ai-openai-responses-shared.ts
@@ -41,6 +41,7 @@ import type {
   ResponseInput,
   ResponseStreamEvent,
 } from "openai/resources/responses/responses.js";
+import { appendCappedTextTail, capTextTail } from "@/src/shared/capped-text.js";
 
 export interface OpenAIResponsesStreamOptions {
   serviceTier?: ResponseCreateParamsStreaming["service_tier"];
@@ -69,6 +70,9 @@ type StreamToolCallBlock = Extract<AssistantMessage["content"][number], { type: 
   partialJson?: string;
 };
 type StreamBlock = StreamThinkingBlock | StreamTextBlock | StreamToolCallBlock;
+
+const STREAM_REASONING_CONTENT_MAX_CHARS = 100_000;
+const STREAM_REASONING_TRUNCATION_PREFIX = "...[earlier reasoning truncated]\n";
 
 interface ResponsesReasoningSummaryPart {
   text: string;
@@ -536,8 +540,8 @@ export async function processResponsesStream<TApi extends Api>(
         currentItem.summary = currentItem.summary || [];
         const lastPart = currentItem.summary[currentItem.summary.length - 1];
         if (lastPart) {
-          currentBlock.thinking += event.delta;
-          lastPart.text += event.delta;
+          currentBlock.thinking = appendStreamReasoning(currentBlock.thinking, event.delta);
+          lastPart.text = appendStreamReasoning(lastPart.text, event.delta);
           stream.push({
             type: "thinking_delta",
             contentIndex: blockIndex(),
@@ -551,8 +555,8 @@ export async function processResponsesStream<TApi extends Api>(
         currentItem.summary = currentItem.summary || [];
         const lastPart = currentItem.summary[currentItem.summary.length - 1];
         if (lastPart) {
-          currentBlock.thinking += "\n\n";
-          lastPart.text += "\n\n";
+          currentBlock.thinking = appendStreamReasoning(currentBlock.thinking, "\n\n");
+          lastPart.text = appendStreamReasoning(lastPart.text, "\n\n");
           stream.push({
             type: "thinking_delta",
             contentIndex: blockIndex(),
@@ -617,7 +621,9 @@ export async function processResponsesStream<TApi extends Api>(
     } else if (event.type === "response.output_item.done") {
       const item = event.item as unknown as ResponsesStreamItem;
       if (item.type === "reasoning" && currentBlock?.type === "thinking") {
-        currentBlock.thinking = item.summary?.map((summary) => summary.text).join("\n\n") || "";
+        currentBlock.thinking = capStreamReasoning(
+          item.summary?.map((summary) => summary.text).join("\n\n") || "",
+        );
         currentBlock.thinkingSignature = JSON.stringify(item);
         stream.push({
           type: "thinking_end",
@@ -704,6 +710,20 @@ export async function processResponsesStream<TApi extends Api>(
       });
     }
   }
+}
+
+function appendStreamReasoning(existing: string, delta: string): string {
+  return appendCappedTextTail(existing, delta, {
+    maxChars: STREAM_REASONING_CONTENT_MAX_CHARS,
+    truncationPrefix: STREAM_REASONING_TRUNCATION_PREFIX,
+  });
+}
+
+function capStreamReasoning(value: string): string {
+  return capTextTail(value, {
+    maxChars: STREAM_REASONING_CONTENT_MAX_CHARS,
+    truncationPrefix: STREAM_REASONING_TRUNCATION_PREFIX,
+  });
 }
 
 function mapStopReason(status?: string): StopReason {

--- a/src/agent/llm/pi-bridge.ts
+++ b/src/agent/llm/pi-bridge.ts
@@ -5,6 +5,7 @@
  * streaming/completion execution, and normalizes usage + errors back into local
  * runtime contracts.
  */
+import { setImmediate as setImmediatePromise } from "node:timers/promises";
 import {
   type Api,
   type AssistantMessage,
@@ -46,6 +47,7 @@ const PERMISSIVE_TOOL_PARAMETERS = Type.Object({}, { additionalProperties: true 
 const DEFAULT_REASONING_LEVEL = "medium";
 const logger = createSubsystemLogger("llm-bridge");
 const LOG_PREVIEW_LIMIT = 160;
+const STREAM_EVENT_LOOP_YIELD_EVERY_EVENTS = 256;
 const OPENAI_COMPAT_ROLE_OVERRIDE = {
   supportsDeveloperRole: false,
 } as const;
@@ -98,14 +100,15 @@ export class PiBridge {
     const tools = input.model.supportsTools
       ? buildPiTools(input.tools, input.sessionPurpose, input.agentKind)
       : null;
+    const contextMessages = buildPiContextMessages(
+      input.compactSummary,
+      input.messages,
+      input.model.supportsVision,
+      input.resolveRuntimeImages,
+    );
     const context = {
       ...(input.systemPrompt == null ? {} : { systemPrompt: input.systemPrompt }),
-      messages: buildPiContextMessages(
-        input.compactSummary,
-        input.messages,
-        input.model.supportsVision,
-        input.resolveRuntimeImages,
-      ),
+      messages: contextMessages,
     };
     if (tools != null) {
       Object.assign(context, { tools });
@@ -130,7 +133,9 @@ export class PiBridge {
         }),
       );
       let accumulatedText = "";
+      let streamEventCount = 0;
       for await (const event of stream) {
+        streamEventCount += 1;
         switch (event.type) {
           case "text_delta":
             accumulatedText += event.delta;
@@ -146,6 +151,10 @@ export class PiBridge {
             break;
           default:
             break;
+        }
+
+        if (streamEventCount % STREAM_EVENT_LOOP_YIELD_EVERY_EVENTS === 0) {
+          await setImmediatePromise();
         }
       }
 

--- a/src/agent/llm/upstream-openai.ts
+++ b/src/agent/llm/upstream-openai.ts
@@ -33,6 +33,7 @@ import {
   convertResponsesTools,
   processResponsesStream,
 } from "@/src/agent/llm/pi-ai-openai-responses-shared.js";
+import { appendCappedTextTail } from "@/src/shared/capped-text.js";
 
 type CostedModel = Pick<Model<Api>, "api" | "baseUrl" | "cost">;
 
@@ -153,6 +154,8 @@ const DEFAULT_COMPAT: ResolvedOpenAICompletionsCompat = {
 };
 
 const OPENAI_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode"]);
+const STREAM_REASONING_CONTENT_MAX_CHARS = 100_000;
+const STREAM_REASONING_TRUNCATION_PREFIX = "...[earlier reasoning truncated]\n";
 
 export function supportsUpstreamCostParser(model: Pick<Model<Api>, "baseUrl">): boolean {
   return COST_PARSERS.some((parser) => parser.supports(model));
@@ -360,7 +363,7 @@ function streamOpenAICompletionsWithUpstreamUsage(
             });
           }
 
-          currentBlock.thinking += reasoningDelta;
+          currentBlock.thinking = appendStreamReasoning(currentBlock.thinking, reasoningDelta);
           stream.push({
             type: "thinking_delta",
             contentIndex: output.content.length - 1,
@@ -498,6 +501,13 @@ function streamOpenAICompletionsWithUpstreamUsage(
   })();
 
   return stream;
+}
+
+function appendStreamReasoning(existing: string, delta: string): string {
+  return appendCappedTextTail(existing, delta, {
+    maxChars: STREAM_REASONING_CONTENT_MAX_CHARS,
+    truncationPrefix: STREAM_REASONING_TRUNCATION_PREFIX,
+  });
 }
 
 function streamOpenAIResponsesWithUpstreamUsage(

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -84,6 +84,7 @@ import { SessionSteerQueueRegistry, type SteerInput } from "@/src/runtime/steer-
 import { buildSystemPolicy } from "@/src/security/policy.js";
 import type { PermissionRequest } from "@/src/security/scope.js";
 import { SecurityService } from "@/src/security/service.js";
+import { appendCappedTextTail } from "@/src/shared/capped-text.js";
 import { createSubsystemLogger } from "@/src/shared/logger.js";
 import { buildSubagentWorkspaceDir, POKOCLAW_WORKSPACE_DIR } from "@/src/shared/paths.js";
 import { resolveLocalCalendarContext } from "@/src/shared/time.js";
@@ -121,6 +122,10 @@ import {
 const logger = createSubsystemLogger("agent-loop");
 const ASSISTANT_RESPONSE_LOG_PREVIEW_MAX_LENGTH = 144;
 const ASSISTANT_REASONING_LOG_PREVIEW_MAX_LENGTH = 144;
+const ASSISTANT_REASONING_CAPTURE_MAX_CHARS = 100_000;
+const ASSISTANT_REASONING_EVENT_FLUSH_CHARS = 512;
+const ASSISTANT_REASONING_EVENT_FLUSH_MS = 250;
+const ASSISTANT_REASONING_TRUNCATION_PREFIX = "...[earlier reasoning truncated]\n";
 const EMPTY_OUTPUT_LLM_RETRY_LIMIT = 1;
 const UNKNOWN_ASSISTANT_ERROR_USAGE: MessageUsage = {
   input: 0,
@@ -636,11 +641,41 @@ export class AgentLoop {
         let sawStreamedReasoning = false;
         let streamedAssistantText = "";
         let streamedReasoningText = "";
+        let pendingReasoningDelta = "";
+        let lastReasoningEventFlushAt = 0;
         let streamedReasoningDeltaCount = 0;
         let streamedReasoningChars = 0;
         let overflowRecovered = false;
         let emptyOutputRetryCount = 0;
         let response: AgentModelTurnResult;
+
+        const flushPendingReasoningDelta = (force = false) => {
+          if (pendingReasoningDelta.length === 0) {
+            return;
+          }
+          const now = Date.now();
+          if (
+            !force &&
+            pendingReasoningDelta.length < ASSISTANT_REASONING_EVENT_FLUSH_CHARS &&
+            now - lastReasoningEventFlushAt < ASSISTANT_REASONING_EVENT_FLUSH_MS
+          ) {
+            return;
+          }
+
+          const delta = pendingReasoningDelta;
+          pendingReasoningDelta = "";
+          lastReasoningEventFlushAt = now;
+          this.recordEvent(events, {
+            type: "assistant_reasoning_delta",
+            turn: turn + 1,
+            messageId: assistantMessageId,
+            delta,
+            sessionId: input.sessionId,
+            conversationId: context.session.conversationId,
+            branchId: context.session.branchId,
+            runId,
+          });
+        };
 
         while (true) {
           logger.info("requesting assistant response", {
@@ -718,7 +753,11 @@ export class AgentLoop {
               },
               onThinkingDelta: (event) => {
                 sawStreamedReasoning = true;
-                streamedReasoningText += event.delta;
+                streamedReasoningText = appendCappedTextTail(streamedReasoningText, event.delta, {
+                  maxChars: ASSISTANT_REASONING_CAPTURE_MAX_CHARS,
+                  truncationPrefix: ASSISTANT_REASONING_TRUNCATION_PREFIX,
+                });
+                pendingReasoningDelta += event.delta;
                 streamedReasoningDeltaCount += 1;
                 streamedReasoningChars += event.delta.length;
                 this.recordStreamDelta({
@@ -741,16 +780,7 @@ export class AgentLoop {
                     ),
                   });
                 }
-                this.recordEvent(events, {
-                  type: "assistant_reasoning_delta",
-                  turn: turn + 1,
-                  messageId: assistantMessageId,
-                  delta: event.delta,
-                  sessionId: input.sessionId,
-                  conversationId: context.session.conversationId,
-                  branchId: context.session.branchId,
-                  runId,
-                });
+                flushPendingReasoningDelta();
               },
             });
             break;
@@ -810,6 +840,7 @@ export class AgentLoop {
               sawStreamedReasoning = false;
               streamedAssistantText = "";
               streamedReasoningText = "";
+              pendingReasoningDelta = "";
               context = this.deps.sessions.getContext(input.sessionId);
               messages = [...context.messages];
               continue;
@@ -865,6 +896,7 @@ export class AgentLoop {
 
         throwIfAborted(handle.signal);
 
+        flushPendingReasoningDelta(true);
         const assistantText = collectAssistantText(response.content);
         const reasoningText = collectAssistantThinking(response.content);
         const toolCalls = collectAgentToolCalls(response.content);

--- a/src/channels/lark/outbound.ts
+++ b/src/channels/lark/outbound.ts
@@ -71,6 +71,7 @@ const LARK_CARD_LOG_PREVIEW_MAX_LENGTH = 600;
 const LARK_CARDKIT_RECONCILE_RETRY_DELAY_MS = 1000;
 const TASK_STATUS_DELIVERY_PREFIX = "task_status:";
 const STEER_CONFIRMED_REACTION_EMOJI = "OK";
+const LARK_OUTBOUND_DEPENDENCY_RETRY_DELAY_MS = 1_000;
 
 interface LarkCardElementContentInput {
   path: {
@@ -199,6 +200,31 @@ export function createLarkOutboundRuntime(
     scheduleFlush(deliveryId, options);
   };
 
+  const ensureDeliveryScheduled = (
+    deliveryId: string,
+    options?: { immediate?: boolean; delayMs?: number },
+  ) => {
+    if (flushing.has(deliveryId) || scheduled.has(deliveryId)) {
+      return;
+    }
+
+    bumpVersionAndSchedule(deliveryId, options);
+  };
+
+  const scheduleDependentRetry = (deliveryId: string, context: Record<string, unknown>) => {
+    if (scheduled.has(deliveryId)) {
+      return;
+    }
+    logger.debug("scheduled lark outbound dependent retry", {
+      deliveryId,
+      delayMs: LARK_OUTBOUND_DEPENDENCY_RETRY_DELAY_MS,
+      ...context,
+    });
+    scheduleFlush(deliveryId, {
+      delayMs: LARK_OUTBOUND_DEPENDENCY_RETRY_DELAY_MS,
+    });
+  };
+
   const scheduleCardkitSequenceReconcile = (input: {
     bindingsRepo: LarkObjectBindingsRepo;
     channelInstallationId: string;
@@ -257,6 +283,7 @@ export function createLarkOutboundRuntime(
           deliveryId,
           completedVersion: flushVersion,
           latestVersion: deliveryVersions.get(deliveryId) ?? 0,
+          rescheduleImmediate,
         });
         scheduleFlush(deliveryId, { immediate: rescheduleImmediate });
       }
@@ -456,16 +483,24 @@ export function createLarkOutboundRuntime(
         shouldRenderStandaloneTaskCard(state.taskRunType) &&
         taskRootBinding?.larkMessageId == null
       ) {
+        const taskStatusDeliveryId = `${TASK_STATUS_DELIVERY_PREFIX}${state.taskRunId}`;
         logger.debug("deferring task transcript flush until task status card exists", {
           runId: state.runId,
           runCardObjectId,
           taskRunId: state.taskRunId,
           channelInstallationId: target.channelInstallationId,
+          taskStatusDeliveryId,
         });
-        bumpVersionAndSchedule(`${TASK_STATUS_DELIVERY_PREFIX}${state.taskRunId}`, {
+        ensureDeliveryScheduled(taskStatusDeliveryId, {
           immediate: true,
         });
-        bumpVersionAndSchedule(`run:${runCardObjectId}`);
+        scheduleDependentRetry(`run:${runCardObjectId}`, {
+          reason: "task_status_card_missing",
+          runId: state.runId,
+          runCardObjectId,
+          taskRunId: state.taskRunId,
+          taskStatusDeliveryId,
+        });
         continue;
       }
       const renderedPages = buildLarkRenderedRunCardPages(state, {
@@ -1095,15 +1130,22 @@ export function createLarkOutboundRuntime(
         shouldRenderStandaloneTaskCard(state.taskRunType) &&
         taskRootBinding?.larkMessageId == null
       ) {
+        const taskStatusDeliveryId = `${TASK_STATUS_DELIVERY_PREFIX}${state.taskRunId}`;
         logger.debug("deferring task approval card flush until task status card exists", {
           approvalFlowId,
           taskRunId: state.taskRunId,
           channelInstallationId: target.channelInstallationId,
+          taskStatusDeliveryId,
         });
-        bumpVersionAndSchedule(`${TASK_STATUS_DELIVERY_PREFIX}${state.taskRunId}`, {
+        ensureDeliveryScheduled(taskStatusDeliveryId, {
           immediate: true,
         });
-        bumpVersionAndSchedule(`approval:${approvalFlowId}`);
+        scheduleDependentRetry(`approval:${approvalFlowId}`, {
+          reason: "task_status_card_missing",
+          approvalFlowId,
+          taskRunId: state.taskRunId,
+          taskStatusDeliveryId,
+        });
         continue;
       }
       const existing = bindingsRepo.getByInternalObject({

--- a/src/channels/lark/run-state.ts
+++ b/src/channels/lark/run-state.ts
@@ -18,6 +18,11 @@ import type {
   OrchestratedRuntimeEventEnvelope,
   OrchestratedTaskRunEventEnvelope,
 } from "@/src/orchestration/outbound-events.js";
+import { appendCappedTextTail } from "@/src/shared/capped-text.js";
+
+export const LARK_REASONING_STATE_MAX_CHARS = 8_000;
+
+const LARK_REASONING_TRUNCATION_PREFIX = "...[earlier reasoning truncated]\n";
 
 export type LarkFooterStatus = "thinking" | "tool_running" | "waiting_approval" | null;
 
@@ -283,7 +288,7 @@ function onAssistantReasoningDelta(
       content:
         event.delta.length === 0
           ? state.reasoning.content
-          : `${state.reasoning.content}${event.delta}`,
+          : appendReasoningContentWithSeparator(state.reasoning.content, event.delta, ""),
       active: true,
       expanded: true,
     },
@@ -588,10 +593,19 @@ function finalizeActiveToolSequenceIfNeeded(
 }
 
 function appendReasoningContent(existing: string, next: string): string {
-  if (existing.length === 0) {
-    return next;
-  }
-  return `${existing}\n\n${next}`;
+  return appendReasoningContentWithSeparator(existing, next, "\n\n");
+}
+
+function appendReasoningContentWithSeparator(
+  existing: string,
+  next: string,
+  separator: string,
+): string {
+  const content = existing.length === 0 ? next : `${separator}${next}`;
+  return appendCappedTextTail(existing, content, {
+    maxChars: LARK_REASONING_STATE_MAX_CHARS,
+    truncationPrefix: LARK_REASONING_TRUNCATION_PREFIX,
+  });
 }
 
 function resolvePendingPermissionRequestTools(

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -378,6 +378,7 @@ export class CronService {
   }
 
   private kickoffClaimedRun(job: CronJob, triggerKind: "scheduled" | "manual"): void {
+    const startedAt = this.now();
     logger.info("kicking off claimed cron job run", {
       cronJobId: job.id,
       triggerKind,
@@ -437,6 +438,7 @@ export class CronService {
           cronJobId: job.id,
           triggerKind,
           inFlightRuns: this.inFlightRuns.size,
+          durationMs: this.now().getTime() - startedAt.getTime(),
         });
       });
 

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -36,6 +36,7 @@ import {
 import { SessionRunAbortRegistry } from "@/src/runtime/cancel.js";
 import { RuntimeControlService } from "@/src/runtime/control.js";
 import { RuntimeEventBus } from "@/src/runtime/event-bus.js";
+import { RuntimeEventLoopWatchdog } from "@/src/runtime/event-loop-watchdog.js";
 import { SessionRuntimeIngress } from "@/src/runtime/ingress.js";
 import { MinuteHeartbeat } from "@/src/runtime/minute-heartbeat.js";
 import {
@@ -62,6 +63,7 @@ export interface RuntimeBootstrap {
   readonly manager: AgentManager;
   readonly liveConfig: LiveConfigManager;
   readonly heartbeat: MinuteHeartbeat;
+  readonly eventLoopWatchdog: RuntimeEventLoopWatchdog;
   readonly cron: CronService;
   readonly meditation: MeditationScheduler;
   readonly mcp: McpClientManager;
@@ -181,6 +183,7 @@ export function createRuntimeBootstrap(input: CreateRuntimeBootstrapInput): Runt
     agentManager: manager,
   });
   const heartbeat = new MinuteHeartbeat();
+  const eventLoopWatchdog = new RuntimeEventLoopWatchdog();
   const meditationState = new MeditationStateRepo(input.storage);
   const meditation = new MeditationScheduler({
     config: input.config.selfHarness,
@@ -273,6 +276,7 @@ export function createRuntimeBootstrap(input: CreateRuntimeBootstrapInput): Runt
     manager,
     liveConfig,
     heartbeat,
+    eventLoopWatchdog,
     cron,
     meditation,
     mcp,
@@ -326,6 +330,7 @@ export function createRuntimeBootstrap(input: CreateRuntimeBootstrapInput): Runt
       lark.start();
       cron.start();
       meditation.start();
+      eventLoopWatchdog.start();
       heartbeat.start();
       started = true;
       logger.info("runtime bootstrap started", {
@@ -334,6 +339,8 @@ export function createRuntimeBootstrap(input: CreateRuntimeBootstrapInput): Runt
         toolCount: tools.list().length,
         mcpServers: Object.keys(input.config.mcp.servers).length,
         larkInstallations: lark.status().configuredInstallations,
+        heartbeat: heartbeat.status(),
+        eventLoopWatchdog: eventLoopWatchdog.status(),
       });
 
       void dispatchPreparedBackOnlineRecovery({
@@ -361,10 +368,13 @@ export function createRuntimeBootstrap(input: CreateRuntimeBootstrapInput): Runt
 
         logger.info("runtime bootstrap shutting down", {
           heartbeatStarted: heartbeat.status().started,
+          heartbeatNextTimerFireAt: heartbeat.status().nextTimerFireAt,
+          eventLoopWatchdog: eventLoopWatchdog.status(),
           inFlightCronRuns: cron.status().inFlightRuns,
           inFlightMeditationRuns: meditation.status().inFlightRuns,
         });
         heartbeat.stop();
+        eventLoopWatchdog.stop();
         unsubscribeMcpConfig();
         a2ui?.shutdown();
         await lark.shutdown();

--- a/src/runtime/event-bus.ts
+++ b/src/runtime/event-bus.ts
@@ -7,11 +7,20 @@
 import { createSubsystemLogger } from "@/src/shared/logger.js";
 
 const logger = createSubsystemLogger("runtime/event-bus");
+const PENDING_DISPATCH_WARN_THRESHOLD = 500;
+const PENDING_DISPATCH_ERROR_THRESHOLD = 5_000;
+const DISPATCH_SLOW_WARN_MS = 1_000;
+const BACKLOG_LOG_INTERVAL_MS = 5_000;
 
 export type RuntimeEventBusListener<TEvent> = (event: TEvent) => void | Promise<void>;
 
 export class RuntimeEventBus<TEvent> {
   private readonly listeners = new Set<RuntimeEventBusListener<TEvent>>();
+  private pendingDispatches = 0;
+  private publishedDispatches = 0;
+  private completedDispatches = 0;
+  private failedDispatches = 0;
+  private lastBacklogLogAt = 0;
 
   subscribe(listener: RuntimeEventBusListener<TEvent>): () => void {
     this.listeners.add(listener);
@@ -22,12 +31,38 @@ export class RuntimeEventBus<TEvent> {
 
   publish(event: TEvent): void {
     for (const listener of this.listeners) {
-      queueMicrotask(() => {
-        void Promise.resolve(listener(event)).catch((error: unknown) => {
-          logger.error("runtime event bus listener failed", {
-            error: error instanceof Error ? error.message : String(error),
+      this.pendingDispatches += 1;
+      this.publishedDispatches += 1;
+      this.logBacklogIfNeeded(event);
+      setImmediate(() => {
+        const startedAt = Date.now();
+        void Promise.resolve(listener(event))
+          .catch((error: unknown) => {
+            this.failedDispatches += 1;
+            logger.error("runtime event bus listener failed", {
+              ...describeRuntimeEventForLog(event),
+              error: error instanceof Error ? error.message : String(error),
+              pendingDispatches: this.pendingDispatches,
+              publishedDispatches: this.publishedDispatches,
+              completedDispatches: this.completedDispatches,
+              failedDispatches: this.failedDispatches,
+            });
+          })
+          .finally(() => {
+            this.pendingDispatches = Math.max(0, this.pendingDispatches - 1);
+            this.completedDispatches += 1;
+            const durationMs = Date.now() - startedAt;
+            if (durationMs >= DISPATCH_SLOW_WARN_MS) {
+              logger.warn("runtime event bus listener dispatch was slow", {
+                ...describeRuntimeEventForLog(event),
+                durationMs,
+                pendingDispatches: this.pendingDispatches,
+                publishedDispatches: this.publishedDispatches,
+                completedDispatches: this.completedDispatches,
+                failedDispatches: this.failedDispatches,
+              });
+            }
           });
-        });
       });
     }
   }
@@ -35,4 +70,58 @@ export class RuntimeEventBus<TEvent> {
   listenerCount(): number {
     return this.listeners.size;
   }
+
+  private logBacklogIfNeeded(event: TEvent): void {
+    if (this.pendingDispatches < PENDING_DISPATCH_WARN_THRESHOLD) {
+      return;
+    }
+    const now = Date.now();
+    if (now - this.lastBacklogLogAt < BACKLOG_LOG_INTERVAL_MS) {
+      return;
+    }
+    this.lastBacklogLogAt = now;
+    const log =
+      this.pendingDispatches >= PENDING_DISPATCH_ERROR_THRESHOLD ? logger.error : logger.warn;
+    log("runtime event bus dispatch backlog is high", {
+      ...describeRuntimeEventForLog(event),
+      pendingDispatches: this.pendingDispatches,
+      listenerCount: this.listeners.size,
+      publishedDispatches: this.publishedDispatches,
+      completedDispatches: this.completedDispatches,
+      failedDispatches: this.failedDispatches,
+    });
+  }
+}
+
+function describeRuntimeEventForLog(event: unknown): Record<string, unknown> {
+  const envelope = asRecord(event);
+  if (envelope == null) {
+    return {
+      eventValueType: typeof event,
+    };
+  }
+
+  const eventRecord = asRecord(envelope.event);
+  const runRecord = asRecord(envelope.run);
+  const sessionRecord = asRecord(envelope.session);
+  const taskRunRecord = asRecord(envelope.taskRun);
+
+  return {
+    envelopeKind: readString(envelope.kind),
+    eventType: readString(eventRecord?.type),
+    runId: readString(runRecord?.runId),
+    sessionId: readString(sessionRecord?.sessionId),
+    taskRunId: readString(taskRunRecord?.taskRunId),
+    taskRunType: readString(taskRunRecord?.runType),
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value != null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
 }

--- a/src/runtime/event-loop-watchdog.ts
+++ b/src/runtime/event-loop-watchdog.ts
@@ -1,0 +1,114 @@
+import { createSubsystemLogger } from "@/src/shared/logger.js";
+
+const logger = createSubsystemLogger("runtime/event-loop-watchdog");
+
+const DEFAULT_INTERVAL_MS = 5_000;
+const DEFAULT_WARN_LAG_MS = 2_000;
+const DEFAULT_ERROR_LAG_MS = 10_000;
+
+export interface RuntimeEventLoopWatchdogDependencies {
+  now?: () => Date;
+  setIntervalFn?: typeof setInterval;
+  clearIntervalFn?: typeof clearInterval;
+  intervalMs?: number;
+  warnLagMs?: number;
+  errorLagMs?: number;
+}
+
+export interface RuntimeEventLoopWatchdogStatus {
+  started: boolean;
+  intervalMs: number;
+  warnLagMs: number;
+  errorLagMs: number;
+  expectedNextTickAt: string | null;
+}
+
+export class RuntimeEventLoopWatchdog {
+  private readonly now: () => Date;
+  private readonly setIntervalFn: typeof setInterval;
+  private readonly clearIntervalFn: typeof clearInterval;
+  private readonly intervalMs: number;
+  private readonly warnLagMs: number;
+  private readonly errorLagMs: number;
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private expectedNextTickAt: Date | null = null;
+
+  constructor(deps: RuntimeEventLoopWatchdogDependencies = {}) {
+    this.now = deps.now ?? (() => new Date());
+    this.setIntervalFn = deps.setIntervalFn ?? setInterval;
+    this.clearIntervalFn = deps.clearIntervalFn ?? clearInterval;
+    this.intervalMs = deps.intervalMs ?? DEFAULT_INTERVAL_MS;
+    this.warnLagMs = deps.warnLagMs ?? DEFAULT_WARN_LAG_MS;
+    this.errorLagMs = deps.errorLagMs ?? DEFAULT_ERROR_LAG_MS;
+  }
+
+  start(): void {
+    if (this.timer != null) {
+      logger.debug("event loop watchdog start skipped because it is already running");
+      return;
+    }
+
+    this.expectedNextTickAt = new Date(this.now().getTime() + this.intervalMs);
+    this.timer = this.setIntervalFn(() => this.check(), this.intervalMs);
+    const timerWithUnref = this.timer as { unref?: () => void };
+    if (typeof timerWithUnref.unref === "function") {
+      timerWithUnref.unref();
+    }
+
+    logger.info("event loop watchdog started", {
+      intervalMs: this.intervalMs,
+      warnLagMs: this.warnLagMs,
+      errorLagMs: this.errorLagMs,
+      expectedNextTickAt: this.expectedNextTickAt.toISOString(),
+    });
+  }
+
+  stop(): void {
+    if (this.timer == null) {
+      logger.debug("event loop watchdog stop skipped because it is already idle");
+      return;
+    }
+
+    this.clearIntervalFn(this.timer);
+    this.timer = null;
+    this.expectedNextTickAt = null;
+    logger.info("event loop watchdog stopped");
+  }
+
+  status(): RuntimeEventLoopWatchdogStatus {
+    return {
+      started: this.timer != null,
+      intervalMs: this.intervalMs,
+      warnLagMs: this.warnLagMs,
+      errorLagMs: this.errorLagMs,
+      expectedNextTickAt: this.expectedNextTickAt?.toISOString() ?? null,
+    };
+  }
+
+  private check(): void {
+    const actual = this.now();
+    const expected = this.expectedNextTickAt;
+    const lagMs = expected == null ? 0 : actual.getTime() - expected.getTime();
+    this.expectedNextTickAt = new Date(actual.getTime() + this.intervalMs);
+
+    if (lagMs >= this.errorLagMs) {
+      logger.error("event loop lag exceeded error threshold", {
+        lagMs,
+        actualTickAt: actual.toISOString(),
+        expectedTickAt: expected?.toISOString() ?? null,
+        nextExpectedTickAt: this.expectedNextTickAt.toISOString(),
+      });
+      return;
+    }
+
+    if (lagMs >= this.warnLagMs) {
+      logger.warn("event loop lag exceeded warning threshold", {
+        lagMs,
+        actualTickAt: actual.toISOString(),
+        expectedTickAt: expected?.toISOString() ?? null,
+        nextExpectedTickAt: this.expectedNextTickAt.toISOString(),
+      });
+    }
+  }
+}

--- a/src/runtime/minute-heartbeat.ts
+++ b/src/runtime/minute-heartbeat.ts
@@ -16,6 +16,7 @@ export interface MinuteHeartbeatDependencies {
 export interface MinuteHeartbeatStatus {
   started: boolean;
   subscriberCount: number;
+  nextTimerFireAt: string | null;
 }
 
 export class MinuteHeartbeat {
@@ -26,6 +27,7 @@ export class MinuteHeartbeat {
 
   private started = false;
   private timer: ReturnType<typeof setTimeout> | null = null;
+  private nextTimerFireAt: Date | null = null;
   private readonly listeners = new Map<string, MinuteHeartbeatListener>();
 
   constructor(deps: MinuteHeartbeatDependencies = {}) {
@@ -78,6 +80,7 @@ export class MinuteHeartbeat {
     if (this.timer != null) {
       this.clearTimeoutFn(this.timer);
       this.timer = null;
+      this.nextTimerFireAt = null;
     }
 
     logger.info("minute heartbeat stopped", {
@@ -89,6 +92,7 @@ export class MinuteHeartbeat {
     return {
       started: this.started,
       subscriberCount: this.listeners.size,
+      nextTimerFireAt: this.nextTimerFireAt?.toISOString() ?? null,
     };
   }
 
@@ -104,17 +108,22 @@ export class MinuteHeartbeat {
     const nowMs = this.now().getTime();
     const remainder = nowMs % this.intervalMs;
     const delayMs = remainder === 0 ? this.intervalMs : this.intervalMs - remainder;
+    const nextTimerFireAt = new Date(nowMs + delayMs);
 
     if (this.timer != null) {
       this.clearTimeoutFn(this.timer);
       this.timer = null;
+      this.nextTimerFireAt = null;
     }
 
+    this.nextTimerFireAt = nextTimerFireAt;
     logger.debug("scheduled next minute heartbeat tick", {
       delayMs,
+      nextTimerFireAt: nextTimerFireAt.toISOString(),
     });
     this.timer = this.setTimeoutFn(() => {
       this.timer = null;
+      this.nextTimerFireAt = null;
       this.dispatchTick(resolveHeartbeatTickAt(this.now()));
       if (this.started) {
         this.scheduleNextTick();

--- a/src/runtime/session-lane.ts
+++ b/src/runtime/session-lane.ts
@@ -108,8 +108,9 @@ export class InMemorySessionLane {
         ...(input.createdAt == null ? {} : { createdAt: input.createdAt }),
       });
       if (steered) {
-        logger.debug("queued inbound message behind active run", {
+        logger.debug("queued inbound message behind active session run", {
           sessionId: input.sessionId,
+          scenario: input.scenario,
           content: truncateLogValue(input.content),
           persistedImageCount: normalized.userPayload?.images?.length ?? 0,
           runtimeImageCount: normalized.runtimeImages?.length ?? 0,
@@ -151,10 +152,32 @@ export class InMemorySessionLane {
           ? {}
           : { afterToolResultHook: input.afterToolResultHook }),
       })
+      .then((run) => {
+        logger.debug("session lane run resolved", {
+          sessionId: input.sessionId,
+          scenario: input.scenario,
+          runId: run.runId,
+          appendedMessages: run.appendedMessageIds.length,
+          toolExecutions: run.toolExecutions,
+          stopSignalReason: run.stopSignal?.reason ?? null,
+        });
+        return run;
+      })
+      .catch((error: unknown) => {
+        logger.error("session lane run rejected", {
+          sessionId: input.sessionId,
+          scenario: input.scenario,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      })
       .finally(() => {
         if (this.activeRun === runPromise) {
           this.activeRun = null;
-          logger.debug("session run became idle", { sessionId: input.sessionId });
+          logger.debug("session run became idle", {
+            sessionId: input.sessionId,
+            scenario: input.scenario,
+          });
         }
       });
 

--- a/src/shared/capped-text.ts
+++ b/src/shared/capped-text.ts
@@ -1,0 +1,35 @@
+export interface CappedTextTailOptions {
+  maxChars: number;
+  truncationPrefix?: string;
+}
+
+const DEFAULT_TRUNCATION_PREFIX = "...[truncated]\n";
+
+export function appendCappedTextTail(
+  existing: string,
+  next: string,
+  options: CappedTextTailOptions,
+): string {
+  if (next.length === 0) {
+    return capTextTail(existing, options);
+  }
+
+  const prefix = options.truncationPrefix ?? DEFAULT_TRUNCATION_PREFIX;
+  const wasTruncated = existing.startsWith(prefix);
+  const normalizedExisting = wasTruncated ? existing.slice(prefix.length) : existing;
+  const combined = `${normalizedExisting}${next}`;
+  if (wasTruncated && combined.length <= Math.max(0, options.maxChars)) {
+    return `${prefix}${combined}`;
+  }
+  return capTextTail(combined, options);
+}
+
+export function capTextTail(value: string, options: CappedTextTailOptions): string {
+  const maxChars = Math.max(0, options.maxChars);
+  if (value.length <= maxChars) {
+    return value;
+  }
+
+  const prefix = options.truncationPrefix ?? DEFAULT_TRUNCATION_PREFIX;
+  return `${prefix}${value.slice(-maxChars)}`;
+}

--- a/src/tasks/runner.ts
+++ b/src/tasks/runner.ts
@@ -85,6 +85,8 @@ export class TaskExecutionRunner {
     created: CreatedTaskExecution;
     createdAt?: Date;
   }): Promise<TaskExecutionRunResult> {
+    const startedAtMs = Date.now();
+    let terminalStatus: TaskExecutionRunResult["status"] | "unknown" = "unknown";
     logger.info("starting task execution", {
       taskRunId: input.created.taskRun.id,
       executionSessionId: input.created.executionSession.id,
@@ -106,6 +108,7 @@ export class TaskExecutionRunner {
         });
 
         if (started.status === "failed") {
+          terminalStatus = "failed";
           return started;
         }
 
@@ -119,11 +122,13 @@ export class TaskExecutionRunner {
 
         const completion = extractTaskCompletionFromRun(started.run);
         if (completion != null) {
-          return this.settleTaskCompletion({
+          const result = this.settleTaskCompletion({
             taskRunId: input.created.taskRun.id,
             started,
             completion,
           });
+          terminalStatus = result.status;
+          return result;
         }
 
         if (pass < this.maxSupervisorPasses) {
@@ -150,6 +155,7 @@ export class TaskExecutionRunner {
         maxSupervisorPasses: this.maxSupervisorPasses,
       });
 
+      terminalStatus = "failed";
       return {
         status: "failed",
         settled,
@@ -172,6 +178,7 @@ export class TaskExecutionRunner {
           error: normalized.message,
         });
 
+        terminalStatus = "cancelled";
         return {
           status: "cancelled",
           settled,
@@ -192,11 +199,20 @@ export class TaskExecutionRunner {
         error: normalized.message,
       });
 
+      terminalStatus = "failed";
       return {
         status: "failed",
         settled,
         errorMessage: normalized.message,
       };
+    } finally {
+      logger.info("task execution runner finished", {
+        taskRunId: input.created.taskRun.id,
+        executionSessionId: input.created.executionSession.id,
+        cronJobId: input.created.taskRun.cronJobId,
+        terminalStatus,
+        durationMs: Date.now() - startedAtMs,
+      });
     }
   }
 

--- a/tests/channels/lark/outbound-task-threads.test.ts
+++ b/tests/channels/lark/outbound-task-threads.test.ts
@@ -323,6 +323,143 @@ describe("lark outbound runtime task threads", () => {
     expect(updatedTaskCard.header?.template).toBe("green");
   });
 
+  test("does not spin when task transcript delivery waits for an in-flight task status card", async () => {
+    vi.useFakeTimers();
+    handle = await createTestDatabase(import.meta.url);
+    handle.storage.sqlite.exec(`
+      INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+      VALUES ('ci_lark_default', 'lark', 'default', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+      VALUES ('conv_1', 'ci_lark_default', 'oc_chat_1', 'dm', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+      VALUES ('branch_1', 'conv_1', 'dm_main', 'main', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO agents (id, conversation_id, main_agent_id, kind, created_at)
+      VALUES ('agent_1', 'conv_1', NULL, 'main', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO sessions (id, conversation_id, branch_id, owner_agent_id, purpose, status, created_at, updated_at)
+      VALUES ('sess_task', 'conv_1', 'branch_1', 'agent_1', 'task', 'active', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO cron_jobs (
+        id, owner_agent_id, target_conversation_id, target_branch_id, name, schedule_kind, schedule_value,
+        payload_json, created_at, updated_at
+      )
+      VALUES (
+        'cron_1', 'agent_1', 'conv_1', 'branch_1', '日报汇总', 'cron', '0 9 * * *',
+        '{}', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z'
+      );
+
+      INSERT INTO task_runs (
+        id, run_type, owner_agent_id, conversation_id, branch_id, cron_job_id, execution_session_id,
+        status, priority, attempt, description, started_at
+      )
+      VALUES (
+        'task_1', 'cron', 'agent_1', 'conv_1', 'branch_1', 'cron_1', 'sess_task',
+        'running', 0, 1, '日报汇总执行', '2026-03-28T00:00:00.000Z'
+      );
+    `);
+
+    new ChannelSurfacesRepo(handle.storage.db).upsert({
+      id: "surface_1",
+      channelType: "lark",
+      channelInstallationId: "default",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      surfaceKey: "chat:oc_chat_1",
+      surfaceObjectJson: JSON.stringify({ chat_id: "oc_chat_1" }),
+    });
+
+    const createCard = vi.fn(() => new Promise<Record<string, unknown>>(() => {}));
+    const createMessage = vi.fn(async (_input: unknown) => ({
+      data: {
+        message_id: "om_task_card_1",
+        open_message_id: "om_task_open_1",
+      },
+    }));
+    const reply = vi.fn(async (_input: unknown) => ({
+      data: {
+        message_id: "om_task_thread_card_1",
+        open_message_id: "om_task_thread_open_1",
+      },
+    }));
+    const bus = new RuntimeEventBus<OrchestratedOutboundEventEnvelope>();
+    const runtime = createLarkOutboundRuntime({
+      storage: handle.storage.db,
+      outboundEventBus: bus,
+      clients: {
+        getOrCreate: () =>
+          ({
+            sdk: {
+              cardkit: {
+                v1: {
+                  card: {
+                    create: createCard,
+                    update: vi.fn(async (_input: unknown) => ({})),
+                  },
+                  cardElement: {
+                    content: vi.fn(async (_input: unknown) => ({})),
+                  },
+                },
+              },
+              im: {
+                message: {
+                  create: createMessage,
+                  reply,
+                },
+              },
+            },
+          }) as never,
+      },
+    });
+
+    runtime.start();
+
+    bus.publish(
+      makeTaskEnvelope({
+        type: "task_run_started",
+        taskRunId: "task_1",
+        runType: "cron",
+        status: "running",
+        startedAt: "2026-03-28T00:00:00.000Z",
+        initiatorSessionId: null,
+        parentRunId: null,
+        cronJobId: "cron_1",
+        executionSessionId: "sess_task",
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(createCard).toHaveBeenCalledOnce();
+    expect(createMessage).not.toHaveBeenCalled();
+
+    bus.publish(
+      makeTaskRuntimeEnvelope({
+        type: "assistant_message_started",
+        eventId: "evt_task_wait_1",
+        createdAt: "2026-03-28T00:00:01.000Z",
+        sessionId: "sess_task",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_task_1",
+        turn: 1,
+        messageId: "msg_task_1",
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(createCard).toHaveBeenCalledOnce();
+    expect(createMessage).not.toHaveBeenCalled();
+    expect(reply).not.toHaveBeenCalled();
+
+    await runtime.shutdown();
+  });
+
   test("creates a standalone task status card for a fresh cron run and does not reuse an older task thread", async () => {
     vi.useFakeTimers();
     handle = await createTestDatabase(import.meta.url);

--- a/tests/channels/lark/outbound.test.ts
+++ b/tests/channels/lark/outbound.test.ts
@@ -3575,7 +3575,7 @@ describe("lark outbound runtime", () => {
       }),
     );
 
-    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(0);
     await Promise.resolve();
 
     expect(updateCard).toHaveBeenCalledOnce();

--- a/tests/channels/lark/run-state.test.ts
+++ b/tests/channels/lark/run-state.test.ts
@@ -10,6 +10,7 @@ import {
 } from "@/src/channels/lark/render.js";
 import {
   LARK_ASSISTANT_PLACEHOLDER_TEXT,
+  LARK_REASONING_STATE_MAX_CHARS,
   markLarkRunApprovalResolved,
   markLarkRunAwaitingApproval,
   reduceLarkRunState,
@@ -435,6 +436,48 @@ describe("lark run state", () => {
       "tool_sequence",
       "assistant_text",
     ]);
+  });
+
+  test("caps streamed reasoning state to a bounded tail", () => {
+    let state = reduceLarkRunState(
+      null,
+      makeEnvelope({
+        type: "assistant_message_started",
+        eventId: "evt_reasoning_1",
+        createdAt: "2026-03-28T00:00:00.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        messageId: "msg_1",
+      }),
+    );
+
+    for (let index = 0; index < 40; index += 1) {
+      state = reduceLarkRunState(
+        state,
+        makeEnvelope({
+          type: "assistant_reasoning_delta",
+          eventId: `evt_reasoning_${index + 2}`,
+          createdAt: "2026-03-28T00:00:01.000Z",
+          sessionId: "sess_1",
+          conversationId: "conv_1",
+          branchId: "branch_1",
+          runId: "run_1",
+          turn: 1,
+          messageId: "msg_1",
+          delta: `${String(index).padStart(2, "0")}:${"x".repeat(500)}`,
+        }),
+      );
+    }
+
+    expect(state.reasoning.content.length).toBeLessThanOrEqual(
+      LARK_REASONING_STATE_MAX_CHARS + "...[earlier reasoning truncated]\n".length,
+    );
+    expect(state.reasoning.content).toContain("...[earlier reasoning truncated]\n");
+    expect(state.reasoning.content).toContain("39:");
+    expect(state.reasoning.content).not.toContain("00:");
   });
 
   test("does not split a tool sequence on assistant turns with no visible text", () => {

--- a/tests/orchestration/agent-manager.test.ts
+++ b/tests/orchestration/agent-manager.test.ts
@@ -64,6 +64,7 @@ async function withHandle(fn: (handle: TestDatabaseHandle) => Promise<void>): Pr
 }
 
 async function flushMicrotasks(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
   await Promise.resolve();
   await Promise.resolve();
 }

--- a/tests/runtime/event-bus.test.ts
+++ b/tests/runtime/event-bus.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, test, vi } from "vitest";
 
 import { RuntimeEventBus } from "@/src/runtime/event-bus.js";
 
-async function flushMicrotasks(): Promise<void> {
-  await Promise.resolve();
-  await Promise.resolve();
+async function flushRuntimeEvents(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
 }
 
 describe("RuntimeEventBus", () => {
@@ -16,7 +17,7 @@ describe("RuntimeEventBus", () => {
     bus.publish({ id: "evt_1" });
 
     expect(listener).not.toHaveBeenCalled();
-    await flushMicrotasks();
+    await flushRuntimeEvents();
     expect(listener).toHaveBeenCalledExactlyOnceWith({ id: "evt_1" });
   });
 
@@ -28,7 +29,7 @@ describe("RuntimeEventBus", () => {
     unsubscribe();
     bus.publish({ id: "evt_2" });
 
-    await flushMicrotasks();
+    await flushRuntimeEvents();
     expect(listener).not.toHaveBeenCalled();
   });
 });

--- a/tests/runtime/minute-heartbeat.test.ts
+++ b/tests/runtime/minute-heartbeat.test.ts
@@ -49,6 +49,7 @@ describe("minute heartbeat", () => {
     expect(heartbeat.status()).toEqual({
       started: false,
       subscriberCount: 1,
+      nextTimerFireAt: null,
     });
   });
 });


### PR DESCRIPTION
## Summary
- prevent Lark outbound task transcript/approval delivery from self-rescheduling in a tight loop while waiting for the standalone task status card
- reduce runtime starvation risk by yielding during heavy LLM stream consumption, moving event-bus dispatch off microtasks, and capping/batching reasoning deltas
- add low-noise observability for runtime health, event loop lag, heartbeat status, task execution settlement, and regression coverage for the Lark flush loop

## Tests
- pnpm preflight