### PR TITLE
POK-41: Expose current running runtime status

### DIFF
--- a/skills/system-observe/SKILL.md
+++ b/skills/system-observe/SKILL.md
@@ -10,7 +10,7 @@ Use this skill to inspect pokoclaw itself.
 
 ## Channels
 
-- Live runtime status: in-memory state for active runs plus retained snapshots for specific finished runs that still remain in process memory. Use `get_runtime_status` first when you need to know whether something is actively running right now, whether a just-finished run is still inspectable in memory, or whether the latest LLM request is waiting for first token vs already streaming vs already finished.
+- Live runtime status: Main Agent only, global current-running state across active runs, background tasks, cron task runs, and suspect durable rows that still claim to be running without a matching live run. Use `get_runtime_status` first when you need to know what is actively running right now. Use its `runId` form to inspect one low-level run, including a retained just-finished snapshot when still available in process memory.
 - System database: durable facts such as sessions, messages, task runs, cron jobs, approvals, permission grants, and delegated approval history.
 - Runtime log: host-side operational evidence such as failures, routing decisions, retries, crashes, and subsystem errors.
 - Source code and references: authoritative schema definitions and implementation behavior.
@@ -41,8 +41,10 @@ Choose one or more channels based on the question. Do not force a fixed order fo
 
 ## Working rules
 
-- For a question about a run that may still be active now, start with `get_runtime_status` before querying the DB.
-- If `get_runtime_status` says a run is not present in live memory, treat that as "not currently active here and no retained in-memory snapshot was found" rather than proof of success; then use the DB to determine whether it completed, failed, or was cancelled.
+- For a question about what is running now, start with `get_runtime_status` before querying the DB.
+- In the default `get_runtime_status` result, `runningWork` is the current-running main view. Do not treat completed, failed, cancelled, or not-yet-scheduled work as missing evidence; query the DB/logs only when the user asks for history or cause.
+- If `get_runtime_status` returns `suspectRunningTaskRuns` or `suspectRunningCronJobs`, treat those as explicit inconsistency signals: durable state still says running, but the matching live run/current task linkage is absent.
+- If the `runId` form says a run is not present in live memory, treat that as "not currently active here and no retained in-memory snapshot was found" rather than proof of success; then use the DB to determine whether it completed, failed, or was cancelled.
 - If the answer depends on live in-memory state that `get_runtime_status` does not expose, say that clearly and do not guess.
 - Adapt an existing query recipe before inventing a new exploratory query.
 - Delegated approval investigation uses the same DB and log channels; start from the approval recipes and approval log hints in the references.

--- a/skills/system-observe/references/runtime-status.md
+++ b/skills/system-observe/references/runtime-status.md
@@ -1,33 +1,73 @@
 # System Observe Runtime Status Reference
 
-Use this reference when the question is specifically about the live in-memory `get_runtime_status` payload.
+Use this reference when the question is specifically about the `get_runtime_status` payload.
 
 ## What this tool is for
 
-`get_runtime_status` is the live in-memory view for current runtime diagnosis.
+`get_runtime_status` is the Main Agent's global current-running runtime view.
+Its default result combines live in-memory run observability with durable task and cron ownership facts from storage.
 
 Use it to answer questions like:
 
-- Is a run still active right now?
-- Is the run currently in model execution, tool execution, or approval wait?
+- What is actively running anywhere in the system right now?
+- Which agent owns each active run, background task, or cron task run?
+- Is a currently running item in model execution, tool execution, or approval wait?
+- Is a durable task or cron row still marked running even though no matching live run is present?
 - Has the run already produced any response in earlier requests?
 - Is the latest request still waiting for first token, already streaming, or already finished?
 - Is a just-finished run still retained in memory by `runId`?
 
 This tool is not a durable history source.
-If the run is absent from live memory, use the database and logs next.
+The default result intentionally answers "what is running now"; it does not list completed, failed, cancelled, or not-yet-scheduled work.
+If you need history, completion details, or failure causes, use the database and logs next.
 
-This tool only exposes the live in-memory fields that runtime control currently publishes.
-Other in-memory state may still exist internally but remain unavailable through this tool.
+This tool only exposes live run fields that runtime control currently publishes plus selected durable ownership metadata.
+Other runtime state may still exist internally but remain unavailable through this tool.
 If your conclusion depends on live state that is not exposed here, say that clearly and use the database, logs, or source inspection instead of guessing.
+
+SubAgents should not receive this tool. Cross-agent and whole-system runtime diagnosis is a Main Agent responsibility.
 
 ## Return shape overview
 
-When inspecting one run, read the payload in three layers, from broadest to most specific.
+### Default call
+
+Calling `get_runtime_status` without arguments returns:
+
+- `now`
+- `scope = "global_current_running"`
+- `runningWork`: active live runs enriched with ownership metadata
+- `suspectRunningTaskRuns`: `task_runs.status = 'running'` rows whose execution session is absent from current live runs
+- `suspectRunningCronJobs`: `cron_jobs.running_at IS NOT NULL` rows without a matching running task run/current representation
+
+Each `runningWork` item contains:
+
+- `kind`: one of `main_chat`, `subagent_chat`, `approval`, `background_task`, `cron_task`, `task_run`, `run`
+- `runId`
+- `liveRun`: the low-level live run observability snapshot
+- `ownerAgent`: owner agent identity when known
+- `session`: execution session identity when known
+- `taskRun`: durable task run metadata when the run belongs to a task
+- `cronJob`: durable cron job metadata when the run belongs to a cron job
+- `backgroundTask`: background task preview when the task input has the background task payload
+
+### `runId` call
+
+Calling `get_runtime_status` with `runId` returns one enriched `run` item when that low-level run is present in live memory or retained memory:
+
+- `now`
+- `found = true`
+- `run`: the same enriched work item shape used in `runningWork`
+
+If not found, the tool returns the runtime-control not-found payload.
+Use DB/log inspection to determine whether it completed, failed, cancelled, or disappeared after a process restart.
+
+## Live run shape
+
+When inspecting `runningWork[].liveRun` or `run.liveRun`, read the payload in three layers, from broadest to most specific.
 
 ### 1. Run-level state
 
-Top-level fields describe the overall run:
+`liveRun` fields describe the overall low-level run:
 
 - `runId`, `sessionId`, `conversationId`, `branchId`, `scenario`
 - `phase`
@@ -38,7 +78,7 @@ Top-level fields describe the overall run:
 
 ### 2. `latestRequest`
 
-`latestRequest` describes the newest LLM request known for this run:
+`liveRun.latestRequest` describes the newest LLM request known for this run:
 
 - `sequence`
 - `status`
@@ -50,7 +90,7 @@ Top-level fields describe the overall run:
 
 ### 3. `responseSummary`
 
-`responseSummary` summarizes response history across the run so far:
+`liveRun.responseSummary` summarizes response history across the run so far:
 
 - `requestCount`
 - `respondedRequestCount`
@@ -111,55 +151,118 @@ That means the latest model request already ended and the run has moved on to to
 
 ## Examples
 
