### PR TITLE
Fix Lark CardKit ambiguous send retry

### DIFF
--- a/src/channels/lark/outbound.ts
+++ b/src/channels/lark/outbound.ts
@@ -18,9 +18,11 @@ import {
   getNextCardkitSequence,
   invokeLarkCardkitCallWithBusinessRetry,
   invokeSequencedLarkCardkitMutation,
+  isAmbiguousLarkCardkitTransportError,
   type LarkCardCreateResponse,
   type LarkCardOperationResponse,
   parseBindingMetadata,
+  readLarkHttpStatus,
   setCardkitSequenceFloorInMetadata,
 } from "@/src/channels/lark/cardkit-mutations.js";
 import type { LarkSdkClient } from "@/src/channels/lark/client.js";
@@ -70,6 +72,9 @@ const APPROVAL_CARD_OBJECT_KIND = "approval_card";
 const SUBAGENT_REQUEST_CARD_OBJECT_KIND = "subagent_creation_request_card";
 const LARK_CARD_LOG_PREVIEW_MAX_LENGTH = 600;
 const LARK_CARDKIT_RECONCILE_RETRY_DELAY_MS = 1000;
+const LARK_CARD_REFERENCE_SEND_RETRY_DELAY_MS = 1000;
+const LARK_CARD_REFERENCE_SEND_RETRY_LIMIT = 1;
+const LARK_CARD_REFERENCE_SEND_FAILURE_METADATA_KEY = "cardReferenceSendFailure";
 const TASK_STATUS_DELIVERY_PREFIX = "task_status:";
 const STEER_CONFIRMED_REACTION_EMOJI = "OK";
 const LARK_OUTBOUND_DEPENDENCY_RETRY_DELAY_MS = 1_000;
