### PR TITLE
POK-47: Support Windows autopilot host bash

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -343,6 +343,10 @@ autopilot = true
 
 Restart Pokoclaw after changing this value.
 
+On native Windows, sandboxed bash is not available yet. If `[runtime] autopilot = true` is enabled,
+bash commands run directly on the Windows host with full access instead of using Linux sandbox
+isolation. Only enable this on a machine and workspace where that trust model is acceptable.
+
 ### LLM empty-output retries
 
 Pokoclaw retries a model response when the model times out before producing any

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -91,7 +91,11 @@ Current checks:
   - `socat`, used by sandbox-runtime Linux networking
   - bubblewrap filesystem smoke
   - bubblewrap network namespace smoke
-- Windows and WSL:
+- native Windows-like shells (`MINGW*`, `MSYS*`, `CYGWIN*`):
+  - common checks only
+  - sandboxed bash is not available yet
+  - runnable startup requires explicit `[runtime] autopilot = true`, which makes bash commands run directly on the Windows host with full access and no Linux sandbox isolation
+- WSL:
   - currently unsupported; the doctor exits with a clear message and points contributors to the GitHub repository
 
 Required Linux host capability:
@@ -228,7 +232,7 @@ If the user wants web search or web fetch, also write:
 - `[tools.web.search]`
 - `[tools.web.fetch]`
 
-Do not enable `[runtime] autopilot = true` during onboarding unless the user explicitly asks for fewer approval prompts and accepts that Pokoclaw will skip eligible human approval waits.
+Do not enable `[runtime] autopilot = true` during onboarding unless the user explicitly asks for fewer approval prompts and accepts that Pokoclaw will skip eligible human approval waits. On native Windows, this setting is also the explicit unsafe host-execution opt-in required for startup because sandboxed bash is not available yet.
 
 This phase is for LLM configuration. Complete channel setup separately in Phase 3C: Required Feishu/Lark setup.
 
@@ -286,6 +290,7 @@ Check these first:
 - inconsistent provider or model IDs
 - a provider with no usable model mapping
 - an empty scenario list for a setup that is supposed to be runnable
+- on native Windows, startup failure because `[runtime] autopilot = true` is not set; enabling it means bash commands run directly on the Windows host with full access and no Linux sandbox isolation
 - on Linux, sandbox setup failures:
   - missing `bwrap`, `socat`, or `rg`
   - bubblewrap namespace or setuid failures from Phase 1

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -15,14 +15,17 @@ fail() {
   printf '[doctor] error: %s\n' "$*" >&2
 }
 
-print_windows_unsupported() {
-  cat >&2 <<EOF
-[doctor] Pokoclaw does not currently support Windows.
+print_windows_autopilot_notice() {
+  cat <<EOF
+[doctor] Pokoclaw only supports native Windows bash through an explicit Autopilot opt-in.
 [doctor]
-[doctor] If you want to help add Windows compatibility, contributions are welcome:
-[doctor] ${REPO_URL}
+[doctor] Set this in ~/.pokoclaw/system/config.toml and restart Pokoclaw:
 [doctor]
-[doctor] Please open an issue or PR with details about your environment.
+[doctor]   [runtime]
+[doctor]   autopilot = true
+[doctor]
+[doctor] With that setting enabled, bash commands run on the Windows host with full access.
+[doctor] This is not Linux sandbox isolation.
 EOF
 }
 
@@ -190,8 +193,8 @@ main() {
       check_linux_host || failures=$((failures + $?))
       ;;
     MINGW* | MSYS* | CYGWIN*)
-      print_windows_unsupported
-      exit 2
+      print_windows_autopilot_notice
+      check_common_tools || failures=$((failures + $?))
       ;;
     *)
       print_unknown_unsupported "${os_name}"

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,10 @@ import { SandboxManager } from "@danielwpz/sandbox-runtime";
 import { getDefaultConfigPaths, loadConfig } from "@/src/config/load.js";
 import type { AppConfig } from "@/src/config/schema.js";
 import { createRuntimeBootstrap } from "@/src/runtime/bootstrap.js";