-### Example 1: earlier requests responded, latest request still waiting for first token
+### Example 1: default global current-running result
 
 ```json
 {
-  "phase": "running",
-  "latestRequest": {
-    "sequence": 4,
-    "status": "waiting_first_token",
-    "startedAt": "2026-04-04T00:00:10.000Z",
-    "ttftMs": null
-  },
-  "responseSummary": {
-    "requestCount": 4,
-    "respondedRequestCount": 3,
-    "hasAnyResponse": true,
-    "lastRespondedRequestSequence": 3,
-    "lastRespondedRequestTtftMs": 1200
+  "scope": "global_current_running",
+  "runningWork": [
+    {
+      "kind": "background_task",
+      "runId": "run_bg",
+      "ownerAgent": { "id": "agent_sub", "kind": "sub" },
+      "taskRun": { "id": "task_bg", "status": "running" },
+      "backgroundTask": { "taskDefinitionPreview": "Scan the repository." },
+      "liveRun": {
+        "phase": "running",
+        "latestRequest": { "status": "waiting_first_token", "ttftMs": null }
+      }
+    },
+    {
+      "kind": "cron_task",
+      "runId": "run_cron",
+      "taskRun": { "id": "task_cron", "status": "running", "cronJobId": "cron_daily" },
+      "cronJob": { "id": "cron_daily", "runningAt": "2026-04-04T00:00:00.000Z" },
+      "liveRun": { "phase": "tool_running", "activeToolName": "bash" }
+    }
+  ],
+  "suspectRunningTaskRuns": [],
+  "suspectRunningCronJobs": []
+}
+```
+
+Correct reading: these are current-running items across the runtime, not just the current conversation.
+
+### Example 2: durable row still says running, but no live run is present
+
+```json
+{
+  "scope": "global_current_running",
+  "runningWork": [],
+  "suspectRunningTaskRuns": [
+    {
+      "reason": "running_task_run_without_live_run",
+      "taskRun": { "id": "task_orphan", "status": "running" }
+    }
+  ],
+  "suspectRunningCronJobs": [
+    {
+      "reason": "running_cron_job_without_running_task_run",
+      "cronJob": { "id": "cron_orphan", "runningAt": "2026-04-04T00:01:00.000Z" }
+    }
+  ]
+}
+```
+
+Correct reading: this is not ordinary active work. It is an observable inconsistency that should be investigated through DB/logs.
+
+### Example 3: earlier requests responded, latest request still waiting for first token
+
+```json
+{
+  "liveRun": {
+    "phase": "running",
+    "latestRequest": {
+      "sequence": 4,
+      "status": "waiting_first_token",
+      "startedAt": "2026-04-04T00:00:10.000Z",
+      "ttftMs": null
+    },
+    "responseSummary": {
+      "requestCount": 4,
+      "respondedRequestCount": 3,
+      "hasAnyResponse": true,
+      "lastRespondedRequestSequence": 3,
+      "lastRespondedRequestTtftMs": 1200
+    }
   }
 }
 ```
 
 Correct reading: the newest request is still waiting for first token, but the run already produced responses in earlier requests.
 
-### Example 2: latest request finished, run is currently executing a tool
+### Example 4: latest request finished, run is currently executing a tool
 
 ```json
 {
-  "phase": "tool_running",
-  "latestRequest": {
-    "sequence": 2,
-    "status": "finished",
-    "ttftMs": 800
+  "liveRun": {
+    "phase": "tool_running",
+    "latestRequest": {
+      "sequence": 2,
+      "status": "finished",
+      "ttftMs": 800
+    },
+    "activeToolName": "grep"
   },
-  "activeToolName": "grep"
 }
 ```
 
 Correct reading: the model request already ended and the run is now spending time in tool execution.
 
