### PR TITLE
Add Lark subagent chat label

### DIFF
--- a/docs/feishu-lark-setup.md
+++ b/docs/feishu-lark-setup.md
@@ -153,6 +153,8 @@ In **Permissions**, use **Batch import** and paste this permission set:
 
 If the platform UI or permission names have changed, adapt carefully instead of pretending the old list is exact.
 
+The `im:tag:*` and `im:biz_entity_tag_relation:*` scopes let Pokoclaw add the fixed `pokoclaw` enterprise custom group label to newly created SubAgent group chats. If these scopes are missing, SubAgent creation still succeeds, but the label step is skipped with a warning.
+
 ### 3C-6. Enable bot capability
 
 In **App Capability** > **Bot**:

--- a/src/channels/lark/subagent-provisioner.ts
+++ b/src/channels/lark/subagent-provisioner.ts
@@ -12,6 +12,8 @@ import { ConversationsRepo } from "@/src/storage/repos/conversations.repo.js";
 
 const logger = createSubsystemLogger("channels/lark-subagent-provisioner");
 
+const SUBAGENT_CHAT_TAG_NAME = "pokoclaw";
+
 export interface CreateLarkSubagentConversationSurfaceProvisionerInput {
   storage: StorageDb;
   clients: {
@@ -83,6 +85,8 @@ export function createLarkSubagentConversationSurfaceProvisioner(
           };
         }
 
+        const subagentChatTagId = await applySubagentChatTag(client, externalChatId);
+
         const memberIds = await listChatMemberIds(client, sourceConversation.externalChatId);
         if (memberIds.length > 0) {
           const addResp = await client.sdk.im.chatMembers.create({
@@ -112,6 +116,7 @@ export function createLarkSubagentConversationSurfaceProvisioner(
           shareLink,
           channelInstallationId: installationId,
           memberCount: memberIds.length,
+          subagentChatTagId,
         });
 
         return {
@@ -151,6 +156,52 @@ export function createLarkSubagentConversationSurfaceProvisioner(
       }
     },
   };
+}
+
+async function applySubagentChatTag(client: LarkSdkClient, chatId: string): Promise<string | null> {
+  try {
+    const tagResp = await client.sdk.im.v2.tag.create({
+      data: {
+        create_tag: {
+          tag_type: "tenant",
+          name: SUBAGENT_CHAT_TAG_NAME,
+        },
+      },
+    });
+    assertLarkOk(tagResp, `create or reuse lark subagent chat tag ${SUBAGENT_CHAT_TAG_NAME}`);
+
+    const tagId = tagResp.data?.id ?? tagResp.data?.create_tag_fail_reason?.duplicate_id ?? "";
+    if (tagId.length === 0) {
+      logger.warn("lark subagent chat tag creation returned no tag id", {
+        chatId,
+        tagName: SUBAGENT_CHAT_TAG_NAME,
+      });
+      return null;
+    }
+
+    const bindResp = await client.sdk.im.v2.bizEntityTagRelation.create({
+      data: {
+        tag_biz_type: "chat",
+        biz_entity_id: chatId,
+        tag_ids: [tagId],
+      },
+    });
+    assertLarkOk(bindResp, `bind lark subagent chat tag ${SUBAGENT_CHAT_TAG_NAME}`);
+
+    logger.info("tagged lark subagent chat surface", {
+      chatId,
+      tagName: SUBAGENT_CHAT_TAG_NAME,
+      tagId,
+    });
+    return tagId;
+  } catch (error: unknown) {
+    logger.warn("failed to tag lark subagent chat surface", {
+      chatId,
+      tagName: SUBAGENT_CHAT_TAG_NAME,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
 }
 
 async function listChatMemberIds(client: LarkSdkClient, chatId: string): Promise<string[]> {

--- a/tests/channels/lark/subagent-provisioner.test.ts
+++ b/tests/channels/lark/subagent-provisioner.test.ts
@@ -41,6 +41,10 @@ describe("lark subagent provisioner", () => {
     const chatMembersCreate = vi.fn(async () => ({ data: { invalid_id_list: [] } }));
     const messageCreate = vi.fn(async () => ({ data: { message_id: "om_welcome_1" } }));
     const putTopNotice = vi.fn(async () => ({ data: {} }));
+    const tagCreate = vi.fn(async () => ({
+      data: { create_tag_fail_reason: { duplicate_id: "tag_pokoclaw" } },
+    }));
+    const bizEntityTagRelationCreate = vi.fn(async () => ({ data: {} }));
 
     const provisioner = createLarkSubagentConversationSurfaceProvisioner({
       storage: handle.storage.db,
@@ -63,6 +67,14 @@ describe("lark subagent provisioner", () => {
                 },
                 chatTopNotice: {
                   putTopNotice,
+                },
+                v2: {
+                  tag: {
+                    create: tagCreate,
+                  },
+                  bizEntityTagRelation: {
+                    create: bizEntityTagRelationCreate,
+                  },
                 },
               },
             },
@@ -97,6 +109,21 @@ describe("lark subagent provisioner", () => {
     expect(chatCreate).toHaveBeenCalledWith({
       data: {
         name: "PR Review",
+      },
+    });
+    expect(tagCreate).toHaveBeenCalledExactlyOnceWith({
+      data: {
+        create_tag: {
+          tag_type: "tenant",
+          name: "pokoclaw",
+        },
+      },
+    });
+    expect(bizEntityTagRelationCreate).toHaveBeenCalledExactlyOnceWith({
+      data: {
+        tag_biz_type: "chat",
+        biz_entity_id: "chat_sub_1",
+        tag_ids: ["tag_pokoclaw"],
       },
     });
     expect(chatDelete).not.toHaveBeenCalled();
@@ -159,6 +186,94 @@ describe("lark subagent provisioner", () => {
         chat_top_notice: [{ action_type: "1", message_id: "om_welcome_1" }],
       },
     });
+  });
+
+  test("continues provisioning when lark subagent chat tagging fails", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    handle.storage.sqlite.exec(`
+      INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+      VALUES ('ci_1', 'lark', 'default', '2026-03-29T00:00:00.000Z', '2026-03-29T00:00:00.000Z');
+
+      INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, title, created_at, updated_at)
+      VALUES ('conv_main', 'ci_1', 'chat_main', 'dm', 'Main', '2026-03-29T00:00:00.000Z', '2026-03-29T00:00:00.000Z');
+    `);
+
+    const chatCreate = vi.fn(async () => ({ data: { chat_id: "chat_sub_tag_failure" } }));
+    const chatDelete = vi.fn(async () => ({ data: {} }));
+    const chatLink = vi.fn(async () => ({
+      data: { share_link: "https://example.com/subagent-tag-failure" },
+    }));
+    const chatMembersGet = vi.fn(async () => ({
+      data: {
+        items: [{ member_id: "ou_user_1" }],
+        has_more: false,
+      },
+    }));
+    const chatMembersCreate = vi.fn(async () => ({ data: { invalid_id_list: [] } }));
+    const messageCreate = vi.fn(async () => ({ data: { message_id: "om_welcome_tag_failure" } }));
+    const putTopNotice = vi.fn(async () => ({ data: {} }));
+    const tagCreate = vi.fn(async () => {
+      throw new Error("missing im:tag:write");
+    });
+
+    const provisioner = createLarkSubagentConversationSurfaceProvisioner({
+      storage: handle.storage.db,
+      clients: {
+        getOrCreate: () =>
+          ({
+            sdk: {
+              im: {
+                chat: {
+                  create: chatCreate,
+                  delete: chatDelete,
+                  link: chatLink,
+                },
+                chatMembers: {
+                  get: chatMembersGet,
+                  create: chatMembersCreate,
+                },
+                message: {
+                  create: messageCreate,
+                },
+                chatTopNotice: {
+                  putTopNotice,
+                },
+                v2: {
+                  tag: {
+                    create: tagCreate,
+                  },
+                  bizEntityTagRelation: {
+                    create: vi.fn(async () => ({ data: {} })),
+                  },
+                },
+              },
+            },
+          }) as never,
+      },
+    });
+
+    const result = await provisioner.provisionSubagentSurface({
+      conversationId: "conv_sub_tag_failure",
+      sourceConversationId: "conv_main",
+      channelInstanceId: "ci_1",
+      title: "PR Review",
+      description: "Review pull requests and summarize findings.",
+      initialTask: "Review the current PR and report concrete issues.",
+      workdir: "/Users/example/work/pokoclaw",
+      privateWorkspaceDir: "/Users/example/.pokoclaw/workspace/subagents/abcd1234",
+      preferredSurface: "independent_chat",
+    });
+
+    expect(result).toMatchObject({
+      status: "provisioned",
+      externalChatId: "chat_sub_tag_failure",
+      shareLink: "https://example.com/subagent-tag-failure",
+    });
+    expect(tagCreate).toHaveBeenCalledOnce();
+    expect(chatMembersCreate).toHaveBeenCalledOnce();
+    expect(messageCreate).toHaveBeenCalledOnce();
+    expect(putTopNotice).toHaveBeenCalledOnce();
+    expect(chatDelete).not.toHaveBeenCalled();
   });
 
   test("cleans up the created chat when provisioning fails after chat.create", async () => {


### PR DESCRIPTION
## Summary
- add a Lark-channel-only non-blocking step that creates or reuses the fixed `pokoclaw` enterprise custom group label for new SubAgent group chats
- bind the label to the created chat through Feishu/Lark IM v2 tag relation APIs
- document the required tag scopes in the Feishu/Lark setup guide
- cover successful existing-label reuse and tag API failure fallback in Lark provisioner tests

## Validation
- `pnpm preflight`
- commit hook reran `pnpm preflight`

Linear: POK-50