### PR TITLE
POK-42/44: update system observe docs and return scheduled task run ids

### DIFF
--- a/skills/system-observe/SKILL.md
+++ b/skills/system-observe/SKILL.md
@@ -27,8 +27,9 @@ Choose one or more channels based on the question. Do not force a fixed order fo
     - `../../src/storage/schema/tables.ts`
     - `../../src/storage/schema/types.ts`
     - `../../src/storage/migrate/files/0001_init.sql`
-    - `../../src/storage/db/init.ts`
-      This file is only the bootstrap entrypoint now. The schema truth lives in `tables.ts` and `0001_init.sql`.
+    - `../../src/storage/migrate/files/0002_agent_runtime_modes.sql`
+    - `../../src/storage/migrate/files/0003_a2ui_surface_publications.sql`
+      The schema truth lives in `tables.ts` plus the migration SQL files.
   - Only then use `query_system_db` for live schema discovery.
 - If the task involves live runtime status payload semantics for `get_runtime_status`:
   - Read `references/runtime-status.md` first.

--- a/skills/system-observe/references/query-recipes.md
+++ b/skills/system-observe/references/query-recipes.md
@@ -4,6 +4,27 @@ Use these as starting points and adapt them to the concrete IDs or time window y
 
 If the task is about approvals or delegated approval, start from this file before writing custom SQL.
 
+## Agent and SubAgent inventory
+
+Use this instead of guessing a `subagents` table. SubAgents are stored in `agents`.
+
+```sql
+SELECT
+  a.id,
+  a.kind,
+  a.display_name,
+  a.status,
+  a.main_agent_id,
+  a.workdir,
+  c.title AS conversation_title,
+  c.external_chat_id,
+  a.created_at
+FROM agents a
+LEFT JOIN conversations c ON c.id = a.conversation_id
+ORDER BY a.created_at DESC
+LIMIT 50;
+```
+
 ## Recent task runs
 
 ```sql
@@ -23,6 +44,33 @@ SELECT
 FROM task_runs
 ORDER BY started_at DESC
 LIMIT 20;
+```
+
+## Running or problematic task runs with owner agent
+
+Use `task_runs.owner_agent_id`; there is no `task_runs.agent_id`.
+
+```sql
+SELECT
+  tr.id,
+  tr.run_type,
+  tr.owner_agent_id,
+  a.kind AS owner_agent_kind,
+  a.display_name AS owner_agent_name,
+  tr.workstream_id,
+  tr.thread_root_run_id,
+  tr.cron_job_id,
+  tr.execution_session_id,
+  tr.status,
+  tr.description,
+  tr.started_at,
+  tr.finished_at,
+  tr.error_text
+FROM task_runs tr
+LEFT JOIN agents a ON a.id = tr.owner_agent_id
+WHERE tr.status IN ('running', 'failed', 'cancelled', 'blocked')
+ORDER BY tr.started_at DESC
+LIMIT 50;
 ```
 
 ## Follow one task thread lineage
@@ -82,6 +130,36 @@ FROM task_runs
 WHERE workstream_id = 'REPLACE_WORKSTREAM_ID'
 ORDER BY started_at DESC, id DESC
 LIMIT 20;
+```
+
+## Scheduled tasks with owner agent
+
+`cron_jobs.id` is the scheduled task id used by `schedule_task`.
+
+```sql
+SELECT
+  cj.id AS scheduled_task_id,
+  cj.owner_agent_id,
+  a.kind AS owner_agent_kind,
+  a.display_name AS owner_agent_name,
+  cj.name,
+  cj.enabled,
+  cj.schedule_kind,
+  cj.schedule_value,
+  cj.timezone,
+  cj.context_mode,
+  cj.workstream_id,
+  cj.next_run_at,
+  cj.running_at,
+  cj.last_run_at,
+  cj.last_status,
+  cj.consecutive_failures,
+  cj.last_output
+FROM cron_jobs cj
+LEFT JOIN agents a ON a.id = cj.owner_agent_id
+WHERE cj.deleted_at IS NULL
+ORDER BY COALESCE(cj.last_run_at, cj.next_run_at, cj.created_at) DESC
+LIMIT 50;
 ```
 
 ## Recent pending approvals
@@ -225,6 +303,30 @@ ORDER BY started_at DESC
 LIMIT 10;
 ```
 
