### PR TITLE
POK-50: 创建 SubAgent 时给飞书群聊自动添加 pokoclaw 标签

### DIFF
--- a/src/channels/lark/subagent-provisioner.ts
+++ b/src/channels/lark/subagent-provisioner.ts
@@ -11,6 +11,8 @@ import { ChannelInstancesRepo } from "@/src/storage/repos/channel-instances.repo
 import { ConversationsRepo } from "@/src/storage/repos/conversations.repo.js";
 
 const logger = createSubsystemLogger("channels/lark-subagent-provisioner");
+// Lets users find and manage all Pokoclaw-created SubAgent chats from one Lark tag.
+const POKOCLAW_SUBAGENT_CHAT_TAG_NAME = "pokoclaw";
 
 export interface CreateLarkSubagentConversationSurfaceProvisionerInput {
   storage: StorageDb;
@@ -92,6 +94,13 @@ export function createLarkSubagentConversationSurfaceProvisioner(
           });
           assertLarkOk(addResp, "add subagent chat members");
         }
+
+        await applyPokoclawSubagentChatTag({
+          client,
+          chatId: externalChatId,
+          storage: input.storage,
+          channelInstanceId: channelInstance.id,
+        });
 
         const shareLink = await getChatShareLink(client, externalChatId);
         await publishWelcomeNotice({
@@ -184,6 +193,172 @@ async function listChatMemberIds(client: LarkSdkClient, chatId: string): Promise
 
 function buildSubagentChatName(title: string): string {
   return title.trim();
+}
+
+async function applyPokoclawSubagentChatTag(input: {
+  client: LarkSdkClient;
+  chatId: string;
+  storage: StorageDb;
+  channelInstanceId: string;
+}): Promise<void> {
+  try {
+    const tagId = await ensurePokoclawSubagentChatTag(input);
+    const existingTagIds = await getChatTagIds(input.client, input.chatId);
+    if (existingTagIds.includes(tagId)) {
+      return;
+    }
+
+    const tagIds = existingTagIds.length > 0 ? [...existingTagIds, tagId] : [tagId];
+    const response =
+      existingTagIds.length > 0
+        ? await input.client.sdk.im.v2.bizEntityTagRelation.update({
+            data: {
+              tag_biz_type: "chat",
+              biz_entity_id: input.chatId,
+              tag_ids: tagIds,
+            },
+          })
+        : await input.client.sdk.im.v2.bizEntityTagRelation.create({
+            data: {
+              tag_biz_type: "chat",
+              biz_entity_id: input.chatId,
+              tag_ids: tagIds,
+            },
+          });
+    assertLarkOk(
+      response,
+      `bind ${POKOCLAW_SUBAGENT_CHAT_TAG_NAME} tag to subagent chat ${input.chatId}`,
+    );
+  } catch (error: unknown) {
+    logger.warn("failed to tag lark subagent chat for unified management", {
+      chatId: input.chatId,
+      tagName: POKOCLAW_SUBAGENT_CHAT_TAG_NAME,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function ensurePokoclawSubagentChatTag(input: {
+  client: LarkSdkClient;
+  storage: StorageDb;
+  channelInstanceId: string;
+}): Promise<string> {
+  const response = await input.client.sdk.im.v2.tag.create({
+    data: {
+      create_tag: {
+        tag_type: "tenant",
+        name: POKOCLAW_SUBAGENT_CHAT_TAG_NAME,
+        i18n_names: [
+          {
+            locale: "zh_cn",
+            name: POKOCLAW_SUBAGENT_CHAT_TAG_NAME,
+          },
+          {
+            locale: "en_us",
+            name: POKOCLAW_SUBAGENT_CHAT_TAG_NAME,
+          },
+        ],
+      },
+    },
+  });
+
+  const tagId = response.data?.id ?? response.data?.create_tag_fail_reason?.duplicate_id ?? "";
+  if (tagId.length > 0) {
+    return tagId;
+  }
+
+  if (isDuplicateTagNameResponse(response)) {
+    const existingTagId = await findExistingPokoclawSubagentChatTagId(input);
+    if (existingTagId != null) {
+      return existingTagId;
+    }
+  }
+
+  assertLarkOk(response, `ensure ${POKOCLAW_SUBAGENT_CHAT_TAG_NAME} lark tag`);
+  throw new Error(`Lark tag.create returned no id for ${POKOCLAW_SUBAGENT_CHAT_TAG_NAME}`);
+}
+
+function isDuplicateTagNameResponse(response: {
+  code?: number | undefined;
+  msg?: string | undefined;
+}): boolean {
+  return response.code === 402 && response.msg === "duplicate name in tenant";
+}
+
+async function findExistingPokoclawSubagentChatTagId(input: {
+  client: LarkSdkClient;
+  storage: StorageDb;
+  channelInstanceId: string;
+}): Promise<string | null> {
+  const conversations = new ConversationsRepo(input.storage).listByChannelInstanceId(
+    input.channelInstanceId,
+    100,
+  );
+
+  for (const conversation of conversations) {
+    const tagId = await findPokoclawTagIdBoundToChat(input.client, conversation.externalChatId);
+    if (tagId != null) {
+      return tagId;
+    }
+  }
+
+  return null;
+}
+
+async function findPokoclawTagIdBoundToChat(
+  client: LarkSdkClient,
+  chatId: string,
+): Promise<string | null> {
+  const response = await client.sdk.im.v2.bizEntityTagRelation.get({
+    params: {
+      tag_biz_type: "chat",
+      biz_entity_id: chatId,
+    },
+  });
+  if (response.code !== undefined && response.code !== 0) {
+    return null;
+  }
+
+  for (const item of response.data?.tag_info_with_bind_versions ?? []) {
+    const tagInfo = item.tag_info;
+    const tagId = tagInfo?.id ?? "";
+    if (tagInfo != null && tagId.length > 0 && isPokoclawSubagentTagInfo(tagInfo)) {
+      return tagId;
+    }
+  }
+
+  return null;
+}
+
+function isPokoclawSubagentTagInfo(tagInfo: {
+  name?: string | undefined;
+  i18n_names?: { name?: string | undefined }[] | undefined;
+}): boolean {
+  if (tagInfo.name === POKOCLAW_SUBAGENT_CHAT_TAG_NAME) {
+    return true;
+  }
+
+  return (tagInfo.i18n_names ?? []).some((item) => item.name === POKOCLAW_SUBAGENT_CHAT_TAG_NAME);
+}
+
+async function getChatTagIds(client: LarkSdkClient, chatId: string): Promise<string[]> {
+  const response = await client.sdk.im.v2.bizEntityTagRelation.get({
+    params: {
+      tag_biz_type: "chat",
+      biz_entity_id: chatId,
+    },
+  });
+  assertLarkOk(response, `list tags for subagent chat ${chatId}`);
+
+  const tagIds = new Set<string>();
+  for (const item of response.data?.tag_info_with_bind_versions ?? []) {
+    const tagId = item.tag_info?.id ?? "";
+    if (tagId.length > 0) {
+      tagIds.add(tagId);
+    }
+  }
+
+  return Array.from(tagIds);
 }
 
 async function getChatShareLink(client: LarkSdkClient, chatId: string): Promise<string | null> {

--- a/tests/channels/lark/subagent-provisioner.test.ts
+++ b/tests/channels/lark/subagent-provisioner.test.ts
@@ -41,6 +41,23 @@ describe("lark subagent provisioner", () => {
     const chatMembersCreate = vi.fn(async () => ({ data: { invalid_id_list: [] } }));
     const messageCreate = vi.fn(async () => ({ data: { message_id: "om_welcome_1" } }));
     const putTopNotice = vi.fn(async () => ({ data: {} }));
+    const tagCreate = vi.fn(async () => ({
+      data: { create_tag_fail_reason: { duplicate_id: "tag_pokoclaw" } },
+    }));
+    const tagRelationGet = vi.fn(async () => ({
+      data: {
+        tag_info_with_bind_versions: [
+          {
+            tag_info: {
+              id: "tag_existing",
+              name: "existing",
+            },
+          },
+        ],
+      },
+    }));
+    const tagRelationUpdate = vi.fn(async () => ({ data: {} }));
+    const tagRelationCreate = vi.fn(async () => ({ data: {} }));
 
     const provisioner = createLarkSubagentConversationSurfaceProvisioner({
       storage: handle.storage.db,
@@ -63,6 +80,16 @@ describe("lark subagent provisioner", () => {
                 },
                 chatTopNotice: {
                   putTopNotice,
+                },
+                v2: {
+                  tag: {
+                    create: tagCreate,
+                  },
+                  bizEntityTagRelation: {
+                    get: tagRelationGet,
+                    update: tagRelationUpdate,
+                    create: tagRelationCreate,
+                  },
                 },
               },
             },
@@ -112,6 +139,38 @@ describe("lark subagent provisioner", () => {
       params: { member_id_type: "open_id" },
       data: { id_list: ["ou_user_1", "ou_user_2"] },
     });
+    expect(tagCreate).toHaveBeenCalledExactlyOnceWith({
+      data: {
+        create_tag: {
+          tag_type: "tenant",
+          name: "pokoclaw",
+          i18n_names: [
+            {
+              locale: "zh_cn",
+              name: "pokoclaw",
+            },
+            {
+              locale: "en_us",
+              name: "pokoclaw",
+            },
+          ],
+        },
+      },
+    });
+    expect(tagRelationGet).toHaveBeenCalledExactlyOnceWith({
+      params: {
+        tag_biz_type: "chat",
+        biz_entity_id: "chat_sub_1",
+      },
+    });
+    expect(tagRelationUpdate).toHaveBeenCalledExactlyOnceWith({
+      data: {
+        tag_biz_type: "chat",
+        biz_entity_id: "chat_sub_1",
+        tag_ids: ["tag_existing", "tag_pokoclaw"],
+      },
+    });
+    expect(tagRelationCreate).not.toHaveBeenCalled();
     expect(chatLink).toHaveBeenCalledExactlyOnceWith({
       path: { chat_id: "chat_sub_1" },
       data: { validity_period: "permanently" },
@@ -159,6 +218,132 @@ describe("lark subagent provisioner", () => {
         chat_top_notice: [{ action_type: "1", message_id: "om_welcome_1" }],
       },
     });
+  });
+
+  test("reuses a bound management tag when duplicate tag creation omits duplicate_id", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    handle.storage.sqlite.exec(`
+      INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+      VALUES ('ci_1', 'lark', 'default', '2026-03-29T00:00:00.000Z', '2026-03-29T00:00:00.000Z');
+
+      INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, title, created_at, updated_at)
+      VALUES
+        ('conv_main', 'ci_1', 'chat_main', 'dm', 'Main', '2026-03-29T00:00:00.000Z', '2026-03-29T00:00:00.000Z'),
+        ('conv_tagged', 'ci_1', 'chat_tagged', 'group', 'Tagged', '2026-03-29T00:01:00.000Z', '2026-03-29T00:01:00.000Z');
+    `);
+
+    const chatCreate = vi.fn(async () => ({ data: { chat_id: "chat_sub_duplicate_name" } }));
+    const chatDelete = vi.fn(async () => ({ data: {} }));
+    const chatMembersGet = vi.fn(async () => ({
+      data: {
+        items: [{ member_id: "ou_user_1" }],
+        has_more: false,
+      },
+    }));
+    const chatMembersCreate = vi.fn(async () => ({ data: { invalid_id_list: [] } }));
+    const chatLink = vi.fn(async () => ({
+      data: { share_link: "https://example.com/subagent-duplicate-name" },
+    }));
+    const messageCreate = vi.fn(async () => ({ data: { message_id: "om_welcome_duplicate" } }));
+    const putTopNotice = vi.fn(async () => ({ data: {} }));
+    const tagCreate = vi.fn(async () => ({
+      code: 402,
+      msg: "duplicate name in tenant",
+    }));
+    const tagRelationGet = vi.fn(async (payload: { params: { biz_entity_id: string } }) => {
+      if (payload.params.biz_entity_id === "chat_tagged") {
+        return {
+          data: {
+            tag_info_with_bind_versions: [
+              {
+                tag_info: {
+                  id: "tag_pokoclaw",
+                  name: "pokoclaw",
+                },
+              },
+            ],
+          },
+        };
+      }
+
+      return { data: { tag_info_with_bind_versions: [] } };
+    });
+    const tagRelationCreate = vi.fn(async () => ({ data: {} }));
+
+    const provisioner = createLarkSubagentConversationSurfaceProvisioner({
+      storage: handle.storage.db,
+      clients: {
+        getOrCreate: () =>
+          ({
+            sdk: {
+              im: {
+                chat: {
+                  create: chatCreate,
+                  delete: chatDelete,
+                  link: chatLink,
+                },
+                chatMembers: {
+                  get: chatMembersGet,
+                  create: chatMembersCreate,
+                },
+                message: {
+                  create: messageCreate,
+                },
+                chatTopNotice: {
+                  putTopNotice,
+                },
+                v2: {
+                  tag: {
+                    create: tagCreate,
+                  },
+                  bizEntityTagRelation: {
+                    get: tagRelationGet,
+                    update: vi.fn(async () => ({ data: {} })),
+                    create: tagRelationCreate,
+                  },
+                },
+              },
+            },
+          }) as never,
+      },
+    });
+
+    const result = await provisioner.provisionSubagentSurface({
+      conversationId: "conv_sub_duplicate_name",
+      sourceConversationId: "conv_main",
+      channelInstanceId: "ci_1",
+      title: "PR Review",
+      description: "Review pull requests and summarize findings.",
+      initialTask: "Review the current PR and report concrete issues.",
+      workdir: "/Users/example/work/pokoclaw",
+      privateWorkspaceDir: "/Users/example/.pokoclaw/workspace/subagents/abcd1234",
+      preferredSurface: "independent_chat",
+    });
+
+    expect(result).toMatchObject({
+      status: "provisioned",
+      externalChatId: "chat_sub_duplicate_name",
+    });
+    expect(tagRelationGet).toHaveBeenCalledWith({
+      params: {
+        tag_biz_type: "chat",
+        biz_entity_id: "chat_tagged",
+      },
+    });
+    expect(tagRelationGet).toHaveBeenCalledWith({
+      params: {
+        tag_biz_type: "chat",
+        biz_entity_id: "chat_sub_duplicate_name",
+      },
+    });
+    expect(tagRelationCreate).toHaveBeenCalledExactlyOnceWith({
+      data: {
+        tag_biz_type: "chat",
+        biz_entity_id: "chat_sub_duplicate_name",
+        tag_ids: ["tag_pokoclaw"],
+      },
+    });
+    expect(chatDelete).not.toHaveBeenCalled();
   });
 
   test("cleans up the created chat when provisioning fails after chat.create", async () => {
@@ -231,6 +416,94 @@ describe("lark subagent provisioner", () => {
     expect(chatDelete).toHaveBeenCalledExactlyOnceWith({
       path: { chat_id: "chat_sub_2" },
     });
+  });
+
+  test("keeps provisioning when applying the management tag fails", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    handle.storage.sqlite.exec(`
+      INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+      VALUES ('ci_1', 'lark', 'default', '2026-03-29T00:00:00.000Z', '2026-03-29T00:00:00.000Z');
+
+      INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, title, created_at, updated_at)
+      VALUES ('conv_main', 'ci_1', 'chat_main', 'dm', 'Main', '2026-03-29T00:00:00.000Z', '2026-03-29T00:00:00.000Z');
+    `);
+
+    const chatCreate = vi.fn(async () => ({ data: { chat_id: "chat_sub_tag_failure" } }));
+    const chatDelete = vi.fn(async () => ({ data: {} }));
+    const chatMembersGet = vi.fn(async () => ({
+      data: {
+        items: [{ member_id: "ou_user_1" }],
+        has_more: false,
+      },
+    }));
+    const chatMembersCreate = vi.fn(async () => ({ data: { invalid_id_list: [] } }));
+    const chatLink = vi.fn(async () => ({
+      data: { share_link: "https://example.com/subagent-tag-failure" },
+    }));
+    const messageCreate = vi.fn(async () => ({ data: { message_id: "om_welcome_tag_failure" } }));
+    const putTopNotice = vi.fn(async () => ({ data: {} }));
+    const tagCreate = vi.fn(async () => {
+      throw new Error("missing im:tag:write permission");
+    });
+
+    const provisioner = createLarkSubagentConversationSurfaceProvisioner({
+      storage: handle.storage.db,
+      clients: {
+        getOrCreate: () =>
+          ({
+            sdk: {
+              im: {
+                chat: {
+                  create: chatCreate,
+                  delete: chatDelete,
+                  link: chatLink,
+                },
+                chatMembers: {
+                  get: chatMembersGet,
+                  create: chatMembersCreate,
+                },
+                message: {
+                  create: messageCreate,
+                },
+                chatTopNotice: {
+                  putTopNotice,
+                },
+                v2: {
+                  tag: {
+                    create: tagCreate,
+                  },
+                  bizEntityTagRelation: {
+                    get: vi.fn(async () => ({ data: {} })),
+                    update: vi.fn(async () => ({ data: {} })),
+                    create: vi.fn(async () => ({ data: {} })),
+                  },
+                },
+              },
+            },
+          }) as never,
+      },
+    });
+
+    const result = await provisioner.provisionSubagentSurface({
+      conversationId: "conv_sub_tag_failure",
+      sourceConversationId: "conv_main",
+      channelInstanceId: "ci_1",
+      title: "PR Review",
+      description: "Review pull requests and summarize findings.",
+      initialTask: "Review the current PR and report concrete issues.",
+      workdir: "/Users/example/work/pokoclaw",
+      privateWorkspaceDir: "/Users/example/.pokoclaw/workspace/subagents/abcd1234",
+      preferredSurface: "independent_chat",
+    });
+
+    expect(result).toMatchObject({
+      status: "provisioned",
+      externalChatId: "chat_sub_tag_failure",
+      shareLink: "https://example.com/subagent-tag-failure",
+    });
+    expect(chatDelete).not.toHaveBeenCalled();
+    expect(chatLink).toHaveBeenCalledOnce();
+    expect(messageCreate).toHaveBeenCalledOnce();
   });
 
   test("supports explicit cleanup of a provisioned subagent chat", async () => {


### PR DESCRIPTION
## Summary

- Bind newly-created Lark SubAgent chats to the tenant-level `pokoclaw` tag.
- Reuse the existing tag when Feishu returns `code=402` / `duplicate name in tenant` without a `duplicate_id` by discovering an already-bound `pokoclaw` tag from prior SubAgent conversations.
- Keep tag binding failures non-blocking for SubAgent chat creation and add regression coverage for the duplicate-name path.

## Root Cause

Feishu can report an existing tenant tag as `code=402` with `msg="duplicate name in tenant"` while omitting `create_tag_fail_reason.duplicate_id`. The old creation path had no tag id to bind in that case, so newly-created SubAgent chats could be created successfully but remain untagged.

## Validation

- `pnpm build` passed in `D:\OtherPrograms_from_github\pokoclaw-pok-50-pr`.
- `pnpm vitest run tests/channels/lark/subagent-provisioner.test.ts` passed in `D:\OtherPrograms_from_github\pokoclaw-pok-50-pr`.
- `pnpm exec biome check --error-on-warnings src/channels/lark/subagent-provisioner.ts tests/channels/lark/subagent-provisioner.test.ts` passed in `D:\OtherPrograms_from_github\pokoclaw-pok-50-pr`.
- Real local Feishu creation verified chat `oc_10716dcee0b84893fc883bbfab91a524` has tag `pokoclaw` id `7641929927318621398`.
- `pnpm preflight` was attempted in `D:\OtherPrograms_from_github\pokoclaw-pok-50-pr`: build/format/lint passed, but the full test suite hit unrelated Windows-specific sandbox/symlink/path-permission failures such as unsupported sandbox configuration on Windows, `EPERM` symlink creation, path separator mismatches, and POSIX mode expectations.