-### Example 3: finished run still available by `runId`
+### Example 5: finished run still available by `runId`
 
 ```json
 {
   "found": true,
   "run": {
-    "phase": "completed",
-    "latestRequest": {
-      "status": "finished",
-      "ttftMs": 950
+    "kind": "main_chat",
+    "runId": "run_done",
+    "liveRun": {
+      "phase": "completed",
+      "latestRequest": {
+        "status": "finished",
+        "ttftMs": 950
+      }
     }
   }
 }
@@ -167,15 +270,17 @@ Correct reading: the model request already ended and the run is now spending tim
 
 Correct reading: the run is no longer active, but its retained in-memory snapshot is still available.
 
-### Example 4: run failed after the latest request had already finished
+### Example 6: run failed after the latest request had already finished
 
 ```json
 {
-  "phase": "failed",
-  "latestRequest": {
-    "sequence": 2,
-    "status": "finished",
-    "ttftMs": 700
+  "liveRun": {
+    "phase": "failed",
+    "latestRequest": {
+      "sequence": 2,
+      "status": "finished",
+      "ttftMs": 700
+    }
   }
 }
 ```
@@ -184,5 +289,6 @@ Correct reading: the run failed later in orchestration or tool work. Do not rest
 
 ## Notes
 
+- The default result is current-running only.
 - Snapshots are retained in memory while they remain in runtime control after the run leaves the active list. A completed, failed, or cancelled run may still be accessible by `runId` for immediate diagnosis even though it is no longer active.
-- This tool only exposes the in-memory fields that runtime control currently publishes. Other live state may exist internally but is not accessible here.
+- This tool only exposes the live run fields that runtime control currently publishes plus selected durable owner/task/cron metadata. Other live state may exist internally but is not accessible here.

--- a/src/agent/session-policy.ts
+++ b/src/agent/session-policy.ts
@@ -31,6 +31,10 @@ export function isToolAllowedForSession(input: {
     return input.purpose === "chat" && input.agentKind === "main";
   }
 
+  if (input.toolName === "get_runtime_status") {
+    return input.purpose === "chat" && input.agentKind === "main";
+  }
+
   if (input.toolName === "schedule_task") {
     return input.purpose === "chat" && (input.agentKind === "main" || input.agentKind === "sub");
   }

--- a/src/runtime/current-running-status.ts
+++ b/src/runtime/current-running-status.ts
@@ -1,0 +1,346 @@
+import { resolveSessionLiveState } from "@/src/runtime/live-state.js";
+import type { RunLiveObservabilitySnapshot } from "@/src/runtime/run-observability.js";
+import type { StorageDb } from "@/src/storage/db/client.js";
+import { AgentsRepo } from "@/src/storage/repos/agents.repo.js";
+import { CronJobsRepo } from "@/src/storage/repos/cron-jobs.repo.js";
+import { TaskRunsRepo } from "@/src/storage/repos/task-runs.repo.js";
+import type { Agent, CronJob, Session, TaskRun } from "@/src/storage/schema/types.js";
+import { parseBackgroundTaskPayload } from "@/src/tasks/background-task-payload.js";
+
+const TASK_PREVIEW_CHARS = 240;
+
+export type CurrentRunningWorkKind =
+  | "main_chat"
+  | "subagent_chat"
+  | "approval"
+  | "background_task"
+  | "cron_task"
+  | "task_run"
+  | "run";
+
+export interface CurrentRunningAgentSnapshot {
+  id: string;
+  kind: string;
+  displayName: string | null;
+  mainAgentId: string | null;
+}
+
+export interface CurrentRunningSessionSnapshot {
+  id: string;
+  purpose: string;
+  status: string;
+  conversationId: string;
+  branchId: string;
+  ownerAgentId: string | null;
+}
+
+export interface CurrentRunningTaskRunSnapshot {
+  id: string;
+  runType: string;
+  status: string;
+  description: string | null;
+  startedAt: string;
+  executionSessionId: string | null;
+  initiatorSessionId: string | null;
+  parentRunId: string | null;
+  cronJobId: string | null;
+}
+
+export interface CurrentRunningCronJobSnapshot {
+  id: string;
+  name: string | null;
+  scheduleKind: string;
+  scheduleValue: string;
+  timezone: string | null;
+  runningAt: string | null;
+  nextRunAt: string | null;
+}
+
+export interface CurrentRunningBackgroundTaskSnapshot {
+  taskDefinitionPreview: string;
+}
+
+export interface CurrentRunningWorkItem {
+  kind: CurrentRunningWorkKind;
+  runId: string;
+  liveRun: RunLiveObservabilitySnapshot;
+  ownerAgent: CurrentRunningAgentSnapshot | null;
+  session: CurrentRunningSessionSnapshot | null;
+  taskRun: CurrentRunningTaskRunSnapshot | null;
+  cronJob: CurrentRunningCronJobSnapshot | null;
+  backgroundTask: CurrentRunningBackgroundTaskSnapshot | null;
+}
+
+export interface SuspectRunningTaskRunItem {
+  reason: "running_task_run_without_live_run";
+  ownerAgent: CurrentRunningAgentSnapshot | null;
+  taskRun: CurrentRunningTaskRunSnapshot;
+  cronJob: CurrentRunningCronJobSnapshot | null;
+  backgroundTask: CurrentRunningBackgroundTaskSnapshot | null;
+}
+
+export interface SuspectRunningCronJobItem {
+  reason: "running_cron_job_without_running_task_run";
+  ownerAgent: CurrentRunningAgentSnapshot | null;
+  cronJob: CurrentRunningCronJobSnapshot;
+}
+
+export interface CurrentRunningRuntimeStatusSnapshot {
+  now: string;
+  scope: "global_current_running";
+  runningWork: CurrentRunningWorkItem[];
+  suspectRunningTaskRuns: SuspectRunningTaskRunItem[];
+  suspectRunningCronJobs: SuspectRunningCronJobItem[];
+}
+
+export interface RuntimeRunStatusSnapshot {
+  now: string;
+  found: true;
+  run: CurrentRunningWorkItem;
+}
+
+export function buildCurrentRunningRuntimeStatus(input: {
+  storage: StorageDb;
+  now: string;
+  liveRuns: RunLiveObservabilitySnapshot[];
+}): CurrentRunningRuntimeStatusSnapshot {
+  const repos = createRepos(input.storage);
+  const runningTaskRuns = repos.taskRuns.listRunning();
+  const runningWork = input.liveRuns.map((run) => buildRunningWorkItem({ repos, run }));
+  const liveSessionIds = new Set(input.liveRuns.map((run) => run.sessionId));
+  const representedTaskRunIds = new Set(
+    runningWork.map((item) => item.taskRun?.id).filter((id): id is string => id != null),
+  );
+  const representedCronJobIds = new Set(
+    runningWork.map((item) => item.cronJob?.id).filter((id): id is string => id != null),
+  );
+
+  const suspectRunningTaskRuns = runningTaskRuns
+    .filter((taskRun) => {
+      if (representedTaskRunIds.has(taskRun.id)) {
+        return false;
+      }
+      return taskRun.executionSessionId == null || !liveSessionIds.has(taskRun.executionSessionId);
+    })
+    .map((taskRun) => {
+      const ownerAgent = repos.agents.getById(taskRun.ownerAgentId);
+      const cronJob =
+        taskRun.cronJobId == null
+          ? null
+          : repos.cronJobs.getByIdIncludingDeleted(taskRun.cronJobId);
+      if (cronJob != null) {
+        representedCronJobIds.add(cronJob.id);
+      }
+
+      return {
+        reason: "running_task_run_without_live_run" as const,
+        ownerAgent: toAgentSnapshot(ownerAgent),
+        taskRun: toRequiredTaskRunSnapshot(taskRun),
+        cronJob: toCronJobSnapshot(cronJob),
+        backgroundTask: toBackgroundTaskSnapshot(taskRun),
+      };
+    });
+
+  const runningTaskCronJobIds = new Set(
+    runningTaskRuns.map((taskRun) => taskRun.cronJobId).filter((id): id is string => id != null),
+  );
+  const suspectRunningCronJobs = repos.cronJobs
+    .listRunning()
+    .filter((cronJob) => {
+      if (representedCronJobIds.has(cronJob.id)) {
+        return false;
+      }
+      return !runningTaskCronJobIds.has(cronJob.id);
+    })
+    .map((cronJob) => ({
+      reason: "running_cron_job_without_running_task_run" as const,
+      ownerAgent: toAgentSnapshot(repos.agents.getById(cronJob.ownerAgentId)),
+      cronJob: toRequiredCronJobSnapshot(cronJob),
+    }));
+
+  return {
+    now: input.now,
+    scope: "global_current_running",
+    runningWork,
+    suspectRunningTaskRuns,
+    suspectRunningCronJobs,
+  };
+}
+
+export function buildRuntimeRunStatus(input: {
+  storage: StorageDb;
+  now: string;
+  run: RunLiveObservabilitySnapshot;
+}): RuntimeRunStatusSnapshot {
+  return {
+    now: input.now,
+    found: true,
+    run: buildRunningWorkItem({
+      repos: createRepos(input.storage),
+      run: input.run,
+    }),
+  };
+}
+
+function buildRunningWorkItem(input: {
+  repos: RuntimeStatusRepos;
+  run: RunLiveObservabilitySnapshot;
+}): CurrentRunningWorkItem {
+  const live = resolveSessionLiveState({
+    db: input.repos.storage,
+    sessionId: input.run.sessionId,
+  });
+  const session = live?.session ?? null;
+  const taskRun = live?.taskRun ?? null;
+  const ownerAgent =
+    live?.ownerAgentId == null ? null : input.repos.agents.getById(live.ownerAgentId);
+  const cronJob =
+    taskRun?.cronJobId == null
+      ? null
+      : input.repos.cronJobs.getByIdIncludingDeleted(taskRun.cronJobId);
+  const backgroundTask = taskRun == null ? null : toBackgroundTaskSnapshot(taskRun);
+
+  return {
+    kind: classifyWork({
+      session,
+      ownerAgent,
+      taskRun,
+      cronJob,
+      hasBackgroundTask: backgroundTask != null,
+    }),
+    runId: input.run.runId,
+    liveRun: input.run,
+    ownerAgent: toAgentSnapshot(ownerAgent),
+    session: toSessionSnapshot(session),
+    taskRun: toTaskRunSnapshot(taskRun),
+    cronJob: toCronJobSnapshot(cronJob),
+    backgroundTask,
+  };
+}
+
+interface RuntimeStatusRepos {
+  storage: StorageDb;
+  agents: AgentsRepo;
+  taskRuns: TaskRunsRepo;
+  cronJobs: CronJobsRepo;
+}
+
+function createRepos(storage: StorageDb): RuntimeStatusRepos {
+  return {
+    storage,
+    agents: new AgentsRepo(storage),
+    taskRuns: new TaskRunsRepo(storage),
+    cronJobs: new CronJobsRepo(storage),
+  };
+}
+
+function classifyWork(input: {
+  session: Session | null;
+  ownerAgent: Agent | null;
+  taskRun: TaskRun | null;
+  cronJob: CronJob | null;
+  hasBackgroundTask: boolean;
+}): CurrentRunningWorkKind {
+  if (input.cronJob != null || input.taskRun?.runType === "cron") {
+    return "cron_task";
+  }
+  if (input.hasBackgroundTask) {
+    return "background_task";
+  }
+  if (input.taskRun != null) {
+    return "task_run";
+  }
+  if (input.session?.purpose === "approval") {
+    return "approval";
+  }
+  if (input.session?.purpose === "chat" && input.ownerAgent?.kind === "main") {
+    return "main_chat";
+  }
+  if (input.session?.purpose === "chat" && input.ownerAgent?.kind === "sub") {
+    return "subagent_chat";
+  }
+  return "run";
+}
+
+function toAgentSnapshot(agent: Agent | null): CurrentRunningAgentSnapshot | null {
+  if (agent == null) {
+    return null;
+  }
+  return {
+    id: agent.id,
+    kind: agent.kind,
+    displayName: agent.displayName,
+    mainAgentId: agent.mainAgentId,
+  };
+}
+
+function toSessionSnapshot(session: Session | null): CurrentRunningSessionSnapshot | null {
+  if (session == null) {
+    return null;
+  }
+  return {
+    id: session.id,
+    purpose: session.purpose,
+    status: session.status,
+    conversationId: session.conversationId,
+    branchId: session.branchId,
+    ownerAgentId: session.ownerAgentId,
+  };
+}
+
+function toTaskRunSnapshot(taskRun: TaskRun | null): CurrentRunningTaskRunSnapshot | null {
+  if (taskRun == null) {
+    return null;
+  }
+  return toRequiredTaskRunSnapshot(taskRun);
+}
+
+function toRequiredTaskRunSnapshot(taskRun: TaskRun): CurrentRunningTaskRunSnapshot {
+  return {
+    id: taskRun.id,
+    runType: taskRun.runType,
+    status: taskRun.status,
+    description: taskRun.description,
+    startedAt: taskRun.startedAt,
+    executionSessionId: taskRun.executionSessionId,
+    initiatorSessionId: taskRun.initiatorSessionId,
+    parentRunId: taskRun.parentRunId,
+    cronJobId: taskRun.cronJobId,
+  };
+}
+
+function toCronJobSnapshot(cronJob: CronJob | null): CurrentRunningCronJobSnapshot | null {
+  if (cronJob == null) {
+    return null;
+  }
+  return toRequiredCronJobSnapshot(cronJob);
+}
+
+function toRequiredCronJobSnapshot(cronJob: CronJob): CurrentRunningCronJobSnapshot {
+  return {
+    id: cronJob.id,
+    name: cronJob.name,
+    scheduleKind: cronJob.scheduleKind,
+    scheduleValue: cronJob.scheduleValue,
+    timezone: cronJob.timezone,
+    runningAt: cronJob.runningAt,
+    nextRunAt: cronJob.nextRunAt,
+  };
+}
+
+function toBackgroundTaskSnapshot(taskRun: TaskRun): CurrentRunningBackgroundTaskSnapshot | null {
+  const payload = parseBackgroundTaskPayload(taskRun.inputJson);
+  if (payload == null) {
+    return null;
+  }
+  return {
+    taskDefinitionPreview: truncateText(payload.taskDefinition, TASK_PREVIEW_CHARS),
+  };
+}
+
+function truncateText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) {
+    return value;
+  }
+  return `${value.slice(0, maxChars - 3)}...`;
+}

--- a/src/runtime/current-running-status.ts
+++ b/src/runtime/current-running-status.ts
@@ -104,67 +104,71 @@ export function buildCurrentRunningRuntimeStatus(input: {
   now: string;
   liveRuns: RunLiveObservabilitySnapshot[];
 }): CurrentRunningRuntimeStatusSnapshot {
-  const repos = createRepos(input.storage);
-  const runningTaskRuns = repos.taskRuns.listRunning();
-  const runningWork = input.liveRuns.map((run) => buildRunningWorkItem({ repos, run }));
-  const liveSessionIds = new Set(input.liveRuns.map((run) => run.sessionId));
-  const representedTaskRunIds = new Set(
-    runningWork.map((item) => item.taskRun?.id).filter((id): id is string => id != null),
-  );
-  const representedCronJobIds = new Set(
-    runningWork.map((item) => item.cronJob?.id).filter((id): id is string => id != null),
-  );
+  return input.storage.transaction((tx) => {
+    const repos = createRepos(tx);
+    const runningTaskRuns = repos.taskRuns.listRunning();
+    const runningCronJobs = repos.cronJobs.listRunning();
+    const runningWork = input.liveRuns.map((run) => buildRunningWorkItem({ repos, run }));
+    const liveSessionIds = new Set(input.liveRuns.map((run) => run.sessionId));
+    const representedTaskRunIds = new Set(
+      runningWork.map((item) => item.taskRun?.id).filter((id): id is string => id != null),
+    );
+    const representedCronJobIds = new Set(
+      runningWork.map((item) => item.cronJob?.id).filter((id): id is string => id != null),
+    );
 
-  const suspectRunningTaskRuns = runningTaskRuns
-    .filter((taskRun) => {
-      if (representedTaskRunIds.has(taskRun.id)) {
-        return false;
-      }
-      return taskRun.executionSessionId == null || !liveSessionIds.has(taskRun.executionSessionId);
-    })
-    .map((taskRun) => {
-      const ownerAgent = repos.agents.getById(taskRun.ownerAgentId);
-      const cronJob =
-        taskRun.cronJobId == null
-          ? null
-          : repos.cronJobs.getByIdIncludingDeleted(taskRun.cronJobId);
-      if (cronJob != null) {
-        representedCronJobIds.add(cronJob.id);
-      }
+    const suspectRunningTaskRuns = runningTaskRuns
+      .filter((taskRun) => {
+        if (representedTaskRunIds.has(taskRun.id)) {
+          return false;
+        }
+        return (
+          taskRun.executionSessionId == null || !liveSessionIds.has(taskRun.executionSessionId)
+        );
+      })
+      .map((taskRun) => {
+        const ownerAgent = repos.agents.getById(taskRun.ownerAgentId);
+        const cronJob =
+          taskRun.cronJobId == null
+            ? null
+            : repos.cronJobs.getByIdIncludingDeleted(taskRun.cronJobId);
+        if (cronJob != null) {
+          representedCronJobIds.add(cronJob.id);
+        }
 
-      return {
-        reason: "running_task_run_without_live_run" as const,
-        ownerAgent: toAgentSnapshot(ownerAgent),
-        taskRun: toRequiredTaskRunSnapshot(taskRun),
-        cronJob: toCronJobSnapshot(cronJob),
-        backgroundTask: toBackgroundTaskSnapshot(taskRun),
-      };
-    });
+        return {
+          reason: "running_task_run_without_live_run" as const,
+          ownerAgent: toAgentSnapshot(ownerAgent),
+          taskRun: toRequiredTaskRunSnapshot(taskRun),
+          cronJob: toCronJobSnapshot(cronJob),
+          backgroundTask: toBackgroundTaskSnapshot(taskRun),
+        };
+      });
 
-  const runningTaskCronJobIds = new Set(
-    runningTaskRuns.map((taskRun) => taskRun.cronJobId).filter((id): id is string => id != null),
-  );
-  const suspectRunningCronJobs = repos.cronJobs
-    .listRunning()
-    .filter((cronJob) => {
-      if (representedCronJobIds.has(cronJob.id)) {
-        return false;
-      }
-      return !runningTaskCronJobIds.has(cronJob.id);
-    })
-    .map((cronJob) => ({
-      reason: "running_cron_job_without_running_task_run" as const,
-      ownerAgent: toAgentSnapshot(repos.agents.getById(cronJob.ownerAgentId)),
-      cronJob: toRequiredCronJobSnapshot(cronJob),
-    }));
+    const runningTaskCronJobIds = new Set(
+      runningTaskRuns.map((taskRun) => taskRun.cronJobId).filter((id): id is string => id != null),
+    );
+    const suspectRunningCronJobs = runningCronJobs
+      .filter((cronJob) => {
+        if (representedCronJobIds.has(cronJob.id)) {
+          return false;
+        }
+        return !runningTaskCronJobIds.has(cronJob.id);
+      })
+      .map((cronJob) => ({
+        reason: "running_cron_job_without_running_task_run" as const,
+        ownerAgent: toAgentSnapshot(repos.agents.getById(cronJob.ownerAgentId)),
+        cronJob: toRequiredCronJobSnapshot(cronJob),
+      }));
 
-  return {
-    now: input.now,
-    scope: "global_current_running",
-    runningWork,
-    suspectRunningTaskRuns,
-    suspectRunningCronJobs,
-  };
+    return {
+      now: input.now,
+      scope: "global_current_running",
+      runningWork,
+      suspectRunningTaskRuns,
+      suspectRunningCronJobs,
+    };
+  });
 }
 
 export function buildRuntimeRunStatus(input: {

--- a/src/storage/repos/cron-jobs.repo.ts
+++ b/src/storage/repos/cron-jobs.repo.ts
@@ -161,6 +161,16 @@ export class CronJobsRepo {
       .all();
   }
 
+  listRunning(limit: number = 100): CronJob[] {
+    return this.db
+      .select()
+      .from(cronJobs)
+      .where(and(isNull(cronJobs.deletedAt), isNotNull(cronJobs.runningAt)))
+      .orderBy(asc(cronJobs.runningAt), asc(cronJobs.id))
+      .limit(limit)
+      .all();
+  }
+
   update(input: UpdateCronJobInput): CronJob | null {
     const updatedAt = input.updatedAt ?? new Date();
     const result = this.db

--- a/src/storage/repos/cron-jobs.repo.ts
+++ b/src/storage/repos/cron-jobs.repo.ts
@@ -161,13 +161,12 @@ export class CronJobsRepo {
       .all();
   }
 
-  listRunning(limit: number = 100): CronJob[] {
+  listRunning(): CronJob[] {
     return this.db
       .select()
       .from(cronJobs)
       .where(and(isNull(cronJobs.deletedAt), isNotNull(cronJobs.runningAt)))
       .orderBy(asc(cronJobs.runningAt), asc(cronJobs.id))
-      .limit(limit)
       .all();
   }
 

--- a/src/storage/repos/task-runs.repo.ts
+++ b/src/storage/repos/task-runs.repo.ts
@@ -99,6 +99,16 @@ export class TaskRunsRepo {
       .all();
   }
 
+  listRunning(limit = 100): TaskRun[] {
+    return this.db
+      .select()
+      .from(taskRuns)
+      .where(eq(taskRuns.status, "running"))
+      .orderBy(desc(taskRuns.startedAt), desc(taskRuns.id))
+      .limit(limit)
+      .all();
+  }
+
   listByCronJobId(cronJobId: string, limit = 20): TaskRun[] {
     return this.db
       .select()

--- a/src/storage/repos/task-runs.repo.ts
+++ b/src/storage/repos/task-runs.repo.ts
@@ -99,13 +99,12 @@ export class TaskRunsRepo {
       .all();
   }
 
-  listRunning(limit = 100): TaskRun[] {
+  listRunning(): TaskRun[] {
     return this.db
       .select()
       .from(taskRuns)
       .where(eq(taskRuns.status, "running"))
       .orderBy(desc(taskRuns.startedAt), desc(taskRuns.id))
-      .limit(limit)
       .all();
   }
 

--- a/src/tools/get-runtime-status.ts
+++ b/src/tools/get-runtime-status.ts
@@ -1,13 +1,15 @@
 /**
  * Live runtime status tool.
  *
- * Exposes the in-memory observability view for currently active runs so the
- * main agent can diagnose streaming progress, stalls, tool activity, and
- * approval waits. This intentionally complements, rather than replaces,
- * database and log inspection.
+ * Exposes the main agent's current-running work view by combining in-memory
+ * live run observability with durable task/cron ownership facts.
  */
 import { type Static, Type } from "@sinclair/typebox";
 
+import {
+  buildCurrentRunningRuntimeStatus,
+  buildRuntimeRunStatus,
+} from "@/src/runtime/current-running-status.js";
 import { AgentsRepo } from "@/src/storage/repos/agents.repo.js";
 import { SessionsRepo } from "@/src/storage/repos/sessions.repo.js";
 import { toolInternalError, toolRecoverableError } from "@/src/tools/core/errors.js";
@@ -19,7 +21,7 @@ export const GET_RUNTIME_STATUS_TOOL_SCHEMA = Type.Object(
       Type.String({
         minLength: 1,
         description:
-          "Optional run id to inspect. Omit this field to list all currently active runs in live memory. When runId is provided, the tool can also return a finished/failed/cancelled run snapshot if that run is still retained in memory.",
+          "Optional low-level run id to inspect. Omit this field to list all currently running work across the runtime, enriched with task/cron/background ownership metadata.",
       }),
     ),
   },
@@ -34,7 +36,7 @@ export function createGetRuntimeStatusTool() {
   return defineTool({
     name: "get_runtime_status",
     description:
-      "Read live in-memory runtime status for main-agent diagnosis. By default it returns all currently active runs still present in live memory. If runId is provided, it returns that specific run when present, including a retained finished/failed/cancelled snapshot when still available in memory after the run leaves the active list. The payload separates run-level phase from latest-request status so a null latest-request TTFT only means the current request has not produced a first token yet, not that the whole run never responded.",
+      "Read the main agent's global current-running runtime status. By default it returns every currently running work item across agents, enriched with owner agent, task_run, background_task, and cron_job metadata when available. It also flags durable task/cron rows that still claim to be running without a matching live run. If runId is provided, it inspects that low-level live run and enriches it with the same ownership metadata when present.",
     inputSchema: GET_RUNTIME_STATUS_TOOL_SCHEMA,
     execute(context, args) {
       ensureMainAgentRuntimeCaller(context.sessionId, context.storage);
@@ -45,11 +47,29 @@ export function createGetRuntimeStatusTool() {
         );
       }
 
-      return jsonToolResult(
-        context.runtimeControl.getRuntimeStatus(
-          args.runId == null ? undefined : { runId: args.runId },
-        ),
+      const status = context.runtimeControl.getRuntimeStatus(
+        args.runId == null ? undefined : { runId: args.runId },
       );
+      if ("runs" in status) {
+        return jsonToolResult(
+          buildCurrentRunningRuntimeStatus({
+            storage: context.storage,
+            now: status.now,
+            liveRuns: status.runs,
+          }),
+        );
+      }
+      if (status.found) {
+        return jsonToolResult(
+          buildRuntimeRunStatus({
+            storage: context.storage,
+            now: status.now,
+            run: status.run,
+          }),
+        );
+      }
+
+      return jsonToolResult(status);
     },
   });
 }

--- a/tests/agent/session-policy.test.ts
+++ b/tests/agent/session-policy.test.ts
@@ -3,6 +3,32 @@ import { describe, expect, test } from "vitest";
 import { isToolAllowedForSession } from "@/src/agent/session-policy.js";
 
 describe("session policy", () => {
+  test("allows get_runtime_status only in main chat sessions", () => {
+    expect(
+      isToolAllowedForSession({
+        purpose: "chat",
+        agentKind: "main",
+        toolName: "get_runtime_status",
+      }),
+    ).toBe(true);
+
+    expect(
+      isToolAllowedForSession({
+        purpose: "chat",
+        agentKind: "sub",
+        toolName: "get_runtime_status",
+      }),
+    ).toBe(false);
+
+    expect(
+      isToolAllowedForSession({
+        purpose: "task",
+        agentKind: "main",
+        toolName: "get_runtime_status",
+      }),
+    ).toBe(false);
+  });
+
   test("allows schedule_task only in main or sub chat sessions", () => {
     expect(
       isToolAllowedForSession({

--- a/tests/runtime/current-running-status.test.ts
+++ b/tests/runtime/current-running-status.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, test } from "vitest";
+
+import { buildCurrentRunningRuntimeStatus } from "@/src/runtime/current-running-status.js";
+import {
+  createTestDatabase,
+  destroyTestDatabase,
+  type TestDatabaseHandle,
+} from "@/tests/storage/helpers/test-db.js";
+
+describe("current running runtime status", () => {
+  let handle: TestDatabaseHandle | null = null;
+
+  afterEach(async () => {
+    if (handle != null) {
+      await destroyTestDatabase(handle);
+      handle = null;
+    }
+  });
+
+  test("does not cap durable running consistency checks at 100 rows", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedRuntimeSurface(handle);
+    seedManyRunningTaskRunsAndCronJobs(handle, 101);
+
+    const status = buildCurrentRunningRuntimeStatus({
+      storage: handle.storage.db,
+      now: "2026-04-04T00:00:05.000Z",
+      liveRuns: [],
+    });
+
+    expect(status.suspectRunningTaskRuns).toHaveLength(101);
+    expect(status.suspectRunningCronJobs).toHaveLength(101);
+    expect(status.suspectRunningTaskRuns.map((item) => item.taskRun.id)).toContain("task_101");
+    expect(status.suspectRunningCronJobs.map((item) => item.cronJob.id)).toContain(
+      "orphan_cron_101",
+    );
+    expect(status.suspectRunningCronJobs.map((item) => item.cronJob.id)).not.toContain(
+      "linked_cron_101",
+    );
+  });
+});
+
+function seedRuntimeSurface(handle: TestDatabaseHandle): void {
+  handle.storage.sqlite.exec(`
+    INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+    VALUES ('ci_1', 'lark', 'acct_runtime', '2026-04-04T00:00:00.000Z', '2026-04-04T00:00:00.000Z');
+
+    INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+    VALUES ('conv_1', 'ci_1', 'chat_1', 'dm', '2026-04-04T00:00:00.000Z', '2026-04-04T00:00:00.000Z');
+
+    INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+    VALUES ('branch_1', 'conv_1', 'dm_main', 'main', '2026-04-04T00:00:00.000Z', '2026-04-04T00:00:00.000Z');
+
+    INSERT INTO agents (id, conversation_id, main_agent_id, kind, display_name, created_at)
+    VALUES ('agent_main', 'conv_1', NULL, 'main', 'Main Agent', '2026-04-04T00:00:00.000Z');
+  `);
+}
+
+function seedManyRunningTaskRunsAndCronJobs(handle: TestDatabaseHandle, count: number): void {
+  const linkedCronRows = Array.from({ length: count }, (_, index) => {
+    const n = index + 1;
+    return `(
+      'linked_cron_${n}', 'agent_main', 'conv_1', 'branch_1',
+      'Linked cron ${n}', 'every', '60000', 'Linked cron payload ${n}',
+      '2026-04-04T00:00:00.000Z', '2026-04-04T00:01:00.000Z',
+      '2026-04-04T00:00:00.000Z', '2026-04-04T00:00:00.000Z'
+    )`;
+  }).join(",\n");
+
+  const orphanCronRows = Array.from({ length: count }, (_, index) => {
+    const n = index + 1;
+    return `(
+      'orphan_cron_${n}', 'agent_main', 'conv_1', 'branch_1',
+      'Orphan cron ${n}', 'every', '60000', 'Orphan cron payload ${n}',
+      '2026-04-04T00:00:00.000Z', '2026-04-04T00:01:00.000Z',
+      '2026-04-04T00:00:00.000Z', '2026-04-04T00:00:00.000Z'
+    )`;
+  }).join(",\n");
+
+  const taskRunRows = Array.from({ length: count }, (_, index) => {
+    const n = index + 1;
+    return `(
+      'task_${n}', 'delegate', 'agent_main', 'conv_1', 'branch_1',
+      NULL, 'linked_cron_${n}', NULL, 'running',
+      'Task ${n}', '{"kind":"background_task","version":1,"taskDefinition":"Task ${n}"}',
+      '2026-04-04T00:00:00.000Z'
+    )`;
+  }).join(",\n");
+
+  handle.storage.sqlite.exec(`
+    INSERT INTO cron_jobs (
+      id, owner_agent_id, target_conversation_id, target_branch_id,
+      name, schedule_kind, schedule_value, payload_json, running_at, next_run_at, created_at, updated_at
+    ) VALUES
+      ${linkedCronRows},
+      ${orphanCronRows};
+
+    INSERT INTO task_runs (
+      id, run_type, owner_agent_id, conversation_id, branch_id,
+      initiator_session_id, cron_job_id, execution_session_id, status,
+      description, input_json, started_at
+    ) VALUES
+      ${taskRunRows};
+  `);
+}

--- a/tests/tools/get-runtime-status.test.ts
+++ b/tests/tools/get-runtime-status.test.ts
@@ -97,30 +97,191 @@ describe("get_runtime_status tool", () => {
           type: "json",
           json: {
             now: "2026-04-04T00:00:05.000Z",
-            runs: [
+            scope: "global_current_running",
+            runningWork: [
               expect.objectContaining({
+                kind: "main_chat",
                 runId: "run_1",
-                phase: "tool_running",
-                timeSinceStartMs: 5000,
-                responseSummary: expect.objectContaining({
-                  requestCount: 1,
-                  respondedRequestCount: 1,
-                  hasAnyResponse: true,
-                  lastRespondedRequestTtftMs: 2000,
+                ownerAgent: expect.objectContaining({
+                  id: "agent_main",
+                  kind: "main",
                 }),
-                latestRequest: expect.objectContaining({
-                  status: "finished",
-                  outputChars: 11,
-                  estimatedOutputTokens: 3,
-                  ttftMs: 2000,
-                  timeSinceLastTokenMs: 3000,
+                session: expect.objectContaining({
+                  id: "sess_main",
+                  purpose: "chat",
                 }),
-                activeToolName: "grep",
+                taskRun: null,
+                cronJob: null,
+                backgroundTask: null,
+                liveRun: expect.objectContaining({
+                  runId: "run_1",
+                  phase: "tool_running",
+                  timeSinceStartMs: 5000,
+                  responseSummary: expect.objectContaining({
+                    requestCount: 1,
+                    respondedRequestCount: 1,
+                    hasAnyResponse: true,
+                    lastRespondedRequestTtftMs: 2000,
+                  }),
+                  latestRequest: expect.objectContaining({
+                    status: "finished",
+                    outputChars: 11,
+                    estimatedOutputTokens: 3,
+                    ttftMs: 2000,
+                    timeSinceLastTokenMs: 3000,
+                  }),
+                  activeToolName: "grep",
+                }),
               }),
             ],
+            suspectRunningTaskRuns: [],
+            suspectRunningCronJobs: [],
           },
         },
       ],
+    });
+  });
+
+  test("enriches running background tasks and cron tasks across agents", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedRuntimeWorkFixture(handle);
+
+    const control = new RuntimeControlService(new SessionRunAbortRegistry());
+    control.beginRun({
+      runId: "run_bg",
+      sessionId: "sess_bg_task",
+      conversationId: "conv_sub",
+      branchId: "branch_sub",
+      scenario: "chat",
+    });
+    control.markLlmRequestStarted({
+      runId: "run_bg",
+      assistantMessageId: "msg_bg",
+      at: new Date("2026-04-04T00:00:01.000Z"),
+    });
+    control.beginRun({
+      runId: "run_cron",
+      sessionId: "sess_cron_task",
+      conversationId: "conv_sub",
+      branchId: "branch_sub",
+      scenario: "chat",
+    });
+    control.markToolStarted({
+      runId: "run_cron",
+      toolCallId: "tool_cron",
+      toolName: "bash",
+      at: new Date("2026-04-04T00:00:02.000Z"),
+    });
+
+    const registry = new ToolRegistry();
+    registry.register(createGetRuntimeStatusTool());
+    const result = await registry.execute(
+      "get_runtime_status",
+      {
+        sessionId: "sess_main",
+        conversationId: "conv_main",
+        ownerAgentId: "agent_main",
+        agentKind: "main",
+        securityConfig: DEFAULT_CONFIG.security,
+        storage: handle.storage.db,
+        runtimeControl: {
+          submitApprovalDecision: () => false,
+          getRuntimeStatus: (input) => {
+            const now = new Date("2026-04-04T00:00:05.000Z");
+            if (input?.runId != null) {
+              const run = control.getRunObservability(input.runId, now);
+              return run == null
+                ? {
+                    now: now.toISOString(),
+                    found: false as const,
+                    runId: input.runId,
+                    message: "missing",
+                  }
+                : {
+                    now: now.toISOString(),
+                    found: true as const,
+                    run,
+                  };
+            }
+            return {
+              now: now.toISOString(),
+              runs: control.listActiveRunObservability(now),
+            };
+          },
+        },
+      },
+      {},
+    );
+
+    expect(result.content[0]).toEqual({
+      type: "json",
+      json: {
+        now: "2026-04-04T00:00:05.000Z",
+        scope: "global_current_running",
+        runningWork: expect.arrayContaining([
+          expect.objectContaining({
+            kind: "background_task",
+            runId: "run_bg",
+            ownerAgent: expect.objectContaining({
+              id: "agent_sub",
+              kind: "sub",
+              displayName: "Research SubAgent",
+            }),
+            taskRun: expect.objectContaining({
+              id: "task_bg",
+              runType: "delegate",
+              status: "running",
+            }),
+            backgroundTask: {
+              taskDefinitionPreview: "Scan the repository in the background.",
+            },
+            cronJob: null,
+          }),
+          expect.objectContaining({
+            kind: "cron_task",
+            runId: "run_cron",
+            ownerAgent: expect.objectContaining({
+              id: "agent_sub",
+              kind: "sub",
+            }),
+            taskRun: expect.objectContaining({
+              id: "task_cron",
+              runType: "cron",
+              status: "running",
+              cronJobId: "cron_1",
+            }),
+            cronJob: expect.objectContaining({
+              id: "cron_1",
+              name: "Daily research sweep",
+              scheduleKind: "cron",
+              scheduleValue: "0 9 * * *",
+              runningAt: "2026-04-04T00:00:00.000Z",
+            }),
+            backgroundTask: null,
+            liveRun: expect.objectContaining({
+              activeToolName: "bash",
+            }),
+          }),
+        ]),
+        suspectRunningTaskRuns: [
+          expect.objectContaining({
+            reason: "running_task_run_without_live_run",
+            taskRun: expect.objectContaining({
+              id: "task_orphan",
+              status: "running",
+            }),
+          }),
+        ],
+        suspectRunningCronJobs: [
+          expect.objectContaining({
+            reason: "running_cron_job_without_running_task_run",
+            cronJob: expect.objectContaining({
+              id: "cron_orphan",
+              runningAt: "2026-04-04T00:01:00.000Z",
+            }),
+          }),
+        ],
+      },
     });
   });
 
@@ -201,17 +362,24 @@ describe("get_runtime_status tool", () => {
             now: "2026-04-04T00:00:05.000Z",
             found: true,
             run: expect.objectContaining({
+              kind: "main_chat",
               runId: "run_done",
-              phase: "completed",
-              responseSummary: expect.objectContaining({
-                requestCount: 1,
-                respondedRequestCount: 1,
-                hasAnyResponse: true,
-                lastRespondedRequestTtftMs: 2000,
+              ownerAgent: expect.objectContaining({
+                id: "agent_main",
               }),
-              latestRequest: expect.objectContaining({
-                status: "finished",
-                ttftMs: 2000,
+              liveRun: expect.objectContaining({
+                runId: "run_done",
+                phase: "completed",
+                responseSummary: expect.objectContaining({
+                  requestCount: 1,
+                  respondedRequestCount: 1,
+                  hasAnyResponse: true,
+                  lastRespondedRequestTtftMs: 2000,
+                }),
+                latestRequest: expect.objectContaining({
+                  status: "finished",
+                  ttftMs: 2000,
+                }),
               }),
             }),
           },
@@ -365,5 +533,79 @@ function seedSubagentFixture(handle: TestDatabaseHandle): void {
 
     INSERT INTO sessions (id, conversation_id, branch_id, owner_agent_id, purpose, status, created_at, updated_at)
     VALUES ('sess_sub', 'conv_1', 'branch_1', 'agent_sub', 'chat', 'active', '2026-04-04T00:00:00.000Z', '2026-04-04T00:00:00.000Z');
+  `);
+}
+
+function seedRuntimeWorkFixture(handle: TestDatabaseHandle): void {
+  handle.storage.sqlite.exec(`
+    INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+    VALUES ('ci_1', 'lark', 'acct_runtime', '2026-04-04T00:00:00.000Z', '2026-04-04T00:00:00.000Z');
+
+    INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+    VALUES
+      ('conv_main', 'ci_1', 'chat_main', 'dm', '2026-04-04T00:00:00.000Z', '2026-04-04T00:00:00.000Z'),
+      ('conv_sub', 'ci_1', 'chat_sub', 'group', '2026-04-04T00:00:00.000Z', '2026-04-04T00:00:00.000Z');
+
+    INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+    VALUES
+      ('branch_main', 'conv_main', 'dm_main', 'main', '2026-04-04T00:00:00.000Z', '2026-04-04T00:00:00.000Z'),
+      ('branch_sub', 'conv_sub', 'group_main', 'main', '2026-04-04T00:00:00.000Z', '2026-04-04T00:00:00.000Z');
+
+    INSERT INTO agents (id, conversation_id, main_agent_id, kind, display_name, created_at)
+    VALUES
+      ('agent_main', 'conv_main', NULL, 'main', 'Main Agent', '2026-04-04T00:00:00.000Z'),
+      ('agent_sub', 'conv_sub', 'agent_main', 'sub', 'Research SubAgent', '2026-04-04T00:00:00.000Z');
+
+    INSERT INTO sessions (id, conversation_id, branch_id, owner_agent_id, purpose, status, created_at, updated_at)
+    VALUES
+      ('sess_main', 'conv_main', 'branch_main', 'agent_main', 'chat', 'active', '2026-04-04T00:00:00.000Z', '2026-04-04T00:00:00.000Z'),
+      ('sess_sub_chat', 'conv_sub', 'branch_sub', 'agent_sub', 'chat', 'active', '2026-04-04T00:00:00.000Z', '2026-04-04T00:00:00.000Z'),
+      ('sess_bg_task', 'conv_sub', 'branch_sub', 'agent_sub', 'task', 'active', '2026-04-04T00:00:01.000Z', '2026-04-04T00:00:01.000Z'),
+      ('sess_cron_task', 'conv_sub', 'branch_sub', 'agent_sub', 'task', 'active', '2026-04-04T00:00:02.000Z', '2026-04-04T00:00:02.000Z'),
+      ('sess_orphan_task', 'conv_sub', 'branch_sub', 'agent_sub', 'task', 'active', '2026-04-04T00:00:03.000Z', '2026-04-04T00:00:03.000Z');
+
+    INSERT INTO cron_jobs (
+      id, owner_agent_id, target_conversation_id, target_branch_id,
+      name, schedule_kind, schedule_value, payload_json, running_at, next_run_at, created_at, updated_at
+    ) VALUES
+      (
+        'cron_1', 'agent_sub', 'conv_sub', 'branch_sub',
+        'Daily research sweep', 'cron', '0 9 * * *', 'Summarize research news.',
+        '2026-04-04T00:00:00.000Z', '2026-04-05T01:00:00.000Z',
+        '2026-04-04T00:00:00.000Z', '2026-04-04T00:00:00.000Z'
+      ),
+      (
+        'cron_orphan', 'agent_sub', 'conv_sub', 'branch_sub',
+        'Orphan cron', 'every', '60000', 'Should not be running forever.',
+        '2026-04-04T00:01:00.000Z', '2026-04-04T00:02:00.000Z',
+        '2026-04-04T00:00:00.000Z', '2026-04-04T00:01:00.000Z'
+      );
+
+    INSERT INTO task_runs (
+      id, run_type, owner_agent_id, conversation_id, branch_id,
+      initiator_session_id, cron_job_id, execution_session_id, status,
+      description, input_json, started_at
+    ) VALUES
+      (
+        'task_bg', 'delegate', 'agent_sub', 'conv_sub', 'branch_sub',
+        'sess_sub_chat', NULL, 'sess_bg_task', 'running',
+        'Background repo scan',
+        '{"kind":"background_task","version":1,"taskDefinition":"Scan the repository in the background."}',
+        '2026-04-04T00:00:01.000Z'
+      ),
+      (
+        'task_cron', 'cron', 'agent_sub', 'conv_sub', 'branch_sub',
+        NULL, 'cron_1', 'sess_cron_task', 'running',
+        'Daily cron task',
+        '{"taskDefinition":"Summarize research news."}',
+        '2026-04-04T00:00:02.000Z'
+      ),
+      (
+        'task_orphan', 'delegate', 'agent_sub', 'conv_sub', 'branch_sub',
+        'sess_sub_chat', NULL, 'sess_orphan_task', 'running',
+        'Lost background task',
+        '{"kind":"background_task","version":1,"taskDefinition":"This task has no live run."}',
+        '2026-04-04T00:00:03.000Z'
+      );
   `);
 }


### PR DESCRIPTION
## Summary
- make get_runtime_status default to a global current-running view for the Main Agent
- enrich active runs with owner agent, session, task_run, background task, and cron job metadata
- flag task/cron rows that still claim to be running without matching live runtime state
- hide get_runtime_status from SubAgents via session policy
- update system-observe guidance for the new runtime status contract

## Notes
- /status is intentionally unchanged.
- Per product clarification, the default status view is current-running only; completed/failed/cancelled history remains a DB/log diagnostic path rather than the default runtime status payload.

## Verification
- pnpm preflight

Linear: POK-41