+## Latest task runs for scheduled tasks
+
+Use this to connect scheduled task definitions to their concrete executions.
+
+```sql
+SELECT
+  cj.id AS scheduled_task_id,
+  cj.name,
+  tr.id AS task_run_id,
+  tr.thread_root_run_id,
+  tr.execution_session_id,
+  tr.status,
+  tr.attempt,
+  tr.started_at,
+  tr.finished_at,
+  tr.result_summary,
+  tr.error_text
+FROM cron_jobs cj
+LEFT JOIN task_runs tr ON tr.cron_job_id = cj.id
+WHERE cj.deleted_at IS NULL
+ORDER BY tr.started_at DESC
+LIMIT 50;
+```
+
 ## Cron job status
 
 ```sql
@@ -242,6 +344,49 @@ SELECT
 FROM cron_jobs
 ORDER BY updated_at DESC
 LIMIT 20;
+```
+
+## Lark run card and task card bindings
+
+Task status cards use `internal_object_kind = 'run_card'` and `internal_object_id = 'task:' || task_run_id`.
+Run transcript pages also use `run_card`, with page-specific internal ids.
+
+```sql
+SELECT
+  internal_object_kind,
+  internal_object_id,
+  conversation_id,
+  branch_id,
+  lark_message_id,
+  lark_open_message_id,
+  lark_card_id,
+  thread_root_message_id,
+  card_element_id,
+  last_sequence,
+  status,
+  updated_at
+FROM lark_object_bindings
+WHERE internal_object_kind = 'run_card'
+ORDER BY updated_at DESC
+LIMIT 50;
+```
+
+## Lark binding for one task run
+
+```sql
+SELECT
+  internal_object_kind,
+  internal_object_id,
+  lark_message_id,
+  lark_open_message_id,
+  lark_card_id,
+  thread_root_message_id,
+  status,
+  metadata_json,
+  updated_at
+FROM lark_object_bindings
+WHERE internal_object_kind = 'run_card'
+  AND internal_object_id = 'task:REPLACE_TASK_RUN_ID';
 ```
 
 ## Recent permission grants
@@ -262,6 +407,9 @@ LIMIT 20;
 
 - Select only the columns you need.
 - Filter by `session_id`, `owner_agent_id`, `cron_job_id`, `workstream_id`, `thread_root_run_id`, or time window before reading large tables.
+- Use `agents.display_name`, not `agents.title`.
+- Use `task_runs.owner_agent_id`, not `task_runs.agent_id`.
+- Use `SELECT ... FROM agents WHERE kind = 'sub'`, not a `subagents` table.
 - For task-thread incidents, prefer `thread_root_run_id` over `workstream_id`.
 - For "same cron job, different runs" questions, inspect both `workstream_id` and `thread_root_run_id` so you do not accidentally merge distinct run threads.
 - If a message payload is the only likely source of detail, first identify the relevant rows, then do a second narrower query for `payload_json`.

--- a/skills/system-observe/references/schema-overview.md
+++ b/skills/system-observe/references/schema-overview.md
@@ -10,8 +10,16 @@ If you need the authoritative code definition, inspect:
 - `../../src/storage/schema/tables.ts`
 - `../../src/storage/schema/types.ts`
 - `../../src/storage/migrate/files/0001_init.sql`
-- `../../src/storage/db/init.ts`
-  This file only bootstraps `0001_init.sql`; it is no longer a schema-upgrade source.
+- `../../src/storage/migrate/files/0002_agent_runtime_modes.sql`
+- `../../src/storage/migrate/files/0003_a2ui_surface_publications.sql`
+
+Important current-schema pitfalls:
+
+- There is no `subagents` table. SubAgents are rows in `agents` with `kind = 'sub'`.
+- `agents` has `display_name`; it does not have a `title` column.
+- `task_runs` has `owner_agent_id`; it does not have an `agent_id` column.
+- Scheduled tasks are stored in `cron_jobs`; each execution is stored in `task_runs` with `run_type = 'cron'` and `cron_job_id`.
+- `cron_jobs.id` is the scheduled task id used by `schedule_task`.
 
 Useful schema introspection queries:
 
@@ -27,30 +35,68 @@ PRAGMA table_info(messages);
 ```
 
 ```sql
+PRAGMA table_info(agents);
+```
+
+```sql
 PRAGMA table_info(task_runs);
