### PR TITLE
Add Lark image sending tool

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -315,6 +315,7 @@ export class AgentLoop {
     runId?: string;
     approvalState?: ToolExecutionApprovalState;
   }): ToolExecutionContext {
+    const taskRun = new TaskRunsRepo(this.deps.storage).getByExecutionSessionId(input.sessionId);
     const runtimeControl = {
       submitApprovalDecision: (decision) => this.submitApprovalResponse(decision),
       getRuntimeStatus: (request) => {
@@ -356,6 +357,7 @@ export class AgentLoop {
       abortSignal: input.signal,
       toolCallId: input.toolCallId,
       ...(input.runId === undefined ? {} : { runId: input.runId }),
+      ...(taskRun == null ? {} : { taskRunId: taskRun.id }),
       ...(input.ownerAgentId === undefined ? {} : { ownerAgentId: input.ownerAgentId }),
       ...(input.agentKind === undefined ? {} : { agentKind: input.agentKind }),
       ...(input.approvalState == null ? {} : { approvalState: input.approvalState }),

--- a/src/agent/system-prompt-sections.ts
+++ b/src/agent/system-prompt-sections.ts
@@ -234,6 +234,7 @@ export function buildApprovalAgentOperatingModelSection(): string {
 export function buildToolUsageSection(): string {
   return renderSection("Tool Usage", [
     "- Use the existing first-class tool when one is available instead of inventing an indirect shell workaround.",
+    "- When the user asks you to send, show, share, or deliver an image or file in the current chat, create or locate a real local file and use `send_attachment`; set `type` to `image` for images. Do not replace it with a Markdown link, file path, A2UI surface, or ordinary text/card reply.",
     "- Routine low-risk tool calls do not need narration first.",
     "- For complex, risky, or potentially destructive actions, briefly explain what you are about to do.",
     "- Tool names and arguments are exact; call them precisely as defined.",

--- a/src/channels/lark/image-message.ts
+++ b/src/channels/lark/image-message.ts
@@ -31,8 +31,8 @@ export async function sendLarkImageMessage(input: {
       image: createReadStream(input.imagePath),
     },
   });
-  const imageKey = upload?.image_key ?? null;
-  if (imageKey == null || imageKey.trim().length === 0) {
+  const imageKey = readImageKey(upload);
+  if (imageKey == null) {
     throw new Error("Lark image upload did not return image_key.");
   }
 
@@ -63,18 +63,37 @@ export async function sendLarkImageMessage(input: {
           },
         });
 
-  const responseData =
-    typeof response?.data === "object" && response.data != null
-      ? (response.data as Record<string, unknown>)
-      : {};
-  const messageId =
-    typeof responseData.message_id === "string" ? responseData.message_id : undefined;
-  const openMessageId =
-    typeof responseData.open_message_id === "string" ? responseData.open_message_id : undefined;
+  const messageId = readStringField(response?.data, "message_id") ?? undefined;
+  const openMessageId = readStringField(response?.data, "open_message_id") ?? undefined;
 
   return {
     imageKey,
     ...(messageId === undefined ? {} : { messageId }),
     ...(openMessageId === undefined ? {} : { openMessageId }),
   };
+}
+
+function readImageKey(upload: unknown): string | null {
+  return (
+    readStringField(readObjectField(upload, "data"), "image_key") ??
+    readStringField(upload, "image_key")
+  );
+}
+
+function readObjectField(value: unknown, key: string): Record<string, unknown> | null {
+  if (typeof value !== "object" || value == null || Array.isArray(value)) {
+    return null;
+  }
+  const field = (value as Record<string, unknown>)[key];
+  return typeof field === "object" && field != null && !Array.isArray(field)
+    ? (field as Record<string, unknown>)
+    : null;
+}
+
+function readStringField(value: unknown, key: string): string | null {
+  if (typeof value !== "object" || value == null || Array.isArray(value)) {
+    return null;
+  }
+  const field = (value as Record<string, unknown>)[key];
+  return typeof field === "string" && field.trim().length > 0 ? field.trim() : null;
 }

--- a/src/channels/lark/image-message.ts
+++ b/src/channels/lark/image-message.ts
@@ -1,0 +1,80 @@
+import { createReadStream } from "node:fs";
+
+import type { LarkSdkClient } from "@/src/channels/lark/client.js";
+import { createSubsystemLogger } from "@/src/shared/logger.js";
+
+const logger = createSubsystemLogger("channels/lark-image-message");
+
+export interface SendLarkImageMessageResult {
+  imageKey: string;
+  messageId?: string;
+  openMessageId?: string;
+}
+
+export async function sendLarkImageMessage(input: {
+  installationId: string;
+  chatId: string;
+  replyToMessageId?: string | null;
+  imagePath: string;
+  clients?: {
+    getOrCreate(installationId: string): LarkSdkClient;
+  };
+}): Promise<SendLarkImageMessageResult> {
+  if (input.clients == null) {
+    throw new Error("Lark image sending is not configured in this runtime.");
+  }
+
+  const client = input.clients.getOrCreate(input.installationId);
+  const upload = await client.sdk.im.image.create({
+    data: {
+      image_type: "message",
+      image: createReadStream(input.imagePath),
+    },
+  });
+  const imageKey = upload?.image_key ?? null;
+  if (imageKey == null || imageKey.trim().length === 0) {
+    throw new Error("Lark image upload did not return image_key.");
+  }
+
+  logger.info("uploaded lark image message asset", {
+    installationId: input.installationId,
+    chatId: input.chatId,
+    imagePath: input.imagePath,
+    imageKey,
+  });
+
+  const content = JSON.stringify({ image_key: imageKey });
+  const response =
+    input.replyToMessageId != null && input.replyToMessageId.length > 0
+      ? await client.sdk.im.message.reply({
+          path: { message_id: input.replyToMessageId },
+          data: {
+            msg_type: "image",
+            content,
+            reply_in_thread: true,
+          },
+        })
+      : await client.sdk.im.message.create({
+          params: { receive_id_type: "chat_id" },
+          data: {
+            receive_id: input.chatId,
+            msg_type: "image",
+            content,
+          },
+        });
+
+  const responseData =
+    typeof response?.data === "object" && response.data != null
+      ? (response.data as Record<string, unknown>)
+      : {};
+  const messageId =
+    typeof responseData.message_id === "string" ? responseData.message_id : undefined;
+  const openMessageId =
+    typeof responseData.open_message_id === "string" ? responseData.open_message_id : undefined;
+
+  return {
+    imageKey,
+    ...(messageId === undefined ? {} : { messageId }),
+    ...(openMessageId === undefined ? {} : { openMessageId }),
+  };
+}

--- a/src/channels/lark/outbound.ts
+++ b/src/channels/lark/outbound.ts
@@ -1764,24 +1764,35 @@ export function createLarkOutboundRuntime(
       }
 
       const replyToMessageId = readStringValue(target.surfaceObject.reply_to_message_id);
-      const result = await sendLarkImageMessage({
-        installationId: target.channelInstallationId,
-        chatId,
-        ...(replyToMessageId == null ? {} : { replyToMessageId }),
-        imagePath: envelope.event.attachmentPath,
-        clients: input.clients,
-      });
+      try {
+        const result = await sendLarkImageMessage({
+          installationId: target.channelInstallationId,
+          chatId,
+          ...(replyToMessageId == null ? {} : { replyToMessageId }),
+          imagePath: envelope.event.attachmentPath,
+          clients: input.clients,
+        });
 
-      logger.info("sent lark outbound image attachment event", {
-        eventId: envelope.event.eventId,
-        channelInstallationId: target.channelInstallationId,
-        chatId,
-        replyToMessageId,
-        attachmentPath: envelope.event.attachmentPath,
-        imageKey: result.imageKey,
-        messageId: result.messageId,
-        openMessageId: result.openMessageId,
-      });
+        logger.info("sent lark outbound image attachment event", {
+          eventId: envelope.event.eventId,
+          channelInstallationId: target.channelInstallationId,
+          chatId,
+          replyToMessageId,
+          attachmentPath: envelope.event.attachmentPath,
+          imageKey: result.imageKey,
+          messageId: result.messageId,
+          openMessageId: result.openMessageId,
+        });
+      } catch (error) {
+        logger.error("failed to send lark outbound image attachment event", {
+          eventId: envelope.event.eventId,
+          channelInstallationId: target.channelInstallationId,
+          chatId,
+          replyToMessageId,
+          attachmentPath: envelope.event.attachmentPath,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
   };
 

--- a/src/channels/lark/outbound.ts
+++ b/src/channels/lark/outbound.ts
@@ -25,6 +25,7 @@ import {
 } from "@/src/channels/lark/cardkit-mutations.js";
 import type { LarkSdkClient } from "@/src/channels/lark/client.js";
 import { listLarkDeliveryTargets, readStringValue } from "@/src/channels/lark/delivery-targets.js";
+import { sendLarkImageMessage } from "@/src/channels/lark/image-message.js";
 import {
   addLarkMessageReaction,
   removeLarkMessageReaction,
@@ -50,6 +51,7 @@ import {
 import type { LarkSteerReactionState } from "@/src/channels/lark/steer-reaction-state.js";
 import { sendLarkTextMessage } from "@/src/channels/lark/text-message.js";
 import type {
+  OrchestratedOutboundAttachmentEventEnvelope,
   OrchestratedOutboundEventEnvelope,
   OrchestratedRuntimeEventEnvelope,
 } from "@/src/orchestration/outbound-events.js";
@@ -1717,6 +1719,72 @@ export function createLarkOutboundRuntime(
     }
   };
 
+  const handleOutboundAttachmentEvent = async (
+    envelope: OrchestratedOutboundAttachmentEventEnvelope,
+  ): Promise<void> => {
+    if (envelope.event.attachmentType !== "image") {
+      logger.warn("skipping lark outbound attachment because only image delivery is implemented", {
+        eventId: envelope.event.eventId,
+        conversationId: envelope.target.conversationId,
+        branchId: envelope.target.branchId,
+        taskRunId: envelope.taskRun.taskRunId,
+        attachmentType: envelope.event.attachmentType,
+        attachmentPath: envelope.event.attachmentPath,
+      });
+      return;
+    }
+
+    const deliveryTargets = listLarkDeliveryTargets(input.storage, {
+      conversationId: envelope.target.conversationId,
+      branchId: envelope.target.branchId,
+      taskRunId: envelope.taskRun.taskRunId,
+    });
+
+    if (deliveryTargets.length === 0) {
+      logger.warn("skipping lark outbound image because no lark delivery target is paired", {
+        eventId: envelope.event.eventId,
+        conversationId: envelope.target.conversationId,
+        branchId: envelope.target.branchId,
+        attachmentPath: envelope.event.attachmentPath,
+      });
+      return;
+    }
+
+    for (const target of deliveryTargets) {
+      const chatId = readStringValue(target.surfaceObject.chat_id);
+      if (chatId == null) {
+        logger.warn("skipping lark outbound image because surface is missing chat_id", {
+          eventId: envelope.event.eventId,
+          conversationId: envelope.target.conversationId,
+          branchId: envelope.target.branchId,
+          channelInstallationId: target.channelInstallationId,
+          attachmentPath: envelope.event.attachmentPath,
+        });
+        continue;
+      }
+
+      const replyToMessageId = readStringValue(target.surfaceObject.reply_to_message_id);
+      const result = await sendLarkImageMessage({
+        installationId: target.channelInstallationId,
+        chatId,
+        ...(replyToMessageId == null ? {} : { replyToMessageId }),
+        imagePath: envelope.event.attachmentPath,
+        clients: input.clients,
+      });
+
+      logger.info("sent lark outbound image attachment event", {
+        eventId: envelope.event.eventId,
+        channelInstallationId: target.channelInstallationId,
+        chatId,
+        replyToMessageId,
+        attachmentPath: envelope.event.attachmentPath,
+        imageKey: result.imageKey,
+        messageId: result.messageId,
+        openMessageId: result.openMessageId,
+      });
+    }
+  };
+
   return {
     start() {
       if (unsubscribe != null) {
@@ -1796,6 +1864,10 @@ export function createLarkOutboundRuntime(
             immediate: isTaskLifecycleTerminalEvent(envelope),
           });
           return;
+        }
+
+        if (envelope.kind === "outbound_attachment_event") {
+          return handleOutboundAttachmentEvent(envelope);
         }
 
         if (envelope.kind !== "runtime_event") {

--- a/src/orchestration/agent-manager.ts
+++ b/src/orchestration/agent-manager.ts
@@ -16,6 +16,9 @@ import {
 import {
   type OrchestratedOutboundEventEnvelope,
   type OrchestratedRuntimeEventEnvelope,
+  type OutboundAttachmentRequestedEvent,
+  type OutboundAttachmentType,
+  projectOutboundAttachmentEvent,
   projectRuntimeEvent,
   projectSubagentCreationEvent,
   projectTaskRunEvent,
@@ -151,6 +154,43 @@ export class AgentManager {
       db: this.deps.storage,
       event,
     });
+  }
+
+  publishOutboundAttachment(input: {
+    sourceSessionId: string;
+    conversationId: string;
+    branchId: string;
+    runId?: string | null;
+    taskRunId?: string | null;
+    attachmentPath: string;
+    displayPath: string;
+    type: OutboundAttachmentType;
+  }): { accepted: true; eventId: string } {
+    const event: OutboundAttachmentRequestedEvent = {
+      type: "outbound_attachment_requested",
+      eventId: randomUUID(),
+      attachmentPath: input.attachmentPath,
+      displayPath: input.displayPath,
+      attachmentType: input.type,
+      requestedAt: new Date().toISOString(),
+    };
+
+    this.publishOutboundEvent(
+      projectOutboundAttachmentEvent({
+        db: this.deps.storage,
+        sourceSessionId: input.sourceSessionId,
+        conversationId: input.conversationId,
+        branchId: input.branchId,
+        ...(input.runId === undefined ? {} : { runId: input.runId }),
+        ...(input.taskRunId === undefined ? {} : { taskRunId: input.taskRunId }),
+        event,
+      }),
+    );
+
+    return {
+      accepted: true,
+      eventId: event.eventId,
+    };
   }
 
   createTaskExecution(params: CreateTaskExecutionInput): CreatedTaskExecution {

--- a/src/orchestration/outbound-events.ts
+++ b/src/orchestration/outbound-events.ts
@@ -8,11 +8,21 @@
 import type { AgentRuntimeEvent } from "@/src/agent/events.js";
 import {
   resolveSessionLiveState,
+  resolveTaskRunLiveState,
   resolveTaskRunLiveStateFromTaskRun,
 } from "@/src/runtime/live-state.js";
 import type { AgentRuntimeRole } from "@/src/security/policy.js";
 import type { StorageDb } from "@/src/storage/db/client.js";
 import type { Session, SubagentCreationRequest, TaskRun } from "@/src/storage/schema/types.js";
+
+export type OutboundAttachmentType =
+  | "image"
+  | "pdf"
+  | "word"
+  | "spreadsheet"
+  | "presentation"
+  | "html"
+  | "file";
 
 export interface OutboundEventContext {
   target: {
@@ -154,10 +164,25 @@ export interface OrchestratedSubagentCreationEventEnvelope extends OutboundEvent
   event: SubagentCreationOutboundEvent;
 }
 
+export interface OutboundAttachmentRequestedEvent {
+  type: "outbound_attachment_requested";
+  eventId: string;
+  attachmentPath: string;
+  displayPath: string;
+  attachmentType: OutboundAttachmentType;
+  requestedAt: string;
+}
+
+export interface OrchestratedOutboundAttachmentEventEnvelope extends OutboundEventContext {
+  kind: "outbound_attachment_event";
+  event: OutboundAttachmentRequestedEvent;
+}
+
 export type OrchestratedOutboundEventEnvelope =
   | OrchestratedRuntimeEventEnvelope
   | OrchestratedTaskRunEventEnvelope
-  | OrchestratedSubagentCreationEventEnvelope;
+  | OrchestratedSubagentCreationEventEnvelope
+  | OrchestratedOutboundAttachmentEventEnvelope;
 
 export function projectRuntimeEvent(input: {
   db: StorageDb;
@@ -242,6 +267,50 @@ export function projectSubagentCreationEvent(input: {
       mainAgentId: state?.mainAgentId ?? input.request.sourceAgentId,
       taskRun: state?.taskRun ?? null,
       runId: null,
+      object: {
+        messageId: null,
+        toolCallId: null,
+        toolName: null,
+        approvalId: null,
+      },
+    }),
+    event: input.event,
+  };
+}
+
+export function projectOutboundAttachmentEvent(input: {
+  db: StorageDb;
+  sourceSessionId: string;
+  conversationId: string;
+  branchId: string;
+  runId?: string | null;
+  taskRunId?: string | null;
+  event: OutboundAttachmentRequestedEvent;
+}): OrchestratedOutboundAttachmentEventEnvelope {
+  const state = resolveSessionLiveState({
+    db: input.db,
+    sessionId: input.sourceSessionId,
+  });
+  const taskRun =
+    input.taskRunId == null
+      ? (state?.taskRun ?? null)
+      : (resolveTaskRunLiveState({
+          db: input.db,
+          taskRunId: input.taskRunId,
+        })?.taskRun ?? null);
+
+  return {
+    kind: "outbound_attachment_event",
+    ...buildContext({
+      conversationId: input.conversationId,
+      branchId: input.branchId,
+      sessionId: input.sourceSessionId,
+      sessionPurpose: state?.session.purpose ?? null,
+      ownerAgentId: state?.ownerAgentId ?? null,
+      ownerRole: state?.ownerRole ?? null,
+      mainAgentId: state?.mainAgentId ?? null,
+      taskRun,
+      runId: input.runId ?? null,
       object: {
         messageId: null,
         toolCallId: null,

--- a/src/runtime/orchestration-bridge.ts
+++ b/src/runtime/orchestration-bridge.ts
@@ -15,6 +15,7 @@ const logger = createSubsystemLogger("runtime-orchestration-bridge");
 type RuntimeOrchestrationTarget = Pick<
   AgentManager,
   | "emitRuntimeEvent"
+  | "publishOutboundAttachment"
   | "submitSubagentCreationRequest"
   | "runCronJobNow"
   | "startBackgroundTask"
@@ -69,6 +70,20 @@ export class RuntimeOrchestrationBridge {
       this.requireManager(
         "suppressBackgroundTaskCompletionNotice",
       ).suppressBackgroundTaskCompletionNotice(input);
+    },
+    sendAttachment: async (input) => {
+      const result = this.requireManager("publishOutboundAttachment").publishOutboundAttachment(
+        input,
+      );
+
+      logger.info("published outbound attachment request through runtime bridge", {
+        sourceSessionId: input.sourceSessionId,
+        eventId: result.eventId,
+        attachmentPath: input.attachmentPath,
+        attachmentType: input.type,
+      });
+
+      return result;
     },
   };
 

--- a/src/tools/builtins.ts
+++ b/src/tools/builtins.ts
@@ -18,6 +18,7 @@ import { createQuerySystemDbTool } from "@/src/tools/query-system-db.js";
 import { createReadTool } from "@/src/tools/read.js";
 import { createRequestPermissionsTool } from "@/src/tools/request-permissions.js";
 import { createReviewPermissionRequestTool } from "@/src/tools/review-permission-request.js";
+import { createSendAttachmentTool } from "@/src/tools/send-attachment.js";
 import { createWaitTaskTool } from "@/src/tools/wait-task.js";
 import { createWebFetchTool } from "@/src/tools/web/fetch.js";
 import { createWebSearchTool } from "@/src/tools/web/search.js";
@@ -49,6 +50,7 @@ export function createBuiltinToolRegistry(
   registry.register(createBackgroundTaskTool());
   registry.register(createWaitTaskTool());
   registry.register(createListBackgroundTasksTool());
+  registry.register(createSendAttachmentTool());
   registry.register(
     createPublishA2uiTool(
       integrations.a2uiPublisher == null ? {} : { publisher: integrations.a2uiPublisher },

--- a/src/tools/core/types.ts
+++ b/src/tools/core/types.ts
@@ -35,6 +35,7 @@ export interface ToolExecutionContext {
   abortSignal?: AbortSignal;
   toolCallId?: string;
   runId?: string;
+  taskRunId?: string;
   approvalState?: ToolExecutionApprovalState;
   runtimeControl?: ToolRuntimeControl;
 }
@@ -100,6 +101,19 @@ export interface ToolRuntimeControl {
     taskRunId: string;
   }>;
   suppressBackgroundTaskCompletionNotice?(input: { taskRunId: string }): void;
+  sendAttachment?(input: {
+    sourceSessionId: string;
+    conversationId: string;
+    branchId: string;
+    runId?: string | null;
+    taskRunId?: string | null;
+    attachmentPath: string;
+    displayPath: string;
+    type: "image" | "pdf" | "word" | "spreadsheet" | "presentation" | "html" | "file";
+  }): Promise<{
+    accepted: true;
+    eventId: string;
+  }>;
 }
 
 export interface ToolExecutionApprovalState {

--- a/src/tools/send-attachment.ts
+++ b/src/tools/send-attachment.ts
@@ -97,11 +97,21 @@ export function createSendAttachmentTool() {
         });
       }
       const attachmentType = args.type ?? inferAttachmentType(displayPath);
+      if (attachmentType === "image" && !hasSupportedImageExtension(displayPath)) {
+        throw toolRecoverableError(
+          `Attachment type "image" requires a supported image extension (PNG, JPEG, WEBP, GIF, TIFF, BMP, ICO): ${displayPath}`,
+          {
+            code: "unsupported_image_format",
+            path: absolutePath,
+            displayPath,
+          },
+        );
+      }
       const maxBytes =
         attachmentType === "image" ? MAX_OUTBOUND_IMAGE_BYTES : MAX_OUTBOUND_ATTACHMENT_BYTES;
       if (fileStats.size > maxBytes) {
         throw toolRecoverableError(
-          `Attachment file is larger than ${formatMegabytes(maxBytes)} MB: ${displayPath}`,
+          `Attachment file is larger than ${bytesToMegabytes(maxBytes)} MB: ${displayPath}`,
           {
             code: "file_too_large",
             path: absolutePath,
@@ -150,7 +160,7 @@ function isMissingPathError(error: unknown): boolean {
 
 function inferAttachmentType(displayPath: string): AttachmentType {
   const normalized = displayPath.toLowerCase();
-  if (/\.(png|jpe?g|webp|gif|tiff?|bmp|ico)$/.test(normalized)) {
+  if (hasSupportedImageExtension(normalized)) {
     return "image";
   }
   if (normalized.endsWith(".pdf")) {
@@ -171,6 +181,10 @@ function inferAttachmentType(displayPath: string): AttachmentType {
   return "file";
 }
 
-function formatMegabytes(bytes: number): number {
+function hasSupportedImageExtension(displayPath: string): boolean {
+  return /\.(png|jpe?g|webp|gif|tiff?|bmp|ico)$/i.test(displayPath);
+}
+
+function bytesToMegabytes(bytes: number): number {
   return bytes / 1024 / 1024;
 }

--- a/src/tools/send-attachment.ts
+++ b/src/tools/send-attachment.ts
@@ -10,7 +10,6 @@ import {
   resolveToolCwd,
 } from "@/src/tools/helpers/common.js";
 
-const MAX_OUTBOUND_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 const MAX_OUTBOUND_IMAGE_BYTES = 10 * 1024 * 1024;
 
 export const ATTACHMENT_TYPES = [
@@ -58,7 +57,7 @@ export function createSendAttachmentTool() {
   return defineTool({
     name: "send_attachment",
     description:
-      "Attach a local file in the current conversation through the active channel's native attachment capability. Use this whenever the user asks you to send, show, share, or deliver a local image or file after creating or locating it. Set type to image for image files. Do not substitute Markdown links, file paths, text cards, or A2UI for an actual chat attachment when this tool is available. Image files must be non-empty JPEG, PNG, WEBP, GIF, TIFF, BMP, or ICO files and under 10 MB; other attachment types are queued only when the channel supports them.",
+      "Attach a local file in the current conversation through the active channel's native attachment capability. Use this whenever the user asks you to send, show, share, or deliver a local image or file after creating or locating it. Set type to image for image files. Do not substitute Markdown links, file paths, text cards, or A2UI for an actual chat attachment when this tool is available. Currently only image attachments are delivered; image files must be non-empty JPEG, PNG, WEBP, GIF, TIFF, BMP, or ICO files and under 10 MB.",
     inputSchema: SEND_ATTACHMENT_TOOL_SCHEMA,
     async execute(context, args) {
       if (context.runtimeControl?.sendAttachment == null) {
@@ -97,6 +96,18 @@ export function createSendAttachmentTool() {
         });
       }
       const attachmentType = args.type ?? inferAttachmentType(displayPath);
+      if (attachmentType !== "image") {
+        throw toolRecoverableError(
+          `Attachment type "${attachmentType}" is not supported by the current delivery channels yet: ${displayPath}`,
+          {
+            code: "unsupported_attachment_type",
+            path: absolutePath,
+            displayPath,
+            attachmentType,
+            supportedTypes: ["image"],
+          },
+        );
+      }
       if (attachmentType === "image" && !hasSupportedImageExtension(displayPath)) {
         throw toolRecoverableError(
           `Attachment type "image" requires a supported image extension (PNG, JPEG, WEBP, GIF, TIFF, BMP, ICO): ${displayPath}`,
@@ -107,16 +118,14 @@ export function createSendAttachmentTool() {
           },
         );
       }
-      const maxBytes =
-        attachmentType === "image" ? MAX_OUTBOUND_IMAGE_BYTES : MAX_OUTBOUND_ATTACHMENT_BYTES;
-      if (fileStats.size > maxBytes) {
+      if (fileStats.size > MAX_OUTBOUND_IMAGE_BYTES) {
         throw toolRecoverableError(
-          `Attachment file is larger than ${bytesToMegabytes(maxBytes)} MB: ${displayPath}`,
+          `Attachment file is larger than ${bytesToMegabytes(MAX_OUTBOUND_IMAGE_BYTES)} MB: ${displayPath}`,
           {
             code: "file_too_large",
             path: absolutePath,
             sizeBytes: fileStats.size,
-            maxBytes,
+            maxBytes: MAX_OUTBOUND_IMAGE_BYTES,
           },
         );
       }

--- a/src/tools/send-attachment.ts
+++ b/src/tools/send-attachment.ts
@@ -1,0 +1,176 @@
+import { stat } from "node:fs/promises";
+import { type Static, Type } from "@sinclair/typebox";
+
+import { SessionsRepo } from "@/src/storage/repos/sessions.repo.js";
+import { toolInternalError, toolRecoverableError } from "@/src/tools/core/errors.js";
+import { defineTool, textToolResult } from "@/src/tools/core/types.js";
+import {
+  formatDisplayPath,
+  requireFilesystemAccess,
+  resolveToolCwd,
+} from "@/src/tools/helpers/common.js";
+
+const MAX_OUTBOUND_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+const MAX_OUTBOUND_IMAGE_BYTES = 10 * 1024 * 1024;
+
+export const ATTACHMENT_TYPES = [
+  "image",
+  "pdf",
+  "word",
+  "spreadsheet",
+  "presentation",
+  "html",
+  "file",
+] as const;
+
+export type AttachmentType = (typeof ATTACHMENT_TYPES)[number];
+
+export const SEND_ATTACHMENT_TOOL_SCHEMA = Type.Object(
+  {
+    path: Type.String({
+      description:
+        "Absolute or relative path to a local file to attach in the current conversation.",
+    }),
+    type: Type.Optional(
+      Type.Union(
+        ATTACHMENT_TYPES.map((attachmentType) => Type.Literal(attachmentType)),
+        {
+          description:
+            "Optional expected attachment type. Use image for PNG/JPEG/WEBP/GIF/BMP/TIFF/ICO files.",
+        },
+      ),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export type SendAttachmentToolArgs = Static<typeof SEND_ATTACHMENT_TOOL_SCHEMA>;
+
+export interface SendAttachmentToolDetails {
+  path: string;
+  absolutePath: string;
+  type: AttachmentType;
+  eventId: string;
+  queued: true;
+}
+
+export function createSendAttachmentTool() {
+  return defineTool({
+    name: "send_attachment",
+    description:
+      "Attach a local file in the current conversation through the active channel's native attachment capability. Use this whenever the user asks you to send, show, share, or deliver a local image or file after creating or locating it. Set type to image for image files. Do not substitute Markdown links, file paths, text cards, or A2UI for an actual chat attachment when this tool is available. Image files must be non-empty JPEG, PNG, WEBP, GIF, TIFF, BMP, or ICO files and under 10 MB; other attachment types are queued only when the channel supports them.",
+    inputSchema: SEND_ATTACHMENT_TOOL_SCHEMA,
+    async execute(context, args) {
+      if (context.runtimeControl?.sendAttachment == null) {
+        throw toolInternalError("send_attachment is not configured in this runtime.");
+      }
+
+      const cwd = resolveToolCwd(context);
+      const absolutePath = requireFilesystemAccess(context, {
+        kind: "fs.read",
+        targetPath: args.path,
+      });
+      const displayPath = formatDisplayPath(args.path, cwd);
+
+      let fileStats: Awaited<ReturnType<typeof stat>>;
+      try {
+        fileStats = await stat(absolutePath);
+      } catch (error) {
+        if (isMissingPathError(error)) {
+          throw toolRecoverableError(`Attachment file not found: ${displayPath}`, {
+            code: "file_not_found",
+            path: absolutePath,
+          });
+        }
+        throw error;
+      }
+      if (!fileStats.isFile()) {
+        throw toolRecoverableError(`Path is not a regular file: ${displayPath}`, {
+          code: "not_a_file",
+          path: absolutePath,
+        });
+      }
+      if (fileStats.size <= 0) {
+        throw toolRecoverableError(`Attachment file is empty: ${displayPath}`, {
+          code: "empty_file",
+          path: absolutePath,
+        });
+      }
+      const attachmentType = args.type ?? inferAttachmentType(displayPath);
+      const maxBytes =
+        attachmentType === "image" ? MAX_OUTBOUND_IMAGE_BYTES : MAX_OUTBOUND_ATTACHMENT_BYTES;
+      if (fileStats.size > maxBytes) {
+        throw toolRecoverableError(
+          `Attachment file is larger than ${formatMegabytes(maxBytes)} MB: ${displayPath}`,
+          {
+            code: "file_too_large",
+            path: absolutePath,
+            sizeBytes: fileStats.size,
+            maxBytes,
+          },
+        );
+      }
+
+      const session = new SessionsRepo(context.storage).getById(context.sessionId);
+      if (session == null) {
+        throw toolInternalError(`Source session not found: ${context.sessionId}`);
+      }
+      if (session.purpose !== "chat" && session.purpose !== "task") {
+        throw toolRecoverableError("send_attachment is only available in chat or task sessions.", {
+          code: "send_attachment_wrong_session_purpose",
+          sessionPurpose: session.purpose,
+        });
+      }
+
+      const result = await context.runtimeControl.sendAttachment({
+        sourceSessionId: context.sessionId,
+        conversationId: context.conversationId,
+        branchId: session.branchId,
+        ...(context.taskRunId === undefined ? {} : { taskRunId: context.taskRunId }),
+        attachmentPath: absolutePath,
+        displayPath,
+        type: attachmentType,
+        ...(context.runId === undefined ? {} : { runId: context.runId }),
+      });
+
+      return textToolResult(`Queued attachment ${displayPath} for sending.`, {
+        path: displayPath,
+        absolutePath,
+        type: attachmentType,
+        eventId: result.eventId,
+        queued: true,
+      } satisfies SendAttachmentToolDetails);
+    },
+  });
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function inferAttachmentType(displayPath: string): AttachmentType {
+  const normalized = displayPath.toLowerCase();
+  if (/\.(png|jpe?g|webp|gif|tiff?|bmp|ico)$/.test(normalized)) {
+    return "image";
+  }
+  if (normalized.endsWith(".pdf")) {
+    return "pdf";
+  }
+  if (/\.(docx?|rtf)$/.test(normalized)) {
+    return "word";
+  }
+  if (/\.(xlsx?|csv|tsv)$/.test(normalized)) {
+    return "spreadsheet";
+  }
+  if (/\.(pptx?|key)$/.test(normalized)) {
+    return "presentation";
+  }
+  if (/\.(html?|xhtml)$/.test(normalized)) {
+    return "html";
+  }
+  return "file";
+}
+
+function formatMegabytes(bytes: number): number {
+  return bytes / 1024 / 1024;
+}

--- a/tests/agent/system-prompt.test.ts
+++ b/tests/agent/system-prompt.test.ts
@@ -189,6 +189,18 @@ describe("agent system prompt", () => {
     expect(prompt).toContain("Showing a plan for review when the only expected reply is");
   });
 
+  test("guides agents to send current-chat images through the native image tool", () => {
+    const prompt = buildAgentSystemPrompt({
+      sessionPurpose: "chat",
+      agentKind: "main",
+    });
+
+    expect(prompt).toContain("use `send_attachment`");
+    expect(prompt).toContain("set `type` to `image`");
+    expect(prompt).toContain("Do not replace it with a Markdown link");
+    expect(prompt).toContain("file path, A2UI surface, or ordinary text/card reply");
+  });
+
   test("defaults chat sessions without agentKind to the main-agent prompt", () => {
     const prompt = buildAgentSystemPrompt({
       sessionPurpose: "chat",

--- a/tests/channels/lark/image-message.test.ts
+++ b/tests/channels/lark/image-message.test.ts
@@ -1,0 +1,100 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { sendLarkImageMessage } from "@/src/channels/lark/image-message.js";
+
+describe("lark image message", () => {
+  let tempDir: string | null = null;
+
+  afterEach(async () => {
+    if (tempDir != null) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  test("uploads an image and sends a native image message", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "pokoclaw-lark-image-message-"));
+    const imagePath = path.join(tempDir, "chart.png");
+    await writeFile(imagePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    const imageCreate = vi.fn(async () => ({ image_key: "img_v3_uploaded" }));
+    const messageCreate = vi.fn(async () => ({
+      data: { message_id: "om_image_1", open_message_id: "om_open_image_1" },
+    }));
+
+    const result = await sendLarkImageMessage({
+      installationId: "default",
+      chatId: "oc_chat_1",
+      imagePath,
+      clients: {
+        getOrCreate: () =>
+          ({
+            sdk: {
+              im: {
+                image: { create: imageCreate },
+                message: { create: messageCreate },
+              },
+            },
+          }) as never,
+      },
+    });
+
+    expect(imageCreate).toHaveBeenCalledWith({
+      data: {
+        image_type: "message",
+        image: expect.objectContaining({ path: imagePath }),
+      },
+    });
+    expect(messageCreate).toHaveBeenCalledWith({
+      params: { receive_id_type: "chat_id" },
+      data: {
+        receive_id: "oc_chat_1",
+        msg_type: "image",
+        content: JSON.stringify({ image_key: "img_v3_uploaded" }),
+      },
+    });
+    expect(result).toEqual({
+      imageKey: "img_v3_uploaded",
+      messageId: "om_image_1",
+      openMessageId: "om_open_image_1",
+    });
+  });
+
+  test("uploads an image and replies in a thread when a reply target exists", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "pokoclaw-lark-image-message-"));
+    const imagePath = path.join(tempDir, "chart.png");
+    await writeFile(imagePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    const imageCreate = vi.fn(async () => ({ image_key: "img_v3_uploaded" }));
+    const reply = vi.fn(async () => ({ data: { message_id: "om_reply_1" } }));
+
+    await sendLarkImageMessage({
+      installationId: "default",
+      chatId: "oc_chat_1",
+      replyToMessageId: "om_thread_root",
+      imagePath,
+      clients: {
+        getOrCreate: () =>
+          ({
+            sdk: {
+              im: {
+                image: { create: imageCreate },
+                message: { reply },
+              },
+            },
+          }) as never,
+      },
+    });
+
+    expect(reply).toHaveBeenCalledWith({
+      path: { message_id: "om_thread_root" },
+      data: {
+        msg_type: "image",
+        content: JSON.stringify({ image_key: "img_v3_uploaded" }),
+        reply_in_thread: true,
+      },
+    });
+  });
+});

--- a/tests/channels/lark/image-message.test.ts
+++ b/tests/channels/lark/image-message.test.ts
@@ -20,7 +20,7 @@ describe("lark image message", () => {
     tempDir = await mkdtemp(path.join(os.tmpdir(), "pokoclaw-lark-image-message-"));
     const imagePath = path.join(tempDir, "chart.png");
     await writeFile(imagePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
-    const imageCreate = vi.fn(async () => ({ image_key: "img_v3_uploaded" }));
+    const imageCreate = vi.fn(async () => ({ data: { image_key: "img_v3_uploaded" } }));
     const messageCreate = vi.fn(async () => ({
       data: { message_id: "om_image_1", open_message_id: "om_open_image_1" },
     }));
@@ -67,7 +67,7 @@ describe("lark image message", () => {
     tempDir = await mkdtemp(path.join(os.tmpdir(), "pokoclaw-lark-image-message-"));
     const imagePath = path.join(tempDir, "chart.png");
     await writeFile(imagePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
-    const imageCreate = vi.fn(async () => ({ image_key: "img_v3_uploaded" }));
+    const imageCreate = vi.fn(async () => ({ data: { image_key: "img_v3_uploaded" } }));
     const reply = vi.fn(async () => ({ data: { message_id: "om_reply_1" } }));
 
     await sendLarkImageMessage({
@@ -96,5 +96,40 @@ describe("lark image message", () => {
         reply_in_thread: true,
       },
     });
+  });
+
+  test("accepts legacy top-level image_key upload responses as a fallback", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "pokoclaw-lark-image-message-"));
+    const imagePath = path.join(tempDir, "chart.png");
+    await writeFile(imagePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    const imageCreate = vi.fn(async () => ({ image_key: "img_v3_uploaded" }));
+    const messageCreate = vi.fn(async () => ({ data: { message_id: "om_image_1" } }));
+
+    const result = await sendLarkImageMessage({
+      installationId: "default",
+      chatId: "oc_chat_1",
+      imagePath,
+      clients: {
+        getOrCreate: () =>
+          ({
+            sdk: {
+              im: {
+                image: { create: imageCreate },
+                message: { create: messageCreate },
+              },
+            },
+          }) as never,
+      },
+    });
+
+    expect(messageCreate).toHaveBeenCalledWith({
+      params: { receive_id_type: "chat_id" },
+      data: {
+        receive_id: "oc_chat_1",
+        msg_type: "image",
+        content: JSON.stringify({ image_key: "img_v3_uploaded" }),
+      },
+    });
+    expect(result.imageKey).toBe("img_v3_uploaded");
   });
 });

--- a/tests/channels/lark/outbound.test.ts
+++ b/tests/channels/lark/outbound.test.ts
@@ -1,9 +1,13 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { createLarkOutboundRuntime } from "@/src/channels/lark/outbound.js";
 import { buildLarkAssistantElementId } from "@/src/channels/lark/run-state.js";
 import { LarkSteerReactionState } from "@/src/channels/lark/steer-reaction-state.js";
 import type {
+  OrchestratedOutboundAttachmentEventEnvelope,
   OrchestratedOutboundEventEnvelope,
   OrchestratedRuntimeEventEnvelope,
   OrchestratedSubagentCreationEventEnvelope,
@@ -90,6 +94,58 @@ function makeSubagentEnvelope(
     },
     event,
   };
+}
+
+function makeAttachmentEnvelope(
+  event: OrchestratedOutboundAttachmentEventEnvelope["event"],
+  overrides: {
+    taskRunId?: string | null;
+    runType?: string | null;
+    executionSessionId?: string | null;
+  } = {},
+): OrchestratedOutboundAttachmentEventEnvelope {
+  return {
+    kind: "outbound_attachment_event",
+    target: {
+      conversationId: "conv_1",
+      branchId: "branch_1",
+    },
+    session: {
+      sessionId: "sess_1",
+      purpose: "chat",
+    },
+    agent: {
+      ownerAgentId: "agent_1",
+      ownerRole: "main",
+      mainAgentId: "agent_1",
+    },
+    taskRun: {
+      taskRunId: overrides.taskRunId ?? null,
+      runType: overrides.runType ?? null,
+      status: null,
+      executionSessionId: overrides.executionSessionId ?? null,
+    },
+    run: {
+      runId: "run_1",
+    },
+    object: {
+      messageId: null,
+      toolCallId: null,
+      toolName: null,
+      approvalId: null,
+    },
+    event,
+  };
+}
+
+async function waitForCondition(condition: () => boolean, attempts = 40): Promise<void> {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (condition()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error("Timed out waiting for condition.");
 }
 
 function makeTaskRuntimeEnvelope(
@@ -205,9 +261,12 @@ function makeApprovalRuntimeEnvelope(
 
 describe("lark outbound runtime", () => {
   let handle: TestDatabaseHandle | null = null;
+  let tempDirs: string[] = [];
 
   afterEach(async () => {
     vi.useRealTimers();
+    await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+    tempDirs = [];
     if (handle != null) {
       await destroyTestDatabase(handle);
       handle = null;
@@ -395,6 +454,159 @@ describe("lark outbound runtime", () => {
     expect(updateCard.mock.calls.at(0)?.[0]).toMatchObject({
       path: { card_id: "card_1" },
     });
+
+    await runtime.shutdown();
+  });
+
+  test("sends outbound image attachment events as native lark image messages", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    handle.storage.sqlite.exec(`
+      INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+      VALUES ('ci_lark_default', 'lark', 'default', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+      VALUES ('conv_1', 'ci_lark_default', 'oc_chat_1', 'dm', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+      VALUES ('branch_1', 'conv_1', 'dm_main', 'main', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+    `);
+
+    new ChannelSurfacesRepo(handle.storage.db).upsert({
+      id: "surface_1",
+      channelType: "lark",
+      channelInstallationId: "default",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      surfaceKey: "chat:oc_chat_1",
+      surfaceObjectJson: JSON.stringify({ chat_id: "oc_chat_1" }),
+    });
+
+    const tempDir = await mkdtemp(join(tmpdir(), "pokoclaw-lark-image-"));
+    tempDirs.push(tempDir);
+    const attachmentPath = join(tempDir, "chart.png");
+    await writeFile(attachmentPath, Buffer.from("png"));
+
+    const uploadImage = vi.fn(async (_input: unknown) => ({
+      image_key: "img_v3_uploaded",
+    }));
+    const createMessage = vi.fn(async (_input: unknown) => ({
+      data: {
+        message_id: "om_image_1",
+        open_message_id: "om_open_image_1",
+      },
+    }));
+    const bus = new RuntimeEventBus<OrchestratedOutboundEventEnvelope>();
+    const runtime = createLarkOutboundRuntime({
+      storage: handle.storage.db,
+      outboundEventBus: bus,
+      clients: {
+        getOrCreate: () =>
+          ({
+            sdk: {
+              im: {
+                image: {
+                  create: uploadImage,
+                },
+                message: {
+                  create: createMessage,
+                },
+              },
+            },
+          }) as never,
+      },
+    });
+
+    runtime.start();
+    bus.publish(
+      makeAttachmentEnvelope({
+        type: "outbound_attachment_requested",
+        eventId: "evt_image_1",
+        attachmentPath,
+        displayPath: "chart.png",
+        attachmentType: "image",
+        requestedAt: "2026-03-28T00:00:00.000Z",
+      }),
+    );
+
+    await waitForCondition(() => createMessage.mock.calls.length === 1);
+
+    expect(uploadImage).toHaveBeenCalledOnce();
+    expect(uploadImage.mock.calls[0]?.[0]).toMatchObject({
+      data: {
+        image_type: "message",
+      },
+    });
+    expect(createMessage).toHaveBeenCalledExactlyOnceWith({
+      params: { receive_id_type: "chat_id" },
+      data: {
+        receive_id: "oc_chat_1",
+        msg_type: "image",
+        content: JSON.stringify({ image_key: "img_v3_uploaded" }),
+      },
+    });
+
+    await runtime.shutdown();
+  });
+
+  test("skips non-image outbound attachment events until lark supports them", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    handle.storage.sqlite.exec(`
+      INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+      VALUES ('ci_lark_default', 'lark', 'default', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+      VALUES ('conv_1', 'ci_lark_default', 'oc_chat_1', 'dm', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+      VALUES ('branch_1', 'conv_1', 'dm_main', 'main', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+    `);
+
+    const uploadImage = vi.fn(async (_input: unknown) => ({
+      image_key: "img_v3_uploaded",
+    }));
+    const createMessage = vi.fn(async (_input: unknown) => ({
+      data: {
+        message_id: "om_file_1",
+        open_message_id: "om_open_file_1",
+      },
+    }));
+    const bus = new RuntimeEventBus<OrchestratedOutboundEventEnvelope>();
+    const runtime = createLarkOutboundRuntime({
+      storage: handle.storage.db,
+      outboundEventBus: bus,
+      clients: {
+        getOrCreate: () =>
+          ({
+            sdk: {
+              im: {
+                image: {
+                  create: uploadImage,
+                },
+                message: {
+                  create: createMessage,
+                },
+              },
+            },
+          }) as never,
+      },
+    });
+
+    runtime.start();
+    bus.publish(
+      makeAttachmentEnvelope({
+        type: "outbound_attachment_requested",
+        eventId: "evt_pdf_1",
+        attachmentPath: "/tmp/report.pdf",
+        displayPath: "report.pdf",
+        attachmentType: "pdf",
+        requestedAt: "2026-03-28T00:00:00.000Z",
+      }),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(uploadImage).not.toHaveBeenCalled();
+    expect(createMessage).not.toHaveBeenCalled();
 
     await runtime.shutdown();
   });

--- a/tests/channels/lark/outbound.test.ts
+++ b/tests/channels/lark/outbound.test.ts
@@ -487,7 +487,9 @@ describe("lark outbound runtime", () => {
     await writeFile(attachmentPath, Buffer.from("png"));
 
     const uploadImage = vi.fn(async (_input: unknown) => ({
-      image_key: "img_v3_uploaded",
+      data: {
+        image_key: "img_v3_uploaded",
+      },
     }));
     const createMessage = vi.fn(async (_input: unknown) => ({
       data: {
@@ -548,6 +550,105 @@ describe("lark outbound runtime", () => {
     await runtime.shutdown();
   });
 
+  test("continues sending outbound image attachments after one lark target fails", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    handle.storage.sqlite.exec(`
+      INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+      VALUES
+        ('ci_lark_bad', 'lark', 'bad', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z'),
+        ('ci_lark_good', 'lark', 'good', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+      VALUES ('conv_1', 'ci_lark_bad', 'oc_bad', 'dm', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+      VALUES ('branch_1', 'conv_1', 'dm_main', 'main', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+    `);
+
+    const surfaces = new ChannelSurfacesRepo(handle.storage.db);
+    surfaces.upsert({
+      id: "surface_bad",
+      channelType: "lark",
+      channelInstallationId: "bad",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      surfaceKey: "chat:oc_bad",
+      surfaceObjectJson: JSON.stringify({ chat_id: "oc_bad" }),
+    });
+    surfaces.upsert({
+      id: "surface_good",
+      channelType: "lark",
+      channelInstallationId: "good",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      surfaceKey: "chat:oc_good",
+      surfaceObjectJson: JSON.stringify({ chat_id: "oc_good" }),
+    });
+
+    const tempDir = await mkdtemp(join(tmpdir(), "pokoclaw-lark-image-"));
+    tempDirs.push(tempDir);
+    const attachmentPath = join(tempDir, "chart.png");
+    await writeFile(attachmentPath, Buffer.from("png"));
+
+    const uploadImage = vi.fn(async (_input: unknown) => ({
+      data: {
+        image_key: "img_v3_uploaded",
+      },
+    }));
+    let createAttempts = 0;
+    const createMessage = vi.fn(async (_input: unknown) => {
+      createAttempts += 1;
+      if (createAttempts === 1) {
+        throw new Error("simulated lark send failure");
+      }
+      return {
+        data: {
+          message_id: "om_image_2",
+          open_message_id: "om_open_image_2",
+        },
+      };
+    });
+    const bus = new RuntimeEventBus<OrchestratedOutboundEventEnvelope>();
+    const runtime = createLarkOutboundRuntime({
+      storage: handle.storage.db,
+      outboundEventBus: bus,
+      clients: {
+        getOrCreate: () =>
+          ({
+            sdk: {
+              im: {
+                image: {
+                  create: uploadImage,
+                },
+                message: {
+                  create: createMessage,
+                },
+              },
+            },
+          }) as never,
+      },
+    });
+
+    runtime.start();
+    bus.publish(
+      makeAttachmentEnvelope({
+        type: "outbound_attachment_requested",
+        eventId: "evt_image_1",
+        attachmentPath,
+        displayPath: "chart.png",
+        attachmentType: "image",
+        requestedAt: "2026-03-28T00:00:00.000Z",
+      }),
+    );
+
+    await waitForCondition(() => createMessage.mock.calls.length === 2);
+
+    expect(uploadImage).toHaveBeenCalledTimes(2);
+    expect(createMessage).toHaveBeenCalledTimes(2);
+
+    await runtime.shutdown();
+  });
+
   test("skips non-image outbound attachment events until lark supports them", async () => {
     handle = await createTestDatabase(import.meta.url);
     handle.storage.sqlite.exec(`
@@ -562,7 +663,9 @@ describe("lark outbound runtime", () => {
     `);
 
     const uploadImage = vi.fn(async (_input: unknown) => ({
-      image_key: "img_v3_uploaded",
+      data: {
+        image_key: "img_v3_uploaded",
+      },
     }));
     const createMessage = vi.fn(async (_input: unknown) => ({
       data: {

--- a/tests/orchestration/agent-manager.test.ts
+++ b/tests/orchestration/agent-manager.test.ts
@@ -1487,6 +1487,84 @@ describe("AgentManager", () => {
     });
   });
 
+  test("publishes outbound attachment envelopes to the outbound event bus", async () => {
+    await withHandle(async (handle) => {
+      seedFixture(handle);
+      handle.storage.sqlite.exec(`
+        INSERT INTO task_runs (
+          id, run_type, owner_agent_id, conversation_id, branch_id,
+          execution_session_id, status, started_at
+        ) VALUES (
+          'task_image_1', 'delegate', 'agent_sub', 'conv_sub', 'branch_sub',
+          'sess_sub', 'running', '2026-03-25T00:00:02.500Z'
+        );
+      `);
+
+      const bus = new RuntimeEventBus<OrchestratedOutboundEventEnvelope>();
+      const published: OrchestratedOutboundEventEnvelope[] = [];
+      bus.subscribe(async (event) => {
+        published.push(event);
+      });
+
+      const manager = new AgentManager({
+        storage: handle.storage.db,
+        ingress: {
+          submitMessage: vi.fn(async () => ({ status: "steered" as const })),
+          submitApprovalDecision: vi.fn(() => false),
+        },
+        outboundEventBus: bus,
+      });
+
+      const result = manager.publishOutboundAttachment({
+        sourceSessionId: "sess_sub",
+        conversationId: "conv_sub",
+        branchId: "branch_sub",
+        runId: "run_1",
+        taskRunId: "task_image_1",
+        attachmentPath: "/tmp/chart.png",
+        displayPath: "chart.png",
+        type: "image",
+      });
+      await flushMicrotasks();
+
+      expect(result).toMatchObject({
+        accepted: true,
+        eventId: expect.any(String),
+      });
+      expect(published).toHaveLength(1);
+      expect(published[0]).toMatchObject({
+        kind: "outbound_attachment_event",
+        target: {
+          conversationId: "conv_sub",
+          branchId: "branch_sub",
+        },
+        session: {
+          sessionId: "sess_sub",
+          purpose: "task",
+        },
+        agent: {
+          ownerAgentId: "agent_sub",
+          ownerRole: "subagent",
+          mainAgentId: "agent_main",
+        },
+        taskRun: {
+          taskRunId: "task_image_1",
+          runType: "delegate",
+        },
+        run: {
+          runId: "run_1",
+        },
+        event: {
+          type: "outbound_attachment_requested",
+          eventId: result.eventId,
+          attachmentPath: "/tmp/chart.png",
+          displayPath: "chart.png",
+          attachmentType: "image",
+        },
+      });
+    });
+  });
+
   test("returns null for invalid delegated approval ids", async () => {
     const submitMessage = vi.fn(
       async (_input: SubmitMessageInput): Promise<SubmitMessageResult> => {

--- a/tests/runtime/orchestration-bridge.test.ts
+++ b/tests/runtime/orchestration-bridge.test.ts
@@ -250,6 +250,7 @@ describe("RuntimeOrchestrationBridge", () => {
       manager: {
         emitRuntimeEvent: vi.fn(),
         submitSubagentCreationRequest: vi.fn(),
+        publishOutboundAttachment: vi.fn(),
         runCronJobNow: vi.fn(async () => ({
           accepted: true,
           cronJobId: "cron_sub_1",
@@ -286,6 +287,7 @@ describe("RuntimeOrchestrationBridge", () => {
       manager: {
         emitRuntimeEvent: vi.fn(),
         submitSubagentCreationRequest: vi.fn(),
+        publishOutboundAttachment: vi.fn(),
         runCronJobNow: vi.fn(async () => ({
           accepted: true,
           cronJobId: "cron_sub_1",
@@ -320,6 +322,57 @@ describe("RuntimeOrchestrationBridge", () => {
     });
     expect(suppressBackgroundTaskCompletionNotice).toHaveBeenCalledExactlyOnceWith({
       taskRunId: "task_bg_1",
+    });
+  });
+
+  test("forwards attachment send requests to the attached manager", async () => {
+    const publishOutboundAttachment = vi.fn(() => ({
+      accepted: true as const,
+      eventId: "evt_image_1",
+    }));
+    const bridge = createRuntimeOrchestrationBridge({
+      manager: {
+        emitRuntimeEvent: vi.fn(),
+        submitSubagentCreationRequest: vi.fn(),
+        publishOutboundAttachment,
+        runCronJobNow: vi.fn(async () => ({
+          accepted: true,
+          cronJobId: "cron_sub_1",
+          taskRunId: "task_run_cron_1",
+          executionSessionId: "sess_task_cron_1",
+        })),
+        startBackgroundTask: vi.fn(async () => ({
+          accepted: true,
+          taskRunId: "task_bg_1",
+        })),
+        suppressBackgroundTaskCompletionNotice: vi.fn(),
+      },
+    });
+
+    await expect(
+      bridge.runtimeControl.sendAttachment?.({
+        sourceSessionId: "sess_main",
+        conversationId: "conv_main",
+        branchId: "branch_main",
+        runId: "run_1",
+        taskRunId: "task_1",
+        attachmentPath: "/tmp/chart.png",
+        displayPath: "chart.png",
+        type: "image",
+      }),
+    ).resolves.toEqual({
+      accepted: true,
+      eventId: "evt_image_1",
+    });
+    expect(publishOutboundAttachment).toHaveBeenCalledExactlyOnceWith({
+      sourceSessionId: "sess_main",
+      conversationId: "conv_main",
+      branchId: "branch_main",
+      runId: "run_1",
+      taskRunId: "task_1",
+      attachmentPath: "/tmp/chart.png",
+      displayPath: "chart.png",
+      type: "image",
     });
   });
 });

--- a/tests/tools/builtins.test.ts
+++ b/tests/tools/builtins.test.ts
@@ -24,6 +24,7 @@ describe("builtin tools", () => {
     expect(registry.has("background_task")).toBe(true);
     expect(registry.has("wait_task")).toBe(true);
     expect(registry.has("list_background_tasks")).toBe(true);
+    expect(registry.has("send_attachment")).toBe(true);
     expect(registry.has("publish_a2ui")).toBe(true);
     expect(registry.has("web_search")).toBe(false);
     expect(registry.has("web_fetch")).toBe(false);
@@ -45,6 +46,7 @@ describe("builtin tools", () => {
       "background_task",
       "wait_task",
       "list_background_tasks",
+      "send_attachment",
       "publish_a2ui",
     ]);
   });

--- a/tests/tools/send-attachment.test.ts
+++ b/tests/tools/send-attachment.test.ts
@@ -40,6 +40,7 @@ describe("send_attachment tool", () => {
     expect(tool.description).toContain("current conversation");
     expect(tool.description).toContain("Do not substitute Markdown links");
     expect(tool.description).toContain("text cards, or A2UI");
+    expect(tool.description).toContain("Currently only image attachments are delivered");
   });
 
   test("publishes a granted local image path as a channel-neutral outbound attachment request", async () => {
@@ -150,6 +151,57 @@ describe("send_attachment tool", () => {
       kind: "recoverable_error",
       details: {
         code: "unsupported_image_format",
+      },
+    });
+    expect(sendAttachment).not.toHaveBeenCalled();
+  });
+
+  test("rejects non-image attachments before publishing unsupported outbound events", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+    handle.storage.sqlite.exec(`
+      INSERT INTO sessions (id, conversation_id, branch_id, owner_agent_id, purpose, created_at, updated_at)
+      VALUES ('sess_1', 'conv_1', 'branch_1', 'agent_1', 'chat', '2026-03-22T00:00:00.000Z', '2026-03-22T00:00:00.000Z');
+    `);
+
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "pokoclaw-send-attachment-"));
+    await writeFile(path.join(tempDir, "report.pdf"), "%PDF-1.7");
+
+    new SecurityService(handle.storage.db).grantScopes({
+      ownerAgentId: "agent_1",
+      grantedBy: "main_agent",
+      scopes: [{ kind: "fs.read", path: `${tempDir}/**` }],
+    });
+
+    const sendAttachment = vi.fn(async () => ({
+      accepted: true as const,
+      eventId: "evt_pdf_1",
+    }));
+    const registry = new ToolRegistry();
+    registry.register(createSendAttachmentTool());
+
+    await expect(
+      registry.execute(
+        "send_attachment",
+        {
+          sessionId: "sess_1",
+          conversationId: "conv_1",
+          ownerAgentId: "agent_1",
+          cwd: tempDir,
+          securityConfig: DEFAULT_CONFIG.security,
+          storage: handle.storage.db,
+          runtimeControl: {
+            sendAttachment,
+            submitApprovalDecision: vi.fn(() => false),
+          },
+        },
+        { path: "report.pdf" },
+      ),
+    ).rejects.toMatchObject({
+      kind: "recoverable_error",
+      details: {
+        code: "unsupported_attachment_type",
+        attachmentType: "pdf",
       },
     });
     expect(sendAttachment).not.toHaveBeenCalled();

--- a/tests/tools/send-attachment.test.ts
+++ b/tests/tools/send-attachment.test.ts
@@ -1,0 +1,107 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { DEFAULT_CONFIG } from "@/src/config/defaults.js";
+import { SecurityService } from "@/src/security/service.js";
+import { ToolRegistry } from "@/src/tools/core/registry.js";
+import { createSendAttachmentTool } from "@/src/tools/send-attachment.js";
+import {
+  createTestDatabase,
+  destroyTestDatabase,
+  type TestDatabaseHandle,
+} from "@/tests/storage/helpers/test-db.js";
+import {
+  resolveExpectedToolAbsolutePath,
+  seedConversationAndAgentFixture,
+} from "@/tests/tools/helpers.js";
+
+describe("send_attachment tool", () => {
+  let handle: TestDatabaseHandle | null = null;
+  let tempDir: string | null = null;
+
+  afterEach(async () => {
+    if (handle != null) {
+      await destroyTestDatabase(handle);
+      handle = null;
+    }
+    if (tempDir != null) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  test("describes native attachment delivery instead of fallback links or cards", () => {
+    const tool = createSendAttachmentTool();
+
+    expect(tool.description).toContain("send, show, share, or deliver a local image or file");
+    expect(tool.description).toContain("current conversation");
+    expect(tool.description).toContain("Do not substitute Markdown links");
+    expect(tool.description).toContain("text cards, or A2UI");
+  });
+
+  test("publishes a granted local image path as a channel-neutral outbound attachment request", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+    handle.storage.sqlite.exec(`
+      INSERT INTO sessions (id, conversation_id, branch_id, owner_agent_id, purpose, created_at, updated_at)
+      VALUES ('sess_1', 'conv_1', 'branch_1', 'agent_1', 'chat', '2026-03-22T00:00:00.000Z', '2026-03-22T00:00:00.000Z');
+    `);
+
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "pokoclaw-send-attachment-"));
+    const attachmentPath = path.join(tempDir, "chart.png");
+    await writeFile(attachmentPath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+    new SecurityService(handle.storage.db).grantScopes({
+      ownerAgentId: "agent_1",
+      grantedBy: "main_agent",
+      scopes: [{ kind: "fs.read", path: `${tempDir}/**` }],
+    });
+
+    const sendAttachment = vi.fn(async () => ({
+      accepted: true as const,
+      eventId: "evt_image_1",
+    }));
+    const registry = new ToolRegistry();
+    registry.register(createSendAttachmentTool());
+
+    const result = await registry.execute(
+      "send_attachment",
+      {
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        ownerAgentId: "agent_1",
+        cwd: tempDir,
+        securityConfig: DEFAULT_CONFIG.security,
+        storage: handle.storage.db,
+        runtimeControl: {
+          sendAttachment,
+          submitApprovalDecision: vi.fn(() => false),
+        },
+      },
+      { path: "chart.png", type: "image" },
+    );
+
+    const expectedAbsolutePath = await resolveExpectedToolAbsolutePath(attachmentPath);
+    expect(sendAttachment).toHaveBeenCalledWith({
+      sourceSessionId: "sess_1",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      attachmentPath: expectedAbsolutePath,
+      displayPath: "chart.png",
+      type: "image",
+    });
+    expect(result).toEqual({
+      content: [{ type: "text", text: "Queued attachment chart.png for sending." }],
+      details: {
+        path: "chart.png",
+        absolutePath: expectedAbsolutePath,
+        type: "image",
+        eventId: "evt_image_1",
+        queued: true,
+      },
+    });
+  });
+});

--- a/tests/tools/send-attachment.test.ts
+++ b/tests/tools/send-attachment.test.ts
@@ -104,4 +104,54 @@ describe("send_attachment tool", () => {
       },
     });
   });
+
+  test("rejects explicit image attachments with unsupported image extensions", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationAndAgentFixture(handle);
+    handle.storage.sqlite.exec(`
+      INSERT INTO sessions (id, conversation_id, branch_id, owner_agent_id, purpose, created_at, updated_at)
+      VALUES ('sess_1', 'conv_1', 'branch_1', 'agent_1', 'chat', '2026-03-22T00:00:00.000Z', '2026-03-22T00:00:00.000Z');
+    `);
+
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "pokoclaw-send-attachment-"));
+    await writeFile(path.join(tempDir, "notes.txt"), "not an image");
+
+    new SecurityService(handle.storage.db).grantScopes({
+      ownerAgentId: "agent_1",
+      grantedBy: "main_agent",
+      scopes: [{ kind: "fs.read", path: `${tempDir}/**` }],
+    });
+
+    const sendAttachment = vi.fn(async () => ({
+      accepted: true as const,
+      eventId: "evt_image_1",
+    }));
+    const registry = new ToolRegistry();
+    registry.register(createSendAttachmentTool());
+
+    await expect(
+      registry.execute(
+        "send_attachment",
+        {
+          sessionId: "sess_1",
+          conversationId: "conv_1",
+          ownerAgentId: "agent_1",
+          cwd: tempDir,
+          securityConfig: DEFAULT_CONFIG.security,
+          storage: handle.storage.db,
+          runtimeControl: {
+            sendAttachment,
+            submitApprovalDecision: vi.fn(() => false),
+          },
+        },
+        { path: "notes.txt", type: "image" },
+      ),
+    ).rejects.toMatchObject({
+      kind: "recoverable_error",
+      details: {
+        code: "unsupported_image_format",
+      },
+    });
+    expect(sendAttachment).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- add a `send_lark_image` builtin tool for uploading local images and sending native Lark/Feishu image messages
- wire the tool into runtime bootstrap through the existing Lark client registry
- update tool/system prompt guidance so current-chat image requests use `send_lark_image` instead of Markdown links, paths, cards, or A2UI

## Why
Pokoclaw could already receive Lark image messages, but outbound Lark support only covered run cards, text messages, and Feishu doc preview links. When a user asked the agent to send an image in chat, there was no first-class native image sending path.

## Validation
- Live E2E on mini: generated a visible PNG and successfully sent it into the current Feishu chat via `send_lark_image`
- `pnpm build`
- `pnpm lint`
- `pnpm test` (150 files / 975 tests)
- pre-commit `pnpm preflight`