@@ -311,7 +316,29 @@ export function createLarkOutboundRuntime(
     status: "active" | "finalized" | "stale";
     metadataJson: string;
     logContext: Record<string, unknown>;
+    deliveryId: string;
   }): Promise<LarkObjectBinding | null> => {
+    const existingBeforeReserve = bindingInput.bindingsRepo.getByInternalObject({
+      channelInstallationId: bindingInput.channelInstallationId,
+      internalObjectKind: bindingInput.internalObjectKind,
+      internalObjectId: bindingInput.internalObjectId,
+    });
+    if (isTerminalIncompleteCardReferenceBinding(existingBeforeReserve)) {
+      logger.warn("skipping lark card reference send for terminal incomplete binding", {
+        ...bindingInput.logContext,
+        channelInstallationId: bindingInput.channelInstallationId,
+        internalObjectKind: bindingInput.internalObjectKind,
+        internalObjectId: bindingInput.internalObjectId,
+        larkCardId: existingBeforeReserve?.larkCardId ?? null,
+        status: existingBeforeReserve?.status ?? null,
+      });
+      return null;
+    }
+
+    let metadataJson = preserveCardReferenceSendFailureMetadata({
+      nextMetadataJson: bindingInput.metadataJson,
+      existingMetadataJson: existingBeforeReserve?.metadataJson ?? null,
+    });
     const threadRootMessageId = readStringValue(bindingInput.surfaceObject.thread_id);
     let binding = bindingInput.bindingsRepo.reserveBinding({
       id: randomUUID(),
@@ -325,7 +352,7 @@ export function createLarkOutboundRuntime(
       cardElementId: bindingInput.cardElementId,
       lastSequence: bindingInput.lastSequence,
       status: bindingInput.status,
-      metadataJson: bindingInput.metadataJson,
+      metadataJson,
     });
 
     if (binding.larkMessageUuid == null) {
@@ -373,7 +400,7 @@ export function createLarkOutboundRuntime(
         cardElementId: bindingInput.cardElementId,
         lastSequence: bindingInput.lastSequence,
         status: bindingInput.status,
-        metadataJson: bindingInput.metadataJson,
+        metadataJson,
       });
       if (attachedBinding == null) {
         return null;
@@ -393,13 +420,43 @@ export function createLarkOutboundRuntime(
         larkCardId,
         larkMessageUuid: binding.larkMessageUuid,
       });
-      const response = await sendLarkInteractiveCardReferenceMessage({
-        client: bindingInput.client,
-        chatId: bindingInput.chatId,
-        surfaceObject: bindingInput.surfaceObject,
-        larkCardId,
-        larkMessageUuid: binding.larkMessageUuid,
-      });
+      let response: LarkInteractiveMessageResponse;
+      try {
+        response = await sendLarkInteractiveCardReferenceMessage({
+          client: bindingInput.client,
+          chatId: bindingInput.chatId,
+          surfaceObject: bindingInput.surfaceObject,
+          larkCardId,
+          larkMessageUuid: binding.larkMessageUuid,
+        });
+      } catch (error) {
+        if (!isRecoverableCardReferenceSendFailure(error)) {
+          throw error;
+        }
+
+        handleRecoverableCardReferenceSendFailure({
+          bindingsRepo: bindingInput.bindingsRepo,
+          binding,
+          channelInstallationId: bindingInput.channelInstallationId,
+          internalObjectKind: bindingInput.internalObjectKind,
+          internalObjectId: bindingInput.internalObjectId,
+          conversationId: bindingInput.conversationId,
+          branchId: bindingInput.branchId,
+          threadRootMessageId,
+          cardElementId: bindingInput.cardElementId,
+          lastSequence: bindingInput.lastSequence,
+          desiredStatus: bindingInput.status,
+          metadataJson,
+          deliveryId: bindingInput.deliveryId,
+          error,
+          logContext: bindingInput.logContext,
+          scheduleRetry: () =>
+            bumpVersionAndSchedule(bindingInput.deliveryId, {
+              delayMs: LARK_CARD_REFERENCE_SEND_RETRY_DELAY_MS,
+            }),
+        });
+        return null;
+      }
       const larkMessageId = response.data?.message_id ?? null;
       if (larkMessageId == null) {
         logger.warn("lark card reference send returned no message id", {
@@ -424,11 +481,12 @@ export function createLarkOutboundRuntime(
         cardElementId: bindingInput.cardElementId,
         lastSequence: bindingInput.lastSequence,
         status: bindingInput.status,
-        metadataJson: bindingInput.metadataJson,
+        metadataJson,
       });
       if (attachedBinding == null) {
         return null;
       }
+      metadataJson = attachedBinding.metadataJson ?? metadataJson;
       binding = attachedBinding;
     }
 
@@ -485,7 +543,8 @@ export function createLarkOutboundRuntime(
       if (
         state.taskRunId != null &&
         shouldRenderStandaloneTaskCard(state.taskRunType) &&
-        taskRootBinding?.larkMessageId == null
+        taskRootBinding?.larkMessageId == null &&
+        taskRootBinding?.status !== "stale"
       ) {
         const taskStatusDeliveryId = `${TASK_STATUS_DELIVERY_PREFIX}${state.taskRunId}`;
         logger.debug("deferring task transcript flush until task status card exists", {
@@ -605,6 +664,7 @@ export function createLarkOutboundRuntime(
               pageObjectId,
               pageIndex: renderedPage.pageIndex,
             },
+            deliveryId: `run:${runCardObjectId}`,
           });
           if (binding == null) {
             shouldDeferDocPreview = true;
@@ -991,6 +1051,7 @@ export function createLarkOutboundRuntime(
             taskRunId,
             cardRole: "task_status",
           },
+          deliveryId: `${TASK_STATUS_DELIVERY_PREFIX}${taskRunId}`,
         });
         if (binding == null) {
           continue;
@@ -1159,7 +1220,8 @@ export function createLarkOutboundRuntime(
       if (
         state.taskRunId != null &&
         shouldRenderStandaloneTaskCard(state.taskRunType) &&
-        taskRootBinding?.larkMessageId == null
+        taskRootBinding?.larkMessageId == null &&
+        taskRootBinding?.status !== "stale"
       ) {
         const taskStatusDeliveryId = `${TASK_STATUS_DELIVERY_PREFIX}${state.taskRunId}`;
         logger.debug("deferring task approval card flush until task status card exists", {
@@ -1219,6 +1281,7 @@ export function createLarkOutboundRuntime(
             approvalId: state.approvalId,
             runId: state.runId,
           },
+          deliveryId: `approval:${approvalFlowId}`,
         });
         if (binding == null) {
           continue;
@@ -1369,6 +1432,7 @@ export function createLarkOutboundRuntime(
             requestId,
             status: entry.state.status,
           },
+          deliveryId: `subagent:${requestId}`,
         });
         if (binding == null) {
           continue;
@@ -2105,6 +2169,206 @@ async function sendLarkInteractiveCardReferenceMessage(input: {
       ...(input.larkMessageUuid == null ? {} : { uuid: input.larkMessageUuid }),
     },
   }) as Promise<LarkInteractiveMessageResponse>;
+}
+
+function isTerminalIncompleteCardReferenceBinding(binding: LarkObjectBinding | null): boolean {
+  return binding?.status === "stale" && binding.larkMessageId == null && binding.larkCardId != null;
+}
+
+function preserveCardReferenceSendFailureMetadata(input: {
+  nextMetadataJson: string;
+  existingMetadataJson: string | null;
+}): string {
+  const nextMetadata = parseBindingMetadata(input.nextMetadataJson);
+  const existingMetadata = parseBindingMetadata(input.existingMetadataJson);
+  const existingFailure = existingMetadata[LARK_CARD_REFERENCE_SEND_FAILURE_METADATA_KEY];
+  if (
+    nextMetadata[LARK_CARD_REFERENCE_SEND_FAILURE_METADATA_KEY] == null &&
+    isRecord(existingFailure)
+  ) {
+    return JSON.stringify({
+      ...nextMetadata,
+      [LARK_CARD_REFERENCE_SEND_FAILURE_METADATA_KEY]: existingFailure,
+    });
+  }
+
+  return JSON.stringify(nextMetadata);
+}
+
+function handleRecoverableCardReferenceSendFailure(input: {
+  bindingsRepo: LarkObjectBindingsRepo;
+  binding: LarkObjectBinding;
+  channelInstallationId: string;
+  internalObjectKind: string;
+  internalObjectId: string;
+  conversationId: string;
+  branchId: string;
+  threadRootMessageId: string | null;
+  cardElementId: string | null | undefined;
+  lastSequence: number | null | undefined;
+  desiredStatus: "active" | "finalized" | "stale";
+  metadataJson: string;
+  deliveryId: string;
+  error: unknown;
+  logContext: Record<string, unknown>;
+  scheduleRetry: () => void;
+}): void {
+  const failureKind = classifyRecoverableCardReferenceSendFailure(input.error);
+  if (failureKind == null) {
+    throw input.error;
+  }
+
+  const existingMetadata = parseBindingMetadata(input.binding.metadataJson ?? input.metadataJson);
+  const attempts = readCardReferenceSendFailureAttempts(existingMetadata) + 1;
+  const terminal = attempts > LARK_CARD_REFERENCE_SEND_RETRY_LIMIT;
+  const failureMetadata = buildCardReferenceSendFailureMetadata({
+    metadata: existingMetadata,
+    attempts,
+    failureKind,
+    error: input.error,
+  });
+
+  if (terminal) {
+    input.bindingsRepo.patchByInternalObject({
+      channelInstallationId: input.channelInstallationId,
+      internalObjectKind: input.internalObjectKind,
+      internalObjectId: input.internalObjectId,
+      conversationId: input.conversationId,
+      branchId: input.branchId,
+      threadRootMessageId: input.threadRootMessageId,
+      cardElementId: input.cardElementId,
+      lastSequence: input.lastSequence,
+      status: "stale",
+      metadataJson: failureMetadata,
+    });
+    logger.error("marked lark card reference binding stale after repeated send failure", {
+      ...input.logContext,
+      channelInstallationId: input.channelInstallationId,
+      internalObjectKind: input.internalObjectKind,
+      internalObjectId: input.internalObjectId,
+      deliveryId: input.deliveryId,
+      larkCardId: input.binding.larkCardId,
+      larkMessageUuid: input.binding.larkMessageUuid,
+      attempts,
+      retryLimit: LARK_CARD_REFERENCE_SEND_RETRY_LIMIT,
+      failureKind,
+      httpStatus: readLarkHttpStatus(input.error),
+    });
+    return;
+  }
+
+  const nextMessageUuid = randomUUID();
+  input.bindingsRepo.patchByInternalObject({
+    channelInstallationId: input.channelInstallationId,
+    internalObjectKind: input.internalObjectKind,
+    internalObjectId: input.internalObjectId,
+    conversationId: input.conversationId,
+    branchId: input.branchId,
+    larkMessageUuid: nextMessageUuid,
+    larkMessageId: null,
+    larkOpenMessageId: null,
+    larkCardId: null,
+    threadRootMessageId: input.threadRootMessageId,
+    cardElementId: input.cardElementId,
+    lastSequence: input.lastSequence,
+    status: input.desiredStatus,
+    metadataJson: failureMetadata,
+  });
+  logger.warn("abandoned ambiguous lark card reference binding and scheduled fresh retry", {
+    ...input.logContext,
+    channelInstallationId: input.channelInstallationId,
+    internalObjectKind: input.internalObjectKind,
+    internalObjectId: input.internalObjectId,
+    deliveryId: input.deliveryId,
+    abandonedLarkCardId: input.binding.larkCardId,
+    abandonedLarkMessageUuid: input.binding.larkMessageUuid,
+    nextLarkMessageUuid: nextMessageUuid,
+    attempts,
+    retryLimit: LARK_CARD_REFERENCE_SEND_RETRY_LIMIT,
+    failureKind,
+    delayMs: LARK_CARD_REFERENCE_SEND_RETRY_DELAY_MS,
+    httpStatus: readLarkHttpStatus(input.error),
+  });
+  input.scheduleRetry();
+}
+
+function buildCardReferenceSendFailureMetadata(input: {
+  metadata: Record<string, unknown>;
+  attempts: number;
+  failureKind: "ambiguous_transport_failure" | "card_binding_biz_count_over_limit";
+  error: unknown;
+}): string {
+  const responseData = readLarkErrorResponseData(input.error);
+  const message =
+    input.error instanceof Error ? input.error.message : truncateLogText(String(input.error), 160);
+  return JSON.stringify({
+    ...input.metadata,
+    [LARK_CARD_REFERENCE_SEND_FAILURE_METADATA_KEY]: {
+      attempts: input.attempts,
+      lastFailureKind: input.failureKind,
+      lastFailedAt: new Date().toISOString(),
+      httpStatus: readLarkHttpStatus(input.error),
+      upstreamCode: readNumberValue(responseData?.code),
+      upstreamLogId: readStringValue(responseData?.log_id),
+      messagePreview: truncateLogText(message, 160),
+    },
+  });
+}
+
+function readCardReferenceSendFailureAttempts(metadata: Record<string, unknown>): number {
+  const failure = metadata[LARK_CARD_REFERENCE_SEND_FAILURE_METADATA_KEY];
+  if (!isRecord(failure)) {
+    return 0;
+  }
+  const attempts = failure.attempts;
+  return typeof attempts === "number" && Number.isInteger(attempts) && attempts > 0 ? attempts : 0;
+}
+
+function isRecoverableCardReferenceSendFailure(error: unknown): boolean {
+  return classifyRecoverableCardReferenceSendFailure(error) != null;
+}
+
+function classifyRecoverableCardReferenceSendFailure(
+  error: unknown,
+): "ambiguous_transport_failure" | "card_binding_biz_count_over_limit" | null {
+  if (isAmbiguousLarkCardkitTransportError(error)) {
+    return "ambiguous_transport_failure";
+  }
+  return isLarkCardBindingBizCountOverLimitError(error)
+    ? "card_binding_biz_count_over_limit"
+    : null;
+}
+
+function isLarkCardBindingBizCountOverLimitError(error: unknown): boolean {
+  const responseData = readLarkErrorResponseData(error);
+  const status = readLarkHttpStatus(error);
+  const code = readNumberValue(responseData?.code);
+  const msg = readStringValue(responseData?.msg) ?? "";
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    status === 400 &&
+    code === 230099 &&
+    /200780|card binding biz count over limit/i.test(`${msg} ${message}`)
+  );
+}
+
+function readLarkErrorResponseData(error: unknown): Record<string, unknown> | null {
+  if (!isRecord(error)) {
+    return null;
+  }
+  const response = error.response;
+  if (!isRecord(response)) {
+    return null;
+  }
+  return isRecord(response.data) ? response.data : null;
+}
+
+function readNumberValue(value: unknown): number | null {
+  return typeof value === "number" ? value : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != null && !Array.isArray(value);
 }
 
 async function sendLarkThreadMarkdownCard(input: {

--- a/tests/channels/lark/outbound.test.ts
+++ b/tests/channels/lark/outbound.test.ts
@@ -166,6 +166,42 @@ function makeTaskEnvelope(
   };
 }
 
+function makeLarkHttpError(
+  status: number,
+  data: Record<string, unknown>,
+): Error & { response: { status: number; data: Record<string, unknown> } } {
+  const error = new Error(`Request failed with status code ${status}`) as Error & {
+    response: { status: number; data: Record<string, unknown> };
+  };
+  error.response = {
+    status,
+    data,
+  };
+  return error;
+}
+
+function readLarkInteractiveCardId(input: unknown): string | null {
+  const content =
+    typeof input === "object" &&
+    input != null &&
+    "data" in input &&
+    typeof input.data === "object" &&
+    input.data != null &&
+    "content" in input.data &&
+    typeof input.data.content === "string"
+      ? input.data.content
+      : null;
+  if (content == null) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(content) as { data?: { card_id?: unknown } };
+    return typeof parsed.data?.card_id === "string" ? parsed.data.card_id : null;
+  } catch {
+    return null;
+  }
+}
+
 function makeApprovalRuntimeEnvelope(
   event: OrchestratedRuntimeEventEnvelope["event"],
 ): OrchestratedRuntimeEventEnvelope {
@@ -2078,6 +2114,197 @@ describe("lark outbound runtime", () => {
     expect(fullReplyPayload?.data?.msg_type).toBe("interactive");
     expect(fullReplyPayload?.data?.content ?? "").toContain("日报汇总 · 完整结果");
     expect(fullReplyPayload?.data?.content ?? "").toContain("tail-end-marker");
+
+    await runtime.shutdown();
+  });
+
+  test("does not retry the same task status card after ambiguous card reference send failure", async () => {
+    vi.useFakeTimers();
+    handle = await createTestDatabase(import.meta.url);
+    handle.storage.sqlite.exec(`
+      INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+      VALUES ('ci_lark_default', 'lark', 'default', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+      VALUES ('conv_1', 'ci_lark_default', 'oc_chat_1', 'dm', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+      VALUES ('branch_1', 'conv_1', 'dm_main', 'main', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO agents (id, conversation_id, main_agent_id, kind, created_at)
+      VALUES ('agent_1', 'conv_1', NULL, 'main', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO sessions (id, conversation_id, branch_id, owner_agent_id, purpose, status, created_at, updated_at)
+      VALUES ('sess_task', 'conv_1', 'branch_1', 'agent_1', 'task', 'active', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO cron_jobs (
+        id, owner_agent_id, target_conversation_id, target_branch_id, name, schedule_kind, schedule_value,
+        payload_json, created_at, updated_at
+      )
+      VALUES (
+        'cron_1', 'agent_1', 'conv_1', 'branch_1', '日报汇总', 'cron', '0 9 * * *',
+        '{}', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z'
+      );
+
+      INSERT INTO task_runs (
+        id, run_type, owner_agent_id, conversation_id, branch_id, cron_job_id, execution_session_id,
+        status, priority, attempt, description, started_at
+      )
+      VALUES (
+        'task_1', 'cron', 'agent_1', 'conv_1', 'branch_1', 'cron_1', 'sess_task',
+        'running', 0, 1, '日报汇总执行', '2026-03-28T00:00:00.000Z'
+      );
+    `);
+
+    new ChannelSurfacesRepo(handle.storage.db).upsert({
+      id: "surface_1",
+      channelType: "lark",
+      channelInstallationId: "default",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      surfaceKey: "chat:oc_chat_1",
+      surfaceObjectJson: JSON.stringify({ chat_id: "oc_chat_1" }),
+    });
+
+    const createCard = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { card_id: "card_task_status_poisoned" } })
+      .mockResolvedValueOnce({ data: { card_id: "card_task_status_retry" } })
+      .mockResolvedValueOnce({ data: { card_id: "card_task_transcript" } });
+    const createMessage = vi.fn(async (input: unknown) => {
+      const cardId = readLarkInteractiveCardId(input);
+      if (cardId === "card_task_status_poisoned") {
+        throw makeLarkHttpError(500, {
+          code: 2200,
+          msg: "Internal Error",
+        });
+      }
+      if (cardId === "card_task_status_retry") {
+        throw makeLarkHttpError(400, {
+          code: 230099,
+          msg: "Failed to create card content, ext=ErrCode: 200780; ErrMsg: card binding biz count over limit; ",
+        });
+      }
+      return {
+        data: {
+          message_id: `om_${cardId ?? "unknown"}`,
+          open_message_id: `oom_${cardId ?? "unknown"}`,
+        },
+      };
+    });
+    const updateCard = vi.fn(async () => ({}));
+    const bus = new RuntimeEventBus<OrchestratedOutboundEventEnvelope>();
+    const runtime = createLarkOutboundRuntime({
+      storage: handle.storage.db,
+      outboundEventBus: bus,
+      clients: {
+        getOrCreate: () =>
+          ({
+            sdk: {
+              cardkit: {
+                v1: {
+                  card: { create: createCard, update: updateCard },
+                  cardElement: { content: vi.fn(async () => ({})) },
+                },
+              },
+              im: {
+                message: {
+                  create: createMessage,
+                  reply: vi.fn(async () => ({})),
+                },
+              },
+            },
+          }) as never,
+      },
+    });
+
+    runtime.start();
+
+    bus.publish(
+      makeTaskEnvelope({
+        type: "task_run_started",
+        taskRunId: "task_1",
+        runType: "cron",
+        status: "running",
+        startedAt: "2026-03-28T00:00:00.000Z",
+        initiatorSessionId: null,
+        parentRunId: null,
+        cronJobId: "cron_1",
+        executionSessionId: "sess_task",
+      }),
+    );
+
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(250);
+
+    bus.publish(
+      makeTaskRuntimeEnvelope({
+        type: "assistant_message_started",
+        eventId: "evt_task_msg_1",
+        createdAt: "2026-03-28T00:00:01.000Z",
+        sessionId: "sess_task",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_task_1",
+        turn: 1,
+        messageId: "msg_task_1",
+      }),
+    );
+    bus.publish(
+      makeTaskRuntimeEnvelope({
+        type: "assistant_message_delta",
+        eventId: "evt_task_msg_2",
+        createdAt: "2026-03-28T00:00:01.100Z",
+        sessionId: "sess_task",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_task_1",
+        turn: 1,
+        messageId: "msg_task_1",
+        delta: "hello",
+        accumulatedText: "hello",
+      }),
+    );
+
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    const sentCardIds = createMessage.mock.calls.map((call) =>
+      readLarkInteractiveCardId(call.at(0)),
+    );
+    expect(createMessage).toHaveBeenCalledTimes(3);
+    expect(sentCardIds.filter((cardId) => cardId === "card_task_status_poisoned")).toHaveLength(1);
+    expect(sentCardIds).toContain("card_task_status_retry");
+    expect(sentCardIds).toContain("card_task_transcript");
+
+    const taskStatusBinding = new LarkObjectBindingsRepo(handle.storage.db).getByInternalObject({
+      channelInstallationId: "default",
+      internalObjectKind: "run_card",
+      internalObjectId: "task:task_1",
+    });
+    expect(taskStatusBinding).toMatchObject({
+      larkCardId: "card_task_status_retry",
+      larkMessageId: null,
+      status: "stale",
+    });
+    expect(JSON.parse(taskStatusBinding?.metadataJson ?? "{}")).toMatchObject({
+      cardReferenceSendFailure: {
+        attempts: 2,
+        lastFailureKind: "card_binding_biz_count_over_limit",
+        httpStatus: 400,
+        upstreamCode: 230099,
+      },
+    });
+
+    const transcriptBinding = new LarkObjectBindingsRepo(handle.storage.db).getByInternalObject({
+      channelInstallationId: "default",
+      internalObjectKind: "run_card",
+      internalObjectId: "run_task_1:seg:1",
+    });
+    expect(transcriptBinding).toMatchObject({
+      larkCardId: "card_task_transcript",
+      larkMessageId: "om_card_task_transcript",
+    });
 
     await runtime.shutdown();
   });

--- a/tests/channels/lark/outbound.test.ts
+++ b/tests/channels/lark/outbound.test.ts
@@ -2309,6 +2309,148 @@ describe("lark outbound runtime", () => {
     await runtime.shutdown();
   });
 
+  test("recovers task status card delivery when fresh retry succeeds after ambiguous send failure", async () => {
+    vi.useFakeTimers();
+    handle = await createTestDatabase(import.meta.url);
+    handle.storage.sqlite.exec(`
+      INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+      VALUES ('ci_lark_default', 'lark', 'default', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+      VALUES ('conv_1', 'ci_lark_default', 'oc_chat_1', 'dm', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+      VALUES ('branch_1', 'conv_1', 'dm_main', 'main', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO agents (id, conversation_id, main_agent_id, kind, created_at)
+      VALUES ('agent_1', 'conv_1', NULL, 'main', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO sessions (id, conversation_id, branch_id, owner_agent_id, purpose, status, created_at, updated_at)
+      VALUES ('sess_task', 'conv_1', 'branch_1', 'agent_1', 'task', 'active', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO cron_jobs (
+        id, owner_agent_id, target_conversation_id, target_branch_id, name, schedule_kind, schedule_value,
+        payload_json, created_at, updated_at
+      )
+      VALUES (
+        'cron_1', 'agent_1', 'conv_1', 'branch_1', '日报汇总', 'cron', '0 9 * * *',
+        '{}', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z'
+      );
+
+      INSERT INTO task_runs (
+        id, run_type, owner_agent_id, conversation_id, branch_id, cron_job_id, execution_session_id,
+        status, priority, attempt, description, started_at
+      )
+      VALUES (
+        'task_1', 'cron', 'agent_1', 'conv_1', 'branch_1', 'cron_1', 'sess_task',
+        'running', 0, 1, '日报汇总执行', '2026-03-28T00:00:00.000Z'
+      );
+    `);
+
+    new ChannelSurfacesRepo(handle.storage.db).upsert({
+      id: "surface_1",
+      channelType: "lark",
+      channelInstallationId: "default",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      surfaceKey: "chat:oc_chat_1",
+      surfaceObjectJson: JSON.stringify({ chat_id: "oc_chat_1" }),
+    });
+
+    const createCard = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { card_id: "card_task_status_poisoned" } })
+      .mockResolvedValueOnce({ data: { card_id: "card_task_status_retry" } });
+    const createMessage = vi.fn(async (input: unknown) => {
+      const cardId = readLarkInteractiveCardId(input);
+      if (cardId === "card_task_status_poisoned") {
+        throw makeLarkHttpError(500, {
+          code: 2200,
+          msg: "Internal Error",
+        });
+      }
+      return {
+        data: {
+          message_id: "om_task_status_retry",
+          open_message_id: "oom_task_status_retry",
+        },
+      };
+    });
+    const updateCard = vi.fn(async () => ({}));
+    const bus = new RuntimeEventBus<OrchestratedOutboundEventEnvelope>();
+    const runtime = createLarkOutboundRuntime({
+      storage: handle.storage.db,
+      outboundEventBus: bus,
+      clients: {
+        getOrCreate: () =>
+          ({
+            sdk: {
+              cardkit: {
+                v1: {
+                  card: { create: createCard, update: updateCard },
+                  cardElement: { content: vi.fn(async () => ({})) },
+                },
+              },
+              im: {
+                message: {
+                  create: createMessage,
+                  reply: vi.fn(async () => ({})),
+                },
+              },
+            },
+          }) as never,
+      },
+    });
+
+    runtime.start();
+
+    bus.publish(
+      makeTaskEnvelope({
+        type: "task_run_started",
+        taskRunId: "task_1",
+        runType: "cron",
+        status: "running",
+        startedAt: "2026-03-28T00:00:00.000Z",
+        initiatorSessionId: null,
+        parentRunId: null,
+        cronJobId: "cron_1",
+        executionSessionId: "sess_task",
+      }),
+    );
+
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    expect(createCard).toHaveBeenCalledTimes(2);
+    expect(createMessage).toHaveBeenCalledTimes(2);
+    expect(createMessage.mock.calls.map((call) => readLarkInteractiveCardId(call.at(0)))).toEqual([
+      "card_task_status_poisoned",
+      "card_task_status_retry",
+    ]);
+
+    const taskStatusBinding = new LarkObjectBindingsRepo(handle.storage.db).getByInternalObject({
+      channelInstallationId: "default",
+      internalObjectKind: "run_card",
+      internalObjectId: "task:task_1",
+    });
+    expect(taskStatusBinding).toMatchObject({
+      larkCardId: "card_task_status_retry",
+      larkMessageId: "om_task_status_retry",
+      larkOpenMessageId: "oom_task_status_retry",
+      status: "active",
+    });
+    expect(JSON.parse(taskStatusBinding?.metadataJson ?? "{}")).toMatchObject({
+      cardReferenceSendFailure: {
+        attempts: 1,
+        lastFailureKind: "ambiguous_transport_failure",
+        httpStatus: 500,
+        upstreamCode: 2200,
+      },
+    });
+
+    await runtime.shutdown();
+  });
+
   test("does not render approval-session runtime transcript into the visible lark chat", async () => {
     vi.useFakeTimers();
     handle = await createTestDatabase(import.meta.url);


### PR DESCRIPTION
## Summary
- stop reusing a CardKit card_id after an ambiguous interactive message send failure
- retry once with a fresh card/message UUID, then mark the binding stale with failure metadata on repeated recoverable failures
- let dependent task transcript/approval cards continue when the task status card binding has reached a stale terminal state

## Root Cause
`card.create` could succeed while `im.message.create` returned an ambiguous 5xx. The existing state machine kept `card_id != null && message_id == null && status=active`, so later flushes reused the same card and could loop forever on Lark `400 / 230099 / 200780 card binding biz count over limit`.

## Tests
- `pnpm preflight`
- commit hook also reran `pnpm preflight`

Linear: POK-51