+```
+
+```sql
+PRAGMA table_info(cron_jobs);
 ```
 
 ## Core tables
 
+- `channel_instances`
+  - Channel installation/account instances.
+  - Columns: `id`, `provider`, `account_key`, `display_name`, `status`, `config_ref`, `created_at`, `updated_at`.
+
+- `conversations`
+  - User-facing chat surfaces.
+  - Columns: `id`, `channel_instance_id`, `external_chat_id`, `kind`, `title`, `status`, `created_at`, `updated_at`.
+
+- `conversation_branches`
+  - Main, thread, task, or control branches under a conversation.
+  - Columns: `id`, `conversation_id`, `kind`, `branch_key`, `external_branch_id`, `parent_branch_id`, `status`, `created_at`, `updated_at`.
+
 - `agents`
   - Long-lived agents.
-  - Important columns: `id`, `kind`, `conversation_id`, `main_agent_id`, `workdir`, `status`.
+  - Columns: `id`, `conversation_id`, `main_agent_id`, `kind`, `display_name`, `description`, `workdir`, `policy_profile`, `default_model`, `status`, `created_at`, `archived_at`.
+  - Main Agent rows have `kind = 'main'`; SubAgent rows have `kind = 'sub'`.
+  - Join `agents.conversation_id` to `conversations.id` when you need the chat title or channel surface.
+
+- `agent_runtime_modes`
+  - Per-agent YOLO/Autopilot runtime mode state.
+  - Columns: `owner_agent_id`, `yolo_enabled`, `yolo_enabled_at`, `yolo_updated_at`, `yolo_updated_by`, `approval_streak_count`, `approval_streak_started_at`, `last_approval_requested_at`, `last_yolo_prompted_at`, `yolo_prompt_count_today`, `yolo_prompt_count_day`, `yolo_snoozed_until`.
+
+- `task_workstreams`
+  - Long-lived task source identity. Useful for grouping runs from the same cron job or task source.
+  - Columns: `id`, `owner_agent_id`, `conversation_id`, `branch_id`, `status`, `created_at`, `updated_at`.
+
+- `channel_threads`
+  - Durable mapping from external thread identity to either a chat branch or a task run lineage.
+  - Columns: `id`, `channel_type`, `channel_installation_id`, `home_conversation_id`, `external_chat_id`, `external_thread_id`, `subject_kind`, `branch_id`, `root_task_run_id`, `opened_from_message_id`, `status`, `created_at`, `updated_at`.
 
 - `sessions`
   - Execution and chat sessions.
-  - Important columns: `id`, `conversation_id`, `branch_id`, `owner_agent_id`, `purpose`, `approval_for_session_id`, `forked_from_session_id`, `status`, `context_mode`, `created_at`, `updated_at`, `ended_at`.
-  - `context_mode` (e.g. `"isolated"`, `"branched"`) controls session isolation and is critical for delegated approval routing — check this first when diagnosing why a permission request went to the wrong target.
+  - Columns: `id`, `conversation_id`, `branch_id`, `owner_agent_id`, `purpose`, `context_mode`, `approval_for_session_id`, `forked_from_session_id`, `fork_source_seq`, `status`, `compact_cursor`, `compact_summary`, `compact_summary_token_total`, `compact_summary_usage_json`, `created_at`, `updated_at`, `ended_at`.
+  - `context_mode` currently uses values such as `"isolated"` and `"group"`; check this when diagnosing approval routing or context isolation.
   - Compaction fields (`compact_cursor`, `compact_summary`, `compact_summary_token_total`, `compact_summary_usage_json`) track memory compaction state; relevant for long-session cost and context analysis.
+
+- `a2ui_surface_publications`
+  - Published A2UI surface state and callback consumption records.
+  - Columns: `id`, `surface_id`, `session_id`, `conversation_id`, `branch_id`, `channel_type`, `channel_installation_id`, `channel_artifact_id`, `channel_message_id`, `channel_sequence`, `surface_state_json`, `consumed_action_keys_json`, `status`, `created_at`, `updated_at`.
 
 - `messages`
   - Stored conversation messages and tool results.
-  - Important columns: `session_id`, `seq`, `role`, `message_type`, `visibility`, `provider`, `model`, `model_api`, `stop_reason`, `error_message`, `payload_json`, `created_at`.
+  - Columns: `id`, `session_id`, `seq`, `role`, `message_type`, `visibility`, `channel_message_id`, `channel_parent_message_id`, `channel_thread_id`, `provider`, `model`, `model_api`, `stop_reason`, `error_message`, `payload_json`, `token_input`, `token_output`, `token_cache_read`, `token_cache_write`, `token_total`, `usage_json`, `created_at`.
   - Token and cost fields: `token_input`, `token_output`, `token_cache_read`, `token_cache_write`, `token_total`, `usage_json`. Use these for cost analysis and token budget investigation.
   - Channel linkage: `channel_message_id`, `channel_parent_message_id`, `channel_thread_id` — useful for correlating DB records with Feishu message IDs.
 
 - `task_runs`
   - Task and cron execution records.
-  - Important columns:
+  - Columns:
     - `id`, `run_type`, `status`, `attempt`, `priority`
     - `owner_agent_id`, `conversation_id`, `branch_id`
     - `workstream_id`
@@ -66,7 +112,7 @@ PRAGMA table_info(task_runs);
 
 - `cron_jobs`
   - Scheduled tasks.
-  - Important columns:
+  - Columns:
     - `id`, `owner_agent_id`, `name`
     - `target_conversation_id`, `target_branch_id`
     - `workstream_id`
@@ -81,25 +127,37 @@ PRAGMA table_info(task_runs);
 
 - `approval_ledger`
   - Approval requests and outcomes.
-  - Important columns: `id`, `owner_agent_id`, `requested_by_session_id`, `requested_scope_json`, `approval_target`, `status`, `reason_text`, `expires_at`, `resume_payload_json`, `created_at`, `decided_at`.
+  - Columns: `id`, `owner_agent_id`, `requested_by_session_id`, `requested_scope_json`, `approval_target`, `status`, `reason_text`, `expires_at`, `resume_payload_json`, `created_at`, `decided_at`.
   - `resume_payload_json` holds the state needed to resume the task after approval — inspect it when investigating why a resumed task got stuck or produced unexpected output.
 
 - `agent_permission_grants`
   - Active and historical granted scopes.
-  - Important columns: `owner_agent_id`, `scope_json`, `granted_by`, `created_at`, `expires_at`.
+  - Columns: `id`, `owner_agent_id`, `source_approval_id`, `scope_json`, `granted_by`, `created_at`, `expires_at`.
 
-## Helpful supporting tables
+- `subagent_creation_requests`
+  - Pending and resolved SubAgent creation confirmation requests.
+  - Columns: `id`, `source_session_id`, `source_agent_id`, `source_conversation_id`, `channel_instance_id`, `title`, `description`, `initial_task`, `workdir`, `initial_extra_scopes_json`, `status`, `created_subagent_agent_id`, `failure_reason`, `created_at`, `updated_at`, `decided_at`, `expires_at`.
 
-- `conversations`
-- `conversation_branches`
-- `task_workstreams`
-  - Long-lived task source identity. Useful for grouping runs from the same cron job or task source.
-- `channel_threads`
-  - Durable mapping from external thread identity to either a chat branch or a task run lineage.
-  - Important columns: `id`, `channel_type`, `channel_installation_id`, `home_conversation_id`, `external_chat_id`, `external_thread_id`, `subject_kind`, `branch_id`, `root_task_run_id`, `opened_from_message_id`, `status`, `updated_at`.
-- `channel_surfaces`
-- `lark_object_bindings`
 - `auth_events`
+  - Authentication and provider status events.
+  - Columns: `id`, `conversation_id`, `agent_id`, `event_type`, `provider`, `status`, `details_json`, `created_at`.
+
+- `harness_events`
+  - Durable self-harness facts, currently including user stop events.
+  - Columns: `id`, `event_type`, `run_id`, `session_id`, `conversation_id`, `branch_id`, `agent_id`, `task_run_id`, `cron_job_id`, `actor`, `source_kind`, `request_scope`, `reason_text`, `details_json`, `created_at`.
+
+- `lark_object_bindings`
+  - Durable Feishu/Lark message, card, and thread anchors for internal objects.
+  - Columns: `id`, `channel_installation_id`, `conversation_id`, `branch_id`, `internal_object_kind`, `internal_object_id`, `lark_message_uuid`, `lark_message_id`, `lark_open_message_id`, `lark_card_id`, `thread_root_message_id`, `card_element_id`, `last_sequence`, `status`, `metadata_json`, `created_at`, `updated_at`.
+
+## Other supporting tables
+
+- `channel_surfaces`
+  - Columns: `id`, `channel_type`, `channel_installation_id`, `conversation_id`, `branch_id`, `surface_key`, `surface_object_json`, `created_at`, `updated_at`.
+- `meditation_state`
+  - Columns: `id`, `running`, `last_started_at`, `last_finished_at`, `last_success_at`, `last_status`, `updated_at`.
+- `schema_migrations`
+  - Columns: `version`, `name`, `checksum`, `applied_at`.
 
 ## Notes
 

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -24,7 +24,7 @@ const DEFAULT_MISSED_GRACE_MS = 3 * 60 * 1000;
 
 export interface CronServiceDependencies {
   storage: StorageDb;
-  agentManager: Pick<AgentManager, "runCronTaskExecutionFromJob">;
+  agentManager: Pick<AgentManager, "createCronTaskExecutionFromJob" | "runCreatedTaskExecution">;
   now?: () => Date;
   staleRunningMs?: number;
   dueBatchLimit?: number;
@@ -51,6 +51,8 @@ export interface AddCronJobInput
 export interface RunCronJobNowResult {
   accepted: boolean;
   cronJobId: string;
+  taskRunId: string;
+  executionSessionId: string;
 }
 
 export class CronService {
@@ -251,10 +253,12 @@ export class CronService {
       runningAt: claimed.runningAt,
     });
 
-    this.kickoffClaimedRun(claimed, "manual");
+    const started = this.kickoffClaimedRun(claimed, "manual");
     return {
       accepted: true,
-      cronJobId: jobId,
+      cronJobId: started.cronJobId,
+      taskRunId: started.taskRunId,
+      executionSessionId: started.executionSessionId,
     };
   }
 
@@ -377,7 +381,14 @@ export class CronService {
     }
   }
 
-  private kickoffClaimedRun(job: CronJob, triggerKind: "scheduled" | "manual"): void {
+  private kickoffClaimedRun(
+    job: CronJob,
+    triggerKind: "scheduled" | "manual",
+  ): {
+    cronJobId: string;
+    taskRunId: string;
+    executionSessionId: string;
+  } {
     const startedAt = this.now();
     logger.info("kicking off claimed cron job run", {
       cronJobId: job.id,
@@ -389,10 +400,15 @@ export class CronService {
       nextRunAt: job.nextRunAt,
     });
 
+    const created = this.deps.agentManager.createCronTaskExecutionFromJob({
+      cronJobId: job.id,
+      createdAt: startedAt,
+    });
+
     const runPromise = this.deps.agentManager
-      .runCronTaskExecutionFromJob({
-        cronJobId: job.id,
-        createdAt: this.now(),
+      .runCreatedTaskExecution({
+        created,
+        createdAt: startedAt,
       })
       .then((result) => {
         const finishedAt = this.now();
@@ -448,6 +464,12 @@ export class CronService {
       triggerKind,
       inFlightRuns: this.inFlightRuns.size,
     });
+
+    return {
+      cronJobId: job.id,
+      taskRunId: created.taskRun.id,
+      executionSessionId: created.executionSession.id,
+    };
   }
 
   private repo(): CronJobsRepo {
@@ -456,7 +478,7 @@ export class CronService {
 }
 
 function summarizeTaskExecutionResult(
-  result: Awaited<ReturnType<AgentManager["runCronTaskExecutionFromJob"]>>,
+  result: Awaited<ReturnType<AgentManager["runCreatedTaskExecution"]>>,
 ): string | null {
   switch (result.status) {
     case "completed":

--- a/src/tools/core/types.ts
+++ b/src/tools/core/types.ts
@@ -87,6 +87,8 @@ export interface ToolRuntimeControl {
   runCronJobNow?(input: { jobId: string }): Promise<{
     accepted: boolean;
     cronJobId: string;
+    taskRunId: string;
+    executionSessionId: string;
   }>;
   startBackgroundTask?(input: {
     sourceSessionId: string;

--- a/src/tools/cron.ts
+++ b/src/tools/cron.ts
@@ -132,8 +132,12 @@ export function createScheduleTaskTool() {
           });
 
           return textToolResult(
-            `Created scheduled task "${created.name ?? created.id}" for this ${resolved.callerAgent.kind === "main" ? "main agent" : "subagent"}.`,
-            formatCronJobForOutput(created),
+            `Created scheduled task "${created.name ?? created.id}" for this ${resolved.callerAgent.kind === "main" ? "main agent" : "subagent"}. Scheduled task id: ${created.id}.`,
+            {
+              ...formatCronJobForOutput(created),
+              scheduledTaskId: created.id,
+              cronJobId: created.id,
+            },
           );
         }
 
@@ -198,10 +202,13 @@ export function createScheduleTaskTool() {
           }
           const result = await context.runtimeControl.runCronJobNow({ jobId: job.id });
           return textToolResult(
-            `Triggered scheduled task "${job.name ?? job.id}" to run now. A separate background task run starts immediately. You will not directly see that run's full execution result inside the current run, so do not manually simulate the same work here.`,
+            `Triggered scheduled task "${job.name ?? job.id}" to run now. Scheduled task id: ${result.cronJobId}. Task run id: ${result.taskRunId}. Execution session id: ${result.executionSessionId}. A separate background task run starts immediately. You will not directly see that run's full execution result inside the current run, so do not manually simulate the same work here.`,
             {
               accepted: result.accepted,
               scheduledTaskId: result.cronJobId,
+              cronJobId: result.cronJobId,
+              taskRunId: result.taskRunId,
+              executionSessionId: result.executionSessionId,
             },
           );
         }