+import {
+  assertNativeWindowsRuntimeSupported,
+  shouldInitializeSandboxRuntime,
+} from "@/src/runtime/host-platform.js";
 import { readLastRuntimeLogTimestamp } from "@/src/runtime/runtime-log.js";
 import { buildSystemPolicy } from "@/src/security/policy.js";
 import {
@@ -42,8 +46,15 @@ export async function main(): Promise<void> {
       models: config.models.catalog.length,
     });
 
-    await initializeSandboxRuntime(config.security);
-    sandboxRuntimeInitialized = true;
+    assertNativeWindowsRuntimeSupported({ autopilotEnabled: config.runtime.autopilot });
+    if (shouldInitializeSandboxRuntime({ autopilotEnabled: config.runtime.autopilot })) {
+      await initializeSandboxRuntime(config.security);
+      sandboxRuntimeInitialized = true;
+    } else {
+      logger.warn("skipping sandbox runtime on native Windows autopilot host execution", {
+        reason: "sandbox-runtime does not support native Windows",
+      });
+    }
 
     storage = await initializeStorageOnStartup();
     runtime = createRuntimeBootstrap({

--- a/src/runtime/host-platform.ts
+++ b/src/runtime/host-platform.ts
@@ -1,0 +1,23 @@
+export function isNativeWindowsPlatform(platform: NodeJS.Platform = process.platform): boolean {
+  return platform === "win32";
+}
+
+export function assertNativeWindowsRuntimeSupported(input: {
+  autopilotEnabled: boolean;
+  platform?: NodeJS.Platform;
+}): void {
+  if (!isNativeWindowsPlatform(input.platform) || input.autopilotEnabled) {
+    return;
+  }
+
+  throw new Error(
+    "Native Windows requires `[runtime] autopilot = true` in ~/.pokoclaw/system/config.toml. With this opt-in, bash commands run on the Windows host with full access instead of Linux sandbox isolation.",
+  );
+}
+
+export function shouldInitializeSandboxRuntime(input: {
+  autopilotEnabled: boolean;
+  platform?: NodeJS.Platform;
+}): boolean {
+  return !(isNativeWindowsPlatform(input.platform) && input.autopilotEnabled);
+}

--- a/src/security/sandbox.ts
+++ b/src/security/sandbox.ts
@@ -787,6 +787,7 @@ async function runUnsandboxedShellCommand(input: {
 
 async function terminateWindowsProcessTree(pid: number): Promise<boolean> {
   return await new Promise<boolean>((resolve) => {
+    const TASKKILL_TIMEOUT_MS = 5_000;
     let taskkill: ChildProcess;
     try {
       taskkill = spawn("taskkill", ["/pid", String(pid), "/t", "/f"], {
@@ -799,11 +800,20 @@ async function terminateWindowsProcessTree(pid: number): Promise<boolean> {
     }
 
     let settled = false;
+    const timeout = setTimeout(() => {
+      try {
+        taskkill.kill("SIGKILL");
+      } catch {
+        // Best-effort cleanup if taskkill itself gets stuck.
+      }
+      finish(false);
+    }, TASKKILL_TIMEOUT_MS);
     const finish = (killed: boolean) => {
       if (settled) {
         return;
       }
       settled = true;
+      clearTimeout(timeout);
       taskkill.removeAllListeners();
       resolve(killed);
     };

--- a/src/security/sandbox.ts
+++ b/src/security/sandbox.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { type ChildProcess, spawn } from "node:child_process";
 import { stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -43,7 +43,9 @@ export interface ExecuteSandboxedBashInput {
   timeoutMs: number;
 }
 
-export interface ExecuteUnsandboxedBashInput extends ExecuteSandboxedBashInput {}
+export interface ExecuteUnsandboxedBashInput extends ExecuteSandboxedBashInput {
+  platform?: NodeJS.Platform;
+}
 
 export interface SandboxedBashResult extends SandboxExecResult {
   command: string;
@@ -203,6 +205,7 @@ export async function executeUnsandboxedBash(
       command: input.command,
       cwd,
       abortSignal,
+      platform: input.platform ?? process.platform,
     });
 
     logger.info("bash full-access host exec done", {
@@ -682,6 +685,7 @@ async function runUnsandboxedShellCommand(input: {
   command: string;
   cwd: string;
   abortSignal: AbortSignal;
+  platform: NodeJS.Platform;
 }): Promise<SandboxExecResult> {
   if (input.abortSignal.aborted) {
     throw createAbortError();
@@ -691,7 +695,7 @@ async function runUnsandboxedShellCommand(input: {
     const child = spawn(DEFAULT_BASH_BINARY, ["-lc", input.command], {
       cwd: input.cwd,
       env: sanitizeSandboxEnv(process.env),
-      detached: process.platform !== "win32",
+      detached: input.platform !== "win32",
       stdio: ["ignore", "pipe", "pipe"],
     });
 
@@ -708,13 +712,20 @@ async function runUnsandboxedShellCommand(input: {
       fn();
     };
 
-    const killChild = () => {
+    const killChild = async () => {
       if (child.exitCode != null || child.signalCode != null) {
         return;
       }
 
       try {
-        if (process.platform !== "win32" && child.pid != null) {
+        if (input.platform === "win32" && child.pid != null) {
+          if (await terminateWindowsProcessTree(child.pid)) {
+            return;
+          }
+          child.kill("SIGKILL");
+          return;
+        }
+        if (child.pid != null) {
           process.kill(-child.pid, "SIGKILL");
         } else {
           child.kill("SIGKILL");
@@ -728,9 +739,10 @@ async function runUnsandboxedShellCommand(input: {
       }
     };
 
+    let aborting = false;
     const onAbort = () => {
-      killChild();
-      finish(() => reject(createAbortError()));
+      aborting = true;
+      void killChild().finally(() => finish(() => reject(createAbortError())));
     };
 
     const cleanup = () => {
@@ -751,8 +763,16 @@ async function runUnsandboxedShellCommand(input: {
     child.stderr?.on("data", (chunk: Buffer | string) => {
       stderr += typeof chunk === "string" ? chunk : chunk.toString("utf8");
     });
-    child.once("error", (error) => finish(() => reject(error)));
-    child.once("close", (exitCode, signal) =>
+    child.once("error", (error) => {
+      if (aborting) {
+        return;
+      }
+      finish(() => reject(error));
+    });
+    child.once("close", (exitCode, signal) => {
+      if (aborting) {
+        return;
+      }
       finish(() =>
         resolve({
           stdout,
@@ -760,8 +780,36 @@ async function runUnsandboxedShellCommand(input: {
           exitCode,
           signal,
         }),
-      ),
-    );
+      );
+    });
+  });
+}
+
+async function terminateWindowsProcessTree(pid: number): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    let taskkill: ChildProcess;
+    try {
+      taskkill = spawn("taskkill", ["/pid", String(pid), "/t", "/f"], {
+        stdio: "ignore",
+        windowsHide: true,
+      });
+    } catch {
+      resolve(false);
+      return;
+    }
+
+    let settled = false;
+    const finish = (killed: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      taskkill.removeAllListeners();
+      resolve(killed);
+    };
+
+    taskkill.once("error", () => finish(false));
+    taskkill.once("close", (exitCode) => finish(exitCode === 0));
   });
 }
 

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -1,5 +1,5 @@
 import { type Static, Type } from "@sinclair/typebox";
-
+import { isNativeWindowsPlatform } from "@/src/runtime/host-platform.js";
 import { classifyBashApprovalHelper } from "@/src/security/bash-approval-helpers.js";
 import {
   type BashCommandSegment,
@@ -21,6 +21,7 @@ const MAX_TIMEOUT_SEC = 10 * 60;
 const MAX_MAIN_CHAT_AGENT_TIMEOUT_SEC = 60;
 const MAX_OUTPUT_CHARS = 128_000;
 const MISSING_PREFIX_GUIDANCE_CODE = "bash_full_access_missing_prefix";
+const WINDOWS_BASH_REQUIRES_AUTOPILOT_CODE = "windows_bash_requires_autopilot_full_access";
 
 export const BASH_TOOL_SCHEMA = Type.Object(
   {
@@ -104,18 +105,26 @@ export function createBashTool() {
 
       assertBashTimeoutAllowed(context, args);
       const timeoutMs = getBashInvocationTimeoutMs(context, args);
-      const sandboxMode = args.sandboxMode ?? "sandboxed";
-      if (sandboxMode !== "full_access" && (args.justification != null || args.prefix != null)) {
+      const requestedSandboxMode = args.sandboxMode ?? "sandboxed";
+      if (
+        requestedSandboxMode !== "full_access" &&
+        (args.justification != null || args.prefix != null)
+      ) {
         throw toolRecoverableError(buildFullAccessArgsRequireModeMessage(args), {
           code: "bash_full_access_args_require_full_access_mode",
         });
       }
+      const effectiveExecution = resolveEffectiveBashExecution({
+        context,
+        requestedSandboxMode,
+      });
+      const sandboxMode = effectiveExecution.sandboxMode;
       const security = new SecurityService(
         context.storage,
         buildSystemPolicy({ security: context.securityConfig }),
       );
       const parsedCommandSequence =
-        sandboxMode === "full_access"
+        sandboxMode === "full_access" && !effectiveExecution.windowsAutopilotHostExecution
           ? await parseConservativeBashCommandSequence(args.command)
           : null;
       const normalizedCommandPrefix =
@@ -123,8 +132,14 @@ export function createBashTool() {
           ? (parsedCommandSequence.commands[0]?.argv ?? null)
           : normalizeBashCommandPrefix(args.command);
 
-      const result =
-        sandboxMode === "full_access"
+      const result = effectiveExecution.windowsAutopilotHostExecution
+        ? await executeUnsandboxedBash({
+            context,
+            command: args.command,
+            timeoutMs,
+            ...(args.cwd === undefined ? {} : { cwd: args.cwd }),
+          })
+        : sandboxMode === "full_access"
           ? await executeBashWithFullAccessIfAllowed({
               context,
               args,
@@ -162,6 +177,36 @@ export function createBashTool() {
         outputTruncated: rendered.truncated,
       });
     },
+  });
+}
+
+type BashSandboxMode = NonNullable<BashToolArgs["sandboxMode"]>;
+
+function resolveEffectiveBashExecution(input: {
+  context: ToolExecutionContext;
+  requestedSandboxMode: BashSandboxMode;
+  platform?: NodeJS.Platform;
+}): {
+  sandboxMode: BashSandboxMode;
+  windowsAutopilotHostExecution: boolean;
+} {
+  if (!isNativeWindowsPlatform(input.platform) || input.requestedSandboxMode === "full_access") {
+    return {
+      sandboxMode: input.requestedSandboxMode,
+      windowsAutopilotHostExecution: false,
+    };
+  }
+
+  if (input.context.approvalState?.runtimeModeAutoApproval?.source === "autopilot") {
+    return {
+      sandboxMode: "full_access",
+      windowsAutopilotHostExecution: true,
+    };
+  }
+
+  throw toolRecoverableError(buildWindowsBashRequiresAutopilotMessage(), {
+    code: WINDOWS_BASH_REQUIRES_AUTOPILOT_CODE,
+    requestedSandboxMode: input.requestedSandboxMode,
   });
 }
 
@@ -442,6 +487,16 @@ function buildFullAccessArgsRequireModeMessage(args: BashToolArgs): string {
     "```json",
     fullAccessRetry,
     "```",
+  ].join("\n");
+}
+
+function buildWindowsBashRequiresAutopilotMessage(): string {
+  return [
+    "Native Windows cannot run sandboxed bash commands yet.",
+    "",
+    "To opt in to Windows bash host execution, set `[runtime] autopilot = true` in `~/.pokoclaw/system/config.toml` and restart Pokoclaw.",
+    "",
+    "With that setting enabled, bash commands run on the Windows host with full access. This is not Linux sandbox isolation, so only enable it on a machine and workspace where that trust model is acceptable.",
   ].join("\n");
 }
 

--- a/tests/agent/bash-approval.test.ts
+++ b/tests/agent/bash-approval.test.ts
@@ -26,6 +26,8 @@ import {
   type TestDatabaseHandle,
 } from "@/tests/storage/helpers/test-db.js";
 
+const originalProcessPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+
 vi.mock("@/src/security/sandbox.js", async () => {
   const actual = await vi.importActual<typeof import("@/src/security/sandbox.js")>(
     "@/src/security/sandbox.js",
@@ -142,16 +144,34 @@ describe("agent loop bash approval flow", () => {
   let handle: TestDatabaseHandle | null = null;
 
   beforeEach(() => {
+    mockProcessPlatform("linux");
     executeSandboxedBashMock.mockReset();
     executeUnsandboxedBashMock.mockReset();
   });
 
   afterEach(async () => {
+    restoreProcessPlatform();
     if (handle != null) {
       await destroyTestDatabase(handle);
       handle = null;
     }
   });
+
+  function mockProcessPlatform(platform: NodeJS.Platform): void {
+    Object.defineProperty(process, "platform", {
+      value: platform,
+      configurable: true,
+      enumerable: originalProcessPlatformDescriptor?.enumerable ?? true,
+    });
+  }
+
+  function restoreProcessPlatform(): void {
+    if (originalProcessPlatformDescriptor == null) {
+      return;
+    }
+
+    Object.defineProperty(process, "platform", originalProcessPlatformDescriptor);
+  }
 
   test("pauses and resumes the same bash tool call after one-shot full-access approval", async () => {
     handle = await createTestDatabase(import.meta.url);

--- a/tests/security/sandbox.windows-timeout.test.ts
+++ b/tests/security/sandbox.windows-timeout.test.ts
@@ -35,6 +35,7 @@ describe("Windows host bash timeout cleanup", () => {
   let tempDir: string | null = null;
 
   beforeEach(() => {
+    vi.useRealTimers();
     vi.resetModules();
     spawnMock.mockReset();
     spawnCalls.length = 0;
@@ -53,6 +54,7 @@ describe("Windows host bash timeout cleanup", () => {
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     vi.resetModules();
     if (tempDir != null) {
       await rm(tempDir, { recursive: true, force: true });
@@ -100,6 +102,48 @@ describe("Windows host bash timeout cleanup", () => {
     });
     expect(spawnCalls[0]?.child.kill).not.toHaveBeenCalled();
   });
+
+  test("falls back to killing bash when taskkill hangs", async () => {
+    spawnMock.mockImplementation(
+      (command: string, args: string[] = [], options: Record<string, unknown> = {}) => {
+        const child = createFakeChild(command === "taskkill" ? 456 : 123);
+        spawnCalls.push({ command, args, options, child });
+        return child;
+      },
+    );
+
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "pokoclaw-windows-timeout-"));
+    const { executeUnsandboxedBash } = await import("@/src/security/sandbox.js");
+
+    const promise = executeUnsandboxedBash({
+      context: {
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        ownerAgentId: "agent_1",
+        cwd: tempDir,
+        securityConfig: DEFAULT_CONFIG.security,
+        storage: {} as ToolExecutionContext["storage"],
+        toolCallId: "tool_1",
+      },
+      command: "node child-process-that-outlives-bash.js",
+      cwd: tempDir,
+      timeoutMs: 5,
+      platform: "win32",
+    });
+
+    await expect(promise).rejects.toMatchObject({
+      name: "ToolFailure",
+      kind: "recoverable_error",
+      details: {
+        code: "bash_timeout",
+        timeoutMs: 5,
+      },
+    });
+
+    expect(spawnCalls.map((call) => path.basename(call.command))).toEqual(["bash", "taskkill"]);
+    expect(spawnCalls[1]?.child.kill).toHaveBeenCalledWith("SIGKILL");
+    expect(spawnCalls[0]?.child.kill).toHaveBeenCalledWith("SIGKILL");
+  }, 8_000);
 });
 
 function createFakeChild(pid: number): FakeChildProcess {

--- a/tests/security/sandbox.windows-timeout.test.ts
+++ b/tests/security/sandbox.windows-timeout.test.ts
@@ -1,0 +1,114 @@
+import { EventEmitter } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { DEFAULT_CONFIG } from "@/src/config/defaults.js";
+import type { ToolExecutionContext } from "@/src/tools/core/types.js";
+
+const { spawnMock, spawnCalls } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  spawnCalls: [] as Array<{
+    command: string;
+    args: string[];
+    options: Record<string, unknown>;
+    child: FakeChildProcess;
+  }>,
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: spawnMock,
+}));
+
+type FakeChildProcess = EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  pid: number;
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  kill: ReturnType<typeof vi.fn>;
+};
+
+describe("Windows host bash timeout cleanup", () => {
+  let tempDir: string | null = null;
+
+  beforeEach(() => {
+    vi.resetModules();
+    spawnMock.mockReset();
+    spawnCalls.length = 0;
+    spawnMock.mockImplementation(
+      (command: string, args: string[] = [], options: Record<string, unknown> = {}) => {
+        const child = createFakeChild(command === "taskkill" ? 456 : 123);
+        spawnCalls.push({ command, args, options, child });
+
+        if (command === "taskkill") {
+          queueMicrotask(() => child.emit("close", 0, null));
+        }
+
+        return child;
+      },
+    );
+  });
+
+  afterEach(async () => {
+    vi.resetModules();
+    if (tempDir != null) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  test("terminates the Windows host bash process tree before reporting timeout", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "pokoclaw-windows-timeout-"));
+    const { executeUnsandboxedBash } = await import("@/src/security/sandbox.js");
+
+    await expect(
+      executeUnsandboxedBash({
+        context: {
+          sessionId: "sess_1",
+          conversationId: "conv_1",
+          ownerAgentId: "agent_1",
+          cwd: tempDir,
+          securityConfig: DEFAULT_CONFIG.security,
+          storage: {} as ToolExecutionContext["storage"],
+          toolCallId: "tool_1",
+        },
+        command: "node child-process-that-outlives-bash.js",
+        cwd: tempDir,
+        timeoutMs: 5,
+        platform: "win32",
+      }),
+    ).rejects.toMatchObject({
+      name: "ToolFailure",
+      kind: "recoverable_error",
+      details: {
+        code: "bash_timeout",
+        timeoutMs: 5,
+      },
+    });
+
+    expect(spawnCalls.map((call) => path.basename(call.command))).toEqual(["bash", "taskkill"]);
+    expect(spawnCalls[1]).toMatchObject({
+      command: "taskkill",
+      args: ["/pid", "123", "/t", "/f"],
+      options: {
+        stdio: "ignore",
+        windowsHide: true,
+      },
+    });
+    expect(spawnCalls[0]?.child.kill).not.toHaveBeenCalled();
+  });
+});
+
+function createFakeChild(pid: number): FakeChildProcess {
+  const child = new EventEmitter() as FakeChildProcess;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.pid = pid;
+  child.exitCode = null;
+  child.signalCode = null;
+  child.kill = vi.fn();
+  return child;
+}

--- a/tests/tools/bash.test.ts
+++ b/tests/tools/bash.test.ts
@@ -19,6 +19,8 @@ import {
 } from "@/tests/storage/helpers/test-db.js";
 import { seedConversationAndAgentFixture } from "@/tests/tools/helpers.js";
 
+const originalProcessPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+
 vi.mock("@/src/security/sandbox.js", async () => {
   const actual = await vi.importActual<typeof import("@/src/security/sandbox.js")>(
     "@/src/security/sandbox.js",
@@ -35,11 +37,13 @@ describe("bash tool", () => {
   let handle: TestDatabaseHandle | null = null;
 
   beforeEach(() => {
+    mockProcessPlatform("linux");
     executeSandboxedBashMock.mockReset();
     executeUnsandboxedBashMock.mockReset();
   });
 
   afterEach(async () => {
+    restoreProcessPlatform();
     if (handle != null) {
       await destroyTestDatabase(handle);
       handle = null;
@@ -67,6 +71,22 @@ describe("bash tool", () => {
         '2026-03-22T00:00:00.000Z'
       );
     `);
+  }
+
+  function mockProcessPlatform(platform: NodeJS.Platform): void {
+    Object.defineProperty(process, "platform", {
+      value: platform,
+      configurable: true,
+      enumerable: originalProcessPlatformDescriptor?.enumerable ?? true,
+    });
+  }
+
+  function restoreProcessPlatform(): void {
+    if (originalProcessPlatformDescriptor == null) {
+      return;
+    }
+
+    Object.defineProperty(process, "platform", originalProcessPlatformDescriptor);
   }
 
   test("returns stdout for a successful command", async () => {
@@ -128,6 +148,133 @@ describe("bash tool", () => {
 </bash_result>`,
       },
     ]);
+  });
+
+  test("uses host full-access bash by default on native Windows when autopilot is enabled", async () => {
+    mockProcessPlatform("win32");
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+    executeUnsandboxedBashMock.mockResolvedValue({
+      command: "pwd",
+      cwd: "/tmp/work",
+      timeoutMs: 10_000,
+      stdout: "/tmp/work\n",
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    });
+
+    const registry = new ToolRegistry([createBashTool()]);
+    const result = await registry.execute(
+      "bash",
+      {
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        ownerAgentId: "agent_1",
+        cwd: "/tmp/work",
+        securityConfig: DEFAULT_CONFIG.security,
+        storage: handle.storage.db,
+        approvalState: {
+          runtimeModeAutoApproval: {
+            source: "autopilot",
+          },
+        },
+      },
+      {
+        command: "pwd",
+      },
+    );
+
+    expect(executeUnsandboxedBashMock).toHaveBeenCalledWith({
+      context: expect.objectContaining({
+        sessionId: "sess_1",
+      }),
+      command: "pwd",
+      timeoutMs: 10_000,
+    });
+    expect(executeSandboxedBashMock).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({
+      command: "pwd",
+      cwd: "/tmp/work",
+      exitCode: 0,
+    });
+  });
+
+  test("rejects default native Windows bash unless autopilot is enabled", async () => {
+    mockProcessPlatform("win32");
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+
+    const registry = new ToolRegistry([createBashTool()]);
+    const failure = registry.execute(
+      "bash",
+      {
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        ownerAgentId: "agent_1",
+        cwd: "/tmp/work",
+        securityConfig: DEFAULT_CONFIG.security,
+        storage: handle.storage.db,
+      },
+      {
+        command: "pwd",
+      },
+    );
+
+    await expect(failure).rejects.toMatchObject({
+      name: "ToolFailure",
+      kind: "recoverable_error",
+      details: {
+        code: "windows_bash_requires_autopilot_full_access",
+        requestedSandboxMode: "sandboxed",
+      },
+    } satisfies Partial<ToolFailure>);
+
+    const message = await failure.catch((error) => (error instanceof Error ? error.message : ""));
+    expect(message).toMatch(/Native Windows cannot run sandboxed bash commands yet\./);
+    expect(message).toMatch(/\[runtime\] autopilot = true/);
+    expect(message).toMatch(/full access/);
+    expect(message).toMatch(/not Linux sandbox isolation/);
+    expect(executeSandboxedBashMock).not.toHaveBeenCalled();
+    expect(executeUnsandboxedBashMock).not.toHaveBeenCalled();
+  });
+
+  test("does not treat YOLO as native Windows bash host-execution opt-in", async () => {
+    mockProcessPlatform("win32");
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+
+    const registry = new ToolRegistry([createBashTool()]);
+    await expect(
+      registry.execute(
+        "bash",
+        {
+          sessionId: "sess_1",
+          conversationId: "conv_1",
+          ownerAgentId: "agent_1",
+          cwd: "/tmp/work",
+          securityConfig: DEFAULT_CONFIG.security,
+          storage: handle.storage.db,
+          approvalState: {
+            runtimeModeAutoApproval: {
+              source: "yolo",
+            },
+          },
+        },
+        {
+          command: "pwd",
+        },
+      ),
+    ).rejects.toMatchObject({
+      name: "ToolFailure",
+      kind: "recoverable_error",
+      details: {
+        code: "windows_bash_requires_autopilot_full_access",
+      },
+    } satisfies Partial<ToolFailure>);
+
+    expect(executeSandboxedBashMock).not.toHaveBeenCalled();
+    expect(executeUnsandboxedBashMock).not.toHaveBeenCalled();
   });
 
   test("returns non-zero exits as normal tool results", async () => {


### PR DESCRIPTION
## Summary

Implements the POK-47 Windows opt-in execution path for bash.

- On native Windows, default/sandboxed bash now requires `[runtime] autopilot = true`; without that explicit opt-in, startup and bash both fail clearly instead of attempting an unavailable sandbox runtime.
- With native Windows autopilot enabled, startup skips sandbox-runtime initialization and default bash commands execute directly on the Windows host through the existing full-access host execution path.
- YOLO is intentionally not treated as the native Windows host-execution opt-in. The Windows unsafe host path is gated specifically on global Autopilot.
- Windows host bash timeout cleanup now terminates the process tree with `taskkill /pid <pid> /t /f`; if `taskkill` itself hangs, a defensive timeout falls back to killing the bash child.
- Doctor, configuration docs, and onboarding docs now describe the required Windows opt-in and the fact that this is not Linux filesystem/network sandbox isolation.
- macOS and Linux default behavior remains unchanged: bash defaults to sandboxed execution, and explicit `full_access` keeps the existing approval/autopilot semantics.

## Scope Boundary

This PR intentionally solves only POK-47: the Windows execution foundation and Autopilot gate for host bash.

It does **not** duplicate POK-49. Agent-visible shell/runtime context, shell-kind detection, syntax hints, runtime status shell metadata, and the durable prompt section that tells agents which Windows shell they are using belong to POK-49 / PR #51.

That boundary keeps the architecture clean:

- POK-47 decides whether Windows can start and how bash is executed once the user explicitly opts into unsafe host execution.
- POK-49 teaches the agent what shell/runtime it is operating in and surfaces the unsafe-host-execution context in prompts and status views.

Until POK-49 lands, this PR should be treated as the execution-path foundation for Windows unsafe host mode, not the complete Windows user-facing shell-context layer.

## Validation

Passed locally after rebasing on current `main`:

- `pnpm exec biome check docs/onboarding.md docs/configuration.md src/runtime/host-platform.ts src/main.ts src/tools/bash.ts src/security/sandbox.ts tests/tools/bash.test.ts tests/agent/bash-approval.test.ts tests/security/sandbox.windows-timeout.test.ts`
- `pnpm test -- tests/tools/bash.test.ts tests/agent/bash-approval.test.ts tests/security/sandbox.windows-timeout.test.ts`
- `pnpm build`
- `pnpm preflight`
