### PR TITLE
POK-46: Normalize Windows subtree scope paths

### DIFF
--- a/src/orchestration/subagents.ts
+++ b/src/orchestration/subagents.ts
@@ -9,7 +9,11 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 
 import { buildSystemPolicy } from "@/src/security/policy.js";
-import { type PermissionScope, serializePermissionScope } from "@/src/security/scope.js";
+import {
+  appendFsSubtreeSuffix,
+  type PermissionScope,
+  serializePermissionScope,
+} from "@/src/security/scope.js";
 import { SecurityService } from "@/src/security/service.js";
 import { createSubsystemLogger } from "@/src/shared/logger.js";
 import {
@@ -669,7 +673,7 @@ function normalizeRequiredTrimmed(field: string, value: string): string {
 }
 
 function toSubtreePath(targetPath: string): string {
-  return path.join(targetPath, "**");
+  return appendFsSubtreeSuffix(targetPath);
 }
 
 function buildSubagentFinalizeFailureReason(input: {

--- a/src/security/permissions.ts
+++ b/src/security/permissions.ts
@@ -58,11 +58,11 @@ export type PermissionCheckResult =
     };
 
 function expandHomePrefix(value: string): string {
+  const homeDir = process.env.HOME;
   if (value === "~") {
-    return process.env.HOME ?? value;
+    return homeDir ?? value;
   }
-  if (value.startsWith("~/")) {
-    const homeDir = process.env.HOME;
+  if (value.startsWith("~/") || value.startsWith("~\\")) {
     return homeDir == null ? value : path.join(homeDir, value.slice(2));
   }
   return value;

--- a/src/security/policy.ts
+++ b/src/security/policy.ts
@@ -2,6 +2,7 @@ import os from "node:os";
 import path from "node:path";
 
 import type { AppConfig } from "@/src/config/schema.js";
+import { appendFsSubtreeSuffix } from "@/src/security/scope.js";
 import {
   POKOCLAW_REPO_DIR,
   POKOCLAW_SKILLS_DIR,
@@ -43,32 +44,28 @@ export interface AgentPermissionBaseline {
   };
 }
 
-function subtree(value: string): string {
-  return path.join(value, "**");
-}
-
 const HOME_DIR = os.homedir();
 
 export const DEFAULT_FILESYSTEM_HARD_DENY_READ = [
-  subtree(POKOCLAW_SYSTEM_DIR),
-  subtree(path.join("~", ".ssh")),
-  subtree(path.join("~", ".gnupg")),
-  subtree(path.join("~", ".aws")),
-  subtree(path.join("~", ".azure")),
-  subtree(path.join("~", ".gcloud")),
-  subtree(path.join("~", ".kube")),
-  subtree(path.join("~", ".docker")),
+  appendFsSubtreeSuffix(POKOCLAW_SYSTEM_DIR),
+  appendFsSubtreeSuffix(path.join("~", ".ssh")),
+  appendFsSubtreeSuffix(path.join("~", ".gnupg")),
+  appendFsSubtreeSuffix(path.join("~", ".aws")),
+  appendFsSubtreeSuffix(path.join("~", ".azure")),
+  appendFsSubtreeSuffix(path.join("~", ".gcloud")),
+  appendFsSubtreeSuffix(path.join("~", ".kube")),
+  appendFsSubtreeSuffix(path.join("~", ".docker")),
 ] as const;
 
 export const DEFAULT_FILESYSTEM_HARD_DENY_WRITE = [
-  subtree(POKOCLAW_SYSTEM_DIR),
-  subtree(path.join("~", ".ssh")),
-  subtree(path.join("~", ".gnupg")),
-  subtree(path.join("~", ".aws")),
-  subtree(path.join("~", ".azure")),
-  subtree(path.join("~", ".gcloud")),
-  subtree(path.join("~", ".kube")),
-  subtree(path.join("~", ".docker")),
+  appendFsSubtreeSuffix(POKOCLAW_SYSTEM_DIR),
+  appendFsSubtreeSuffix(path.join("~", ".ssh")),
+  appendFsSubtreeSuffix(path.join("~", ".gnupg")),
+  appendFsSubtreeSuffix(path.join("~", ".aws")),
+  appendFsSubtreeSuffix(path.join("~", ".azure")),
+  appendFsSubtreeSuffix(path.join("~", ".gcloud")),
+  appendFsSubtreeSuffix(path.join("~", ".kube")),
+  appendFsSubtreeSuffix(path.join("~", ".docker")),
 ] as const;
 
 export const DEFAULT_NETWORK_HARD_DENY_HOSTS = [
@@ -127,12 +124,12 @@ export function buildAgentPermissionBaseline(role: AgentRuntimeRole): AgentPermi
         fs: {
           readMode: "allow_only",
           readAllow: [
-            subtree(HOME_DIR),
-            subtree(POKOCLAW_WORKSPACE_DIR),
-            subtree(POKOCLAW_SKILLS_DIR),
-            subtree(POKOCLAW_REPO_DIR),
+            appendFsSubtreeSuffix(HOME_DIR),
+            appendFsSubtreeSuffix(POKOCLAW_WORKSPACE_DIR),
+            appendFsSubtreeSuffix(POKOCLAW_SKILLS_DIR),
+            appendFsSubtreeSuffix(POKOCLAW_REPO_DIR),
           ],
-          writeAllow: [subtree(POKOCLAW_WORKSPACE_DIR)],
+          writeAllow: [appendFsSubtreeSuffix(POKOCLAW_WORKSPACE_DIR)],
         },
       };
     case "subagent":
@@ -146,11 +143,11 @@ export function buildAgentPermissionBaseline(role: AgentRuntimeRole): AgentPermi
         fs: {
           readMode: "allow_only",
           readAllow: [
-            subtree(POKOCLAW_WORKSPACE_DIR),
-            subtree(POKOCLAW_SKILLS_DIR),
-            subtree(POKOCLAW_REPO_DIR),
+            appendFsSubtreeSuffix(POKOCLAW_WORKSPACE_DIR),
+            appendFsSubtreeSuffix(POKOCLAW_SKILLS_DIR),
+            appendFsSubtreeSuffix(POKOCLAW_REPO_DIR),
           ],
-          writeAllow: [subtree(POKOCLAW_WORKSPACE_DIR)],
+          writeAllow: [appendFsSubtreeSuffix(POKOCLAW_WORKSPACE_DIR)],
         },
       };
   }

--- a/src/security/scope.ts
+++ b/src/security/scope.ts
@@ -45,6 +45,53 @@ export interface PermissionRequest {
 
 const GLOB_CHARS = /[*?[\]]/;
 const SUBTREE_SUFFIX = "/**";
+const SUBTREE_MARKER = "**";
+
+function isPathSeparator(value: string | undefined): boolean {
+  return value === "/" || value === "\\";
+}
+
+function isAbsoluteFsPath(value: string): boolean {
+  return path.isAbsolute(value) || path.win32.isAbsolute(value);
+}
+
+function isFsRootPath(value: string): boolean {
+  const nativeNormalized = path.normalize(value);
+  if (path.isAbsolute(value) && nativeNormalized === path.parse(nativeNormalized).root) {
+    return true;
+  }
+
+  const win32Normalized = path.win32.normalize(value);
+  return path.win32.isAbsolute(value) && win32Normalized === path.win32.parse(win32Normalized).root;
+}
+
+function stripTrailingFsSeparatorsPreservingRoot(value: string): string {
+  let normalized = value;
+  while (normalized.length > 1 && isPathSeparator(normalized.at(-1)) && !isFsRootPath(normalized)) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized;
+}
+
+function getFsSubtreeBase(value: string): string | null {
+  if (!value.endsWith(SUBTREE_MARKER)) {
+    return null;
+  }
+
+  const separator = value.at(-SUBTREE_MARKER.length - 1);
+  if (!isPathSeparator(separator)) {
+    return null;
+  }
+
+  return stripTrailingFsSeparatorsPreservingRoot(value.slice(0, -SUBTREE_MARKER.length));
+}
+
+export function appendFsSubtreeSuffix(targetPath: string): string {
+  const normalizedTargetPath = stripTrailingFsSeparatorsPreservingRoot(
+    getFsSubtreeBase(targetPath) ?? targetPath,
+  );
+  return `${normalizedTargetPath}${SUBTREE_SUFFIX}`;
+}
 
 function assertObject(value: unknown, context: string): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
@@ -64,15 +111,14 @@ function assertString(value: unknown, context: string): string {
 
 function validateFsScopePath(value: unknown, context: string): string {
   const candidatePath = assertString(value, context);
-  if (!path.isAbsolute(candidatePath)) {
+  const subtreeBasePath = getFsSubtreeBase(candidatePath);
+  const pathWithoutSubtreeSuffix = subtreeBasePath ?? candidatePath;
+
+  if (!isAbsoluteFsPath(pathWithoutSubtreeSuffix)) {
     throw new Error(`${context} must be an absolute path`);
   }
 
-  const pathWithoutSubtreeSuffix = candidatePath.endsWith(SUBTREE_SUFFIX)
-    ? candidatePath.slice(0, -SUBTREE_SUFFIX.length)
-    : candidatePath;
-
-  if (pathWithoutSubtreeSuffix.length === 0) {
+  if (subtreeBasePath != null && isFsRootPath(pathWithoutSubtreeSuffix)) {
     throw new Error(`${context} must not target the filesystem root subtree`);
   }
 
@@ -82,7 +128,7 @@ function validateFsScopePath(value: unknown, context: string): string {
     );
   }
 
-  return candidatePath;
+  return subtreeBasePath == null ? candidatePath : appendFsSubtreeSuffix(subtreeBasePath);
 }
 
 function parseFsScope(input: Record<string, unknown>, kind: FsPermissionKind): FsPermissionScope {
@@ -203,7 +249,7 @@ export function serializePermissionRequest(request: PermissionRequest): string {
 }
 
 export function isFsSubtreeScopePath(scopePath: string): boolean {
-  return scopePath.endsWith(SUBTREE_SUFFIX);
+  return getFsSubtreeBase(scopePath) != null;
 }
 
 export function describePermissionScope(scope: PermissionScope): string {

--- a/src/tools/helpers/permission-block.ts
+++ b/src/tools/helpers/permission-block.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs";
-import path from "node:path";
-import type { PermissionScope } from "@/src/security/scope.js";
+import { appendFsSubtreeSuffix, type PermissionScope } from "@/src/security/scope.js";
 
 export type PermissionResource = "filesystem";
 export type PermissionEntryScope = "exact" | "subtree";
@@ -193,7 +192,7 @@ export function expandPermissionEntriesToScopes(
   const scopes: PermissionScope[] = [];
 
   for (const entry of entries) {
-    const scopePath = entry.scope === "subtree" ? path.join(entry.path, "**") : entry.path;
+    const scopePath = entry.scope === "subtree" ? appendFsSubtreeSuffix(entry.path) : entry.path;
     if (entry.access === "read" || entry.access === "read_write") {
       scopes.push({ kind: "fs.read", path: scopePath });
     }

--- a/tests/security/permissions.test.ts
+++ b/tests/security/permissions.test.ts
@@ -138,6 +138,60 @@ describe("effective permissions", () => {
 });
 
 describe("filesystem permission checks", () => {
+  test("expands Windows-style home-relative hard denies under the user's home", () => {
+    const originalHome = process.env.HOME;
+    process.env.HOME = tempDir;
+    try {
+      const permissions = buildEffectivePermissions(
+        [],
+        {
+          ...buildSystemPolicy(),
+          fs: {
+            read: {
+              hardDeny: ["~\\.ssh/**"],
+              deny: [],
+            },
+            write: {
+              hardDeny: ["~\\.ssh/**"],
+              deny: [],
+            },
+          },
+        },
+        buildAgentPermissionBaseline("main"),
+      );
+      const targetPath = path.join(tempDir, ".ssh", "id_rsa");
+
+      expect(
+        checkFilesystemPermission({
+          kind: "fs.read",
+          targetPath,
+          permissions,
+        }),
+      ).toEqual({
+        result: "deny",
+        reason: "hard_deny",
+        summary: `fs.read is blocked by system policy for ${targetPath}`,
+      });
+      expect(
+        checkFilesystemPermission({
+          kind: "fs.write",
+          targetPath,
+          permissions,
+        }),
+      ).toEqual({
+        result: "deny",
+        reason: "hard_deny",
+        summary: `fs.write is blocked by system policy for ${targetPath}`,
+      });
+    } finally {
+      if (originalHome == null) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
   test("main agent can read a normal home path without an explicit grant", () => {
     const permissions = buildEffectivePermissions(
       [],

--- a/tests/security/permissions.test.ts
+++ b/tests/security/permissions.test.ts
@@ -9,6 +9,7 @@ import {
   checkBashFullAccessPermission,
   checkDatabasePermission,
   checkFilesystemPermission,
+  normalizeFilesystemTargetPath,
   parseGrantedScopes,
 } from "@/src/security/permissions.js";
 import {
@@ -160,6 +161,7 @@ describe("filesystem permission checks", () => {
         buildAgentPermissionBaseline("main"),
       );
       const targetPath = path.join(tempDir, ".ssh", "id_rsa");
+      const normalizedTargetPath = normalizeFilesystemTargetPath(targetPath);
 
       expect(
         checkFilesystemPermission({
@@ -170,7 +172,7 @@ describe("filesystem permission checks", () => {
       ).toEqual({
         result: "deny",
         reason: "hard_deny",
-        summary: `fs.read is blocked by system policy for ${targetPath}`,
+        summary: `fs.read is blocked by system policy for ${normalizedTargetPath}`,
       });
       expect(
         checkFilesystemPermission({
@@ -181,7 +183,7 @@ describe("filesystem permission checks", () => {
       ).toEqual({
         result: "deny",
         reason: "hard_deny",
-        summary: `fs.write is blocked by system policy for ${targetPath}`,
+        summary: `fs.write is blocked by system policy for ${normalizedTargetPath}`,
       });
     } finally {
       if (originalHome == null) {

--- a/tests/security/scope.test.ts
+++ b/tests/security/scope.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import {
+  appendFsSubtreeSuffix,
   describePermissionRequest,
   describePermissionScope,
   isFsSubtreeScopePath,
@@ -32,6 +33,30 @@ describe("permission scope parsing", () => {
     expect(isFsSubtreeScopePath("/Users/example/.pokoclaw/workspace/**")).toBe(true);
   });
 
+  test("normalizes Windows fs subtree suffixes to the stable internal suffix", () => {
+    expect(
+      parsePermissionScopeJson(
+        '{"kind":"fs.read","path":"C:\\\\Users\\\\example\\\\project\\\\**"}',
+      ),
+    ).toEqual({
+      kind: "fs.read",
+      path: "C:\\Users\\example\\project/**",
+    });
+    expect(isFsSubtreeScopePath("C:\\Users\\example\\project\\**")).toBe(true);
+  });
+
+  test("appends stable fs subtree suffixes without platform separators", () => {
+    expect(appendFsSubtreeSuffix("C:\\Users\\example\\project")).toBe(
+      "C:\\Users\\example\\project/**",
+    );
+    expect(appendFsSubtreeSuffix("C:\\Users\\example\\project\\")).toBe(
+      "C:\\Users\\example\\project/**",
+    );
+    expect(appendFsSubtreeSuffix("C:\\Users\\example\\project\\**")).toBe(
+      "C:\\Users\\example\\project/**",
+    );
+  });
+
   test("parses db scopes", () => {
     expect(parsePermissionScopeJson('{"kind":"db.read","database":"system"}')).toEqual({
       kind: "db.read",
@@ -47,6 +72,9 @@ describe("permission scope parsing", () => {
 
   test("rejects filesystem root subtree scopes", () => {
     expect(() => parsePermissionScopeJson('{"kind":"fs.read","path":"/**"}')).toThrow(
+      "Invalid permission scope JSON: fs.read path must not target the filesystem root subtree",
+    );
+    expect(() => parsePermissionScopeJson('{"kind":"fs.read","path":"C:\\\\**"}')).toThrow(
       "Invalid permission scope JSON: fs.read path must not target the filesystem root subtree",
     );
   });

--- a/tests/tools/permission-block.test.ts
+++ b/tests/tools/permission-block.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vitest";
+
+import { expandPermissionEntriesToScopes } from "@/src/tools/helpers/permission-block.js";
+
+describe("permission block helpers", () => {
+  test("expands subtree entries with the stable filesystem subtree suffix", () => {
+    expect(
+      expandPermissionEntriesToScopes([
+        {
+          resource: "filesystem",
+          path: "C:\\Users\\example\\project",
+          scope: "subtree",
+          access: "read_write",
+        },
+      ]),
+    ).toEqual([
+      { kind: "fs.read", path: "C:\\Users\\example\\project/**" },
+      { kind: "fs.write", path: "C:\\Users\\example\\project/**" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the filesystem subtree scope normalization piece split out as POK-46 from the Windows compatibility work in PR #39.

- Adds a shared `appendFsSubtreeSuffix()` helper that always emits the stable internal `target/**` form instead of platform-specific `target\**`.
- Accepts Windows-style trailing `\**` filesystem scope inputs and normalizes them to the internal `/**` suffix.
- Replaces subtree scope construction in policy baselines, request permission expansion, and subagent initial path scopes.
- Keeps filesystem root subtree scopes rejected, including Windows roots such as `C:\**`.

## Validation

- `pnpm test -- tests/security/scope.test.ts tests/tools/permission-block.test.ts`
- `pnpm build`
- `pnpm exec biome lint --error-on-warnings src/security/scope.ts src/security/policy.ts src/tools/helpers/permission-block.ts src/orchestration/subagents.ts tests/security/scope.test.ts tests/tools/permission-block.test.ts`

Note: full `pnpm test` / pre-commit preflight still fail on native Windows for existing platform issues unrelated to this PR, including POSIX path expectations, symlink permission failures, and sandbox-runtime unsupported-on-Windows paths.