--- a/tests/cron/service.test.ts
+++ b/tests/cron/service.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { CronService } from "@/src/cron/service.js";
 import { AgentManager } from "@/src/orchestration/agent-manager.js";
+import type { CreatedTaskExecution } from "@/src/orchestration/task-run-factory.js";
 import type { SubmitMessageInput, SubmitMessageResult } from "@/src/runtime/ingress.js";
 import { CronJobsRepo } from "@/src/storage/repos/cron-jobs.repo.js";
 import { SessionsRepo } from "@/src/storage/repos/sessions.repo.js";
@@ -129,6 +130,84 @@ function createCompletedRunResult(taskRunId: string): TaskExecutionRunResult {
   };
 }
 
+function createCreatedCronTaskExecution(
+  taskRunId: string,
+  executionSessionId: string,
+): CreatedTaskExecution {
+  return {
+    taskRun: {
+      id: taskRunId,
+      runType: "cron",
+      ownerAgentId: "agent_1",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      workstreamId: "workstream_1",
+      threadRootRunId: taskRunId,
+      initiatorSessionId: null,
+      initiatorThreadId: null,
+      parentRunId: null,
+      cronJobId: "cron_1",
+      executionSessionId,
+      status: "running",
+      priority: 0,
+      attempt: 1,
+      description: null,
+      inputJson: "{}",
+      resultSummary: null,
+      errorText: null,
+      startedAt: "2026-03-27T12:00:00.000Z",
+      finishedAt: null,
+      durationMs: null,
+      cancelledBy: null,
+    },
+    executionSession: {
+      id: executionSessionId,
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      ownerAgentId: "agent_1",
+      purpose: "task",
+      contextMode: "isolated",
+      approvalForSessionId: null,
+      forkedFromSessionId: null,
+      forkSourceSeq: null,
+      status: "active",
+      compactCursor: 0,
+      compactSummary: null,
+      compactSummaryTokenTotal: null,
+      compactSummaryUsageJson: null,
+      createdAt: "2026-03-27T12:00:00.000Z",
+      updatedAt: "2026-03-27T12:00:00.000Z",
+      endedAt: null,
+    },
+  };
+}
+
+function createMockCronAgentManager(
+  runCreatedTaskExecutionImpl: () => Promise<TaskExecutionRunResult>,
+  createdExecution: CreatedTaskExecution = createCreatedCronTaskExecution(
+    "task_run_mock_1",
+    "sess_task_mock_1",
+  ),
+) {
+  const createCronTaskExecutionFromJob = vi.fn(
+    (_input: Parameters<AgentManager["createCronTaskExecutionFromJob"]>[0]) => createdExecution,
+  );
+  const runCreatedTaskExecution = vi.fn(
+    (_input: Parameters<AgentManager["runCreatedTaskExecution"]>[0]) =>
+      runCreatedTaskExecutionImpl(),
+  );
+
+  return {
+    agentManager: {
+      createCronTaskExecutionFromJob,
+      runCreatedTaskExecution,
+    },
+    createCronTaskExecutionFromJob,
+    runCreatedTaskExecution,
+    createdExecution,
+  };
+}
+
 async function flushMicrotasks() {
   await Promise.resolve();
   await Promise.resolve();
@@ -192,11 +271,14 @@ describe("cron service", () => {
     `);
 
     const deferred = createDeferred<TaskExecutionRunResult>();
-    const runCronTaskExecutionFromJob = vi.fn(() => deferred.promise);
+    const { agentManager, runCreatedTaskExecution } = createMockCronAgentManager(
+      () => deferred.promise,
+      createCreatedCronTaskExecution("run_1", "sess_task_1"),
+    );
 
     const service = new CronService({
       storage: handle.storage.db,
-      agentManager: { runCronTaskExecutionFromJob },
+      agentManager,
       now: () => new Date("2026-03-27T12:00:00.000Z"),
     });
 
@@ -206,7 +288,7 @@ describe("cron service", () => {
       dueJobs: 1,
       claimedJobs: 1,
     });
-    expect(runCronTaskExecutionFromJob).toHaveBeenCalledOnce();
+    expect(runCreatedTaskExecution).toHaveBeenCalledOnce();
 
     const repo = new CronJobsRepo(handle.storage.db);
     expect(repo.getById("cron_1")).toMatchObject({
@@ -240,10 +322,12 @@ describe("cron service", () => {
       );
     `);
 
-    const runCronTaskExecutionFromJob = vi.fn(async () => createCompletedRunResult("unused"));
+    const { agentManager, runCreatedTaskExecution } = createMockCronAgentManager(async () =>
+      createCompletedRunResult("unused"),
+    );
     const service = new CronService({
       storage: handle.storage.db,
-      agentManager: { runCronTaskExecutionFromJob },
+      agentManager,
       now: () => new Date("2026-03-27T12:00:00.000Z"),
     });
 
@@ -254,7 +338,7 @@ describe("cron service", () => {
       claimedJobs: 0,
       missedJobs: 1,
     });
-    expect(runCronTaskExecutionFromJob).not.toHaveBeenCalled();
+    expect(runCreatedTaskExecution).not.toHaveBeenCalled();
     expect(new CronJobsRepo(handle.storage.db).getById("cron_1")).toMatchObject({
       runningAt: null,
       lastStatus: "missed",
@@ -278,15 +362,34 @@ describe("cron service", () => {
     `);
 
     const deferred = createDeferred<TaskExecutionRunResult>();
-    const runCronTaskExecutionFromJob = vi.fn(() => deferred.promise);
+    const createdExecution = createCreatedCronTaskExecution(
+      "task_run_manual_1",
+      "sess_task_manual_1",
+    );
+    const { agentManager, createCronTaskExecutionFromJob, runCreatedTaskExecution } =
+      createMockCronAgentManager(() => deferred.promise, createdExecution);
 
     const service = new CronService({
       storage: handle.storage.db,
-      agentManager: { runCronTaskExecutionFromJob },
+      agentManager,
       now: () => new Date("2026-03-27T12:00:00.000Z"),
     });
 
-    await service.runJobNow("cron_1");
+    const result = await service.runJobNow("cron_1");
+    expect(result).toEqual({
+      accepted: true,
+      cronJobId: "cron_1",
+      taskRunId: "task_run_manual_1",
+      executionSessionId: "sess_task_manual_1",
+    });
+    expect(createCronTaskExecutionFromJob).toHaveBeenCalledExactlyOnceWith({
+      cronJobId: "cron_1",
+      createdAt: new Date("2026-03-27T12:00:00.000Z"),
+    });
+    expect(runCreatedTaskExecution).toHaveBeenCalledExactlyOnceWith({
+      created: createdExecution,
+      createdAt: new Date("2026-03-27T12:00:00.000Z"),
+    });
 
     const repo = new CronJobsRepo(handle.storage.db);
     expect(repo.getById("cron_1")).toMatchObject({
@@ -294,7 +397,7 @@ describe("cron service", () => {
       nextRunAt: "2026-03-28T00:00:00.000Z",
     });
 
-    deferred.resolve(createCompletedRunResult("run_2"));
+    deferred.resolve(createCompletedRunResult("task_run_manual_1"));
     await deferred.promise;
     await flushMicrotasks();
 
@@ -321,9 +424,8 @@ describe("cron service", () => {
 
     const service = new CronService({
       storage: handle.storage.db,
-      agentManager: {
-        runCronTaskExecutionFromJob: vi.fn(async () => createCompletedRunResult("unused")),
-      },
+      agentManager: createMockCronAgentManager(async () => createCompletedRunResult("unused"))
+        .agentManager,
       now: () => new Date("2026-03-27T12:00:00.000Z"),
     });
 
@@ -358,18 +460,21 @@ describe("cron service", () => {
     `);
 
     const deferred = createDeferred<TaskExecutionRunResult>();
-    const runCronTaskExecutionFromJob = vi.fn(() => deferred.promise);
+    const { agentManager, runCreatedTaskExecution } = createMockCronAgentManager(
+      () => deferred.promise,
+      createCreatedCronTaskExecution("run_3", "sess_task_3"),
+    );
 
     const service = new CronService({
       storage: handle.storage.db,
-      agentManager: { runCronTaskExecutionFromJob },
+      agentManager,
       now: () => new Date("2026-03-27T12:00:00.000Z"),
     });
 
     await service.scanOnce();
     await service.scanOnce();
 
-    expect(runCronTaskExecutionFromJob).toHaveBeenCalledTimes(1);
+    expect(runCreatedTaskExecution).toHaveBeenCalledTimes(1);
 
     deferred.resolve(createCompletedRunResult("run_3"));
     await deferred.promise;
@@ -391,16 +496,19 @@ describe("cron service", () => {
     `);
 
     const deferred = createDeferred<TaskExecutionRunResult>();
-    const runCronTaskExecutionFromJob = vi.fn(() => deferred.promise);
+    const { agentManager, runCreatedTaskExecution } = createMockCronAgentManager(
+      () => deferred.promise,
+      createCreatedCronTaskExecution("run_4", "sess_task_4"),
+    );
 
     const service = new CronService({
       storage: handle.storage.db,
-      agentManager: { runCronTaskExecutionFromJob },
+      agentManager,
       now: () => new Date("2026-03-27T12:00:00.000Z"),
     });
 
     await service.runJobNow("cron_1");
-    expect(runCronTaskExecutionFromJob).toHaveBeenCalledOnce();
+    expect(runCreatedTaskExecution).toHaveBeenCalledOnce();
 
     deferred.resolve(createCompletedRunResult("run_4"));
     await deferred.promise;
@@ -422,11 +530,14 @@ describe("cron service", () => {
     `);
 
     const deferred = createDeferred<TaskExecutionRunResult>();
-    const runCronTaskExecutionFromJob = vi.fn(() => deferred.promise);
+    const { agentManager } = createMockCronAgentManager(
+      () => deferred.promise,
+      createCreatedCronTaskExecution("run_5", "sess_task_5"),
+    );
 
     const service = new CronService({
       storage: handle.storage.db,
-      agentManager: { runCronTaskExecutionFromJob },
+      agentManager,
       now: () => new Date("2026-03-27T12:00:00.000Z"),
     });
 
@@ -456,9 +567,8 @@ describe("cron service", () => {
 
     const service = new CronService({
       storage: handle.storage.db,
-      agentManager: {
-        runCronTaskExecutionFromJob: vi.fn(async () => createCompletedRunResult("unused")),
-      },
+      agentManager: createMockCronAgentManager(async () => createCompletedRunResult("unused"))
+        .agentManager,
       now: () => new Date("2026-03-27T12:00:00.000Z"),
     });
 
@@ -479,11 +589,13 @@ describe("cron service", () => {
     seedFixture(handle);
 
     let now = new Date("2026-03-27T12:00:00.000Z");
-    const runCronTaskExecutionFromJob = vi.fn(async () => createCompletedRunResult("run_6"));
+    const { agentManager, runCreatedTaskExecution } = createMockCronAgentManager(async () =>
+      createCompletedRunResult("run_6"),
+    );
 
     const service = new CronService({
       storage: handle.storage.db,
-      agentManager: { runCronTaskExecutionFromJob },
+      agentManager,
       now: () => now,
     });
 
@@ -509,7 +621,7 @@ describe("cron service", () => {
       dueJobs: 1,
       claimedJobs: 1,
     });
-    expect(runCronTaskExecutionFromJob).toHaveBeenCalledTimes(1);
+    expect(runCreatedTaskExecution).toHaveBeenCalledTimes(1);
     expect(new CronJobsRepo(handle.storage.db).getById(created.id)).toMatchObject({
       enabled: false,
       nextRunAt: null,
@@ -524,7 +636,7 @@ describe("cron service", () => {
       dueJobs: 0,
       claimedJobs: 0,
     });
-    expect(runCronTaskExecutionFromJob).toHaveBeenCalledTimes(1);
+    expect(runCreatedTaskExecution).toHaveBeenCalledTimes(1);
   });
 
   test("one-shot jobs with legacy relative schedule values still disable themselves after completion", async () => {
@@ -542,11 +654,14 @@ describe("cron service", () => {
     `);
 
     const deferred = createDeferred<TaskExecutionRunResult>();
-    const runCronTaskExecutionFromJob = vi.fn(() => deferred.promise);
+    const { agentManager } = createMockCronAgentManager(
+      () => deferred.promise,
+      createCreatedCronTaskExecution("run_legacy", "sess_task_legacy"),
+    );
 
     const service = new CronService({
       storage: handle.storage.db,
-      agentManager: { runCronTaskExecutionFromJob },
+      agentManager,
       now: () => new Date("2026-03-27T12:00:00.000Z"),
     });
 

--- a/tests/orchestration/agent-manager.test.ts
+++ b/tests/orchestration/agent-manager.test.ts
@@ -1312,6 +1312,8 @@ describe("AgentManager", () => {
       expect(result).toEqual({
         accepted: true,
         cronJobId: "cron_2",
+        taskRunId: expect.any(String),
+        executionSessionId: expect.any(String),
       });
       expect(submitMessage).toHaveBeenCalledOnce();
       await flushMicrotasks();

--- a/tests/runtime/orchestration-bridge.test.ts
+++ b/tests/runtime/orchestration-bridge.test.ts
@@ -253,6 +253,8 @@ describe("RuntimeOrchestrationBridge", () => {
         runCronJobNow: vi.fn(async () => ({
           accepted: true,
           cronJobId: "cron_sub_1",
+          taskRunId: "task_run_cron_1",
+          executionSessionId: "sess_task_cron_1",
         })),
         startBackgroundTask: vi.fn(async () => ({
           accepted: true,
@@ -269,6 +271,8 @@ describe("RuntimeOrchestrationBridge", () => {
     ).resolves.toEqual({
       accepted: true,
       cronJobId: "cron_sub_1",
+      taskRunId: "task_run_cron_1",
+      executionSessionId: "sess_task_cron_1",
     });
   });
 
@@ -285,6 +289,8 @@ describe("RuntimeOrchestrationBridge", () => {
         runCronJobNow: vi.fn(async () => ({
           accepted: true,
           cronJobId: "cron_sub_1",
+          taskRunId: "task_run_cron_1",
+          executionSessionId: "sess_task_cron_1",
         })),
         startBackgroundTask,
         suppressBackgroundTaskCompletionNotice,

--- a/tests/tools/cron.test.ts
+++ b/tests/tools/cron.test.ts
@@ -205,12 +205,17 @@ describe("schedule_task tool", () => {
       type: "text",
       text: expect.stringContaining("Created scheduled task"),
     });
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: expect.stringContaining("Scheduled task id:"),
+    });
 
     const rows = handle.storage.sqlite
       .prepare(
-        "SELECT owner_agent_id, target_conversation_id, target_branch_id, payload_json FROM cron_jobs WHERE name = ?",
+        "SELECT id, owner_agent_id, target_conversation_id, target_branch_id, payload_json FROM cron_jobs WHERE name = ?",
       )
       .all("Morning review") as Array<{
+      id: string;
       owner_agent_id: string;
       target_conversation_id: string;
       target_branch_id: string;
@@ -218,12 +223,24 @@ describe("schedule_task tool", () => {
     }>;
 
     expect(rows).toHaveLength(1);
-    expect(rows[0]).toEqual({
+    const createdRow = rows[0];
+    if (createdRow == null) {
+      throw new Error("Expected the scheduled task row to exist");
+    }
+    expect(createdRow).toEqual({
+      id: createdRow.id,
       owner_agent_id: "agent_sub",
       target_conversation_id: "conv_sub",
       target_branch_id: "branch_sub",
       payload_json: "Review open pull requests.",
     });
+    expect(result.details).toEqual(
+      expect.objectContaining({
+        id: createdRow.id,
+        scheduledTaskId: createdRow.id,
+        cronJobId: createdRow.id,
+      }),
+    );
   });
 
   test("main agent listing includes subagent-owned scheduled tasks in its management scope", async () => {
@@ -269,6 +286,8 @@ describe("schedule_task tool", () => {
     const runCronJobNow = vi.fn(async () => ({
       accepted: true,
       cronJobId: "cron_sub",
+      taskRunId: "task_run_manual_1",
+      executionSessionId: "sess_task_manual_1",
     }));
     const registry = new ToolRegistry([createScheduleTaskTool()]);
 
@@ -306,6 +325,17 @@ describe("schedule_task tool", () => {
     expect(result.content[0]).toEqual({
       type: "text",
       text: expect.stringContaining("do not manually simulate the same work here"),
+    });
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: expect.stringContaining("Task run id: task_run_manual_1"),
+    });
+    expect(result.details).toEqual({
+      accepted: true,
+      scheduledTaskId: "cron_sub",
+      cronJobId: "cron_sub",
+      taskRunId: "task_run_manual_1",
+      executionSessionId: "sess_task_manual_1",
     });
   });
 

--- a/tests/tools/cron.test.ts
+++ b/tests/tools/cron.test.ts
@@ -330,6 +330,10 @@ describe("schedule_task tool", () => {
       type: "text",
       text: expect.stringContaining("Task run id: task_run_manual_1"),
     });
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: expect.stringContaining("Execution session id: sess_task_manual_1"),
+    });
     expect(result.details).toEqual({
       accepted: true,
       scheduledTaskId: "cron_sub",


### PR DESCRIPTION
## Summary

### POK-42: system-observe schema docs

- Updated system-observe required reads to point at the current schema source: `tables.ts` plus migration SQL files.
- Synced schema guidance with the real SQLite tables:
  - SubAgents are `agents.kind = 'sub'`, not a separate `subagents` table.
  - Agents use `display_name`, not `title`.
  - Task runs use `owner_agent_id`, not `agent_id`.
  - Scheduled tasks live in `cron_jobs`; executions live in `task_runs`.
- Added practical query recipes for agent inventory, scheduled tasks, task runs, and Lark run-card bindings.

### POK-44: schedule_task returns traceable IDs

- `schedule_task create` now includes the scheduled task id in both the text result and details as `scheduledTaskId` / `cronJobId`.
- `schedule_task run` now returns `scheduledTaskId`, `cronJobId`, `taskRunId`, and `executionSessionId`.
- Manual cron runs now create the task execution first, return its persisted IDs immediately, then run it asynchronously. This keeps the non-blocking behavior while making the run directly traceable without a follow-up list call.
- Updated runtime-control and bridge types/tests for the expanded return contract.

## Tests

- `pnpm test tests/tools/cron.test.ts tests/cron/service.test.ts tests/runtime/orchestration-bridge.test.ts tests/orchestration/agent-manager.test.ts`
- `pnpm preflight`
