### PR TITLE
Fix LLM first response timeout retry

### DIFF
--- a/src/agent/llm/pi-bridge.ts
+++ b/src/agent/llm/pi-bridge.ts
@@ -50,7 +50,7 @@ const logger = createSubsystemLogger("llm-bridge");
 const LOG_PREVIEW_LIMIT = 160;
 const STREAM_EVENT_LOOP_YIELD_EVERY_EVENTS = 256;
 const DEFAULT_FIRST_RESPONSE_TIMEOUT_MS = 10_000;
-const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 60_000;
+const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 120_000;
 const OPENAI_COMPAT_ROLE_OVERRIDE = {
   supportsDeveloperRole: false,
 } as const;

--- a/src/agent/llm/pi-bridge.ts
+++ b/src/agent/llm/pi-bridge.ts
@@ -9,6 +9,7 @@ import { setImmediate as setImmediatePromise } from "node:timers/promises";
 import {
   type Api,
   type AssistantMessage,
+  type AssistantMessageEvent,
   completeSimple,
   type Model,
   type Tool,
@@ -48,6 +49,8 @@ const DEFAULT_REASONING_LEVEL = "medium";
 const logger = createSubsystemLogger("llm-bridge");
 const LOG_PREVIEW_LIMIT = 160;
 const STREAM_EVENT_LOOP_YIELD_EVERY_EVENTS = 256;
+const DEFAULT_FIRST_RESPONSE_TIMEOUT_MS = 10_000;
+const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 60_000;
 const OPENAI_COMPAT_ROLE_OVERRIDE = {
   supportsDeveloperRole: false,
 } as const;
@@ -89,8 +92,16 @@ export interface ProviderApiKeyResolver {
   resolveApiKey(provider: ResolvedProvider): Promise<string | undefined>;
 }
 
+export interface PiBridgeOptions {
+  firstResponseTimeoutMs?: number;
+  streamIdleTimeoutMs?: number;
+}
+
 export class PiBridge {
-  constructor(private readonly providerApiKeyResolver?: ProviderApiKeyResolver) {}
+  constructor(
+    private readonly providerApiKeyResolver?: ProviderApiKeyResolver,
+    private readonly options: PiBridgeOptions = {},
+  ) {}
 
   async streamTurn(input: PiBridgeRunTurnInput): Promise<PiBridgeRunTurnResult> {
     // The bridge is intentionally thin: it translates our stored/session state
@@ -124,18 +135,43 @@ export class PiBridge {
       supportsVision: input.model.supportsVision,
     });
 
+    let watchdog: LlmStreamWatchdog | null = null;
+    let streamIterator: AsyncIterator<AssistantMessageEvent> | null = null;
     try {
-      const stream = streamWithNormalizedUpstreamUsage(
-        model,
-        context,
-        await buildPiStreamOptions(this.providerApiKeyResolver, input.model, input.signal, {
+      throwIfSignalAborted(input.signal, input.model);
+      const streamOptions = await buildPiStreamOptions(
+        this.providerApiKeyResolver,
+        input.model,
+        input.signal,
+        {
           enableReasoning: true,
-        }),
+        },
       );
+      throwIfSignalAborted(input.signal, input.model);
+      watchdog = new LlmStreamWatchdog({
+        parentSignal: input.signal,
+        model: input.model,
+        firstResponseTimeoutMs:
+          this.options.firstResponseTimeoutMs ?? DEFAULT_FIRST_RESPONSE_TIMEOUT_MS,
+        streamIdleTimeoutMs: this.options.streamIdleTimeoutMs ?? DEFAULT_STREAM_IDLE_TIMEOUT_MS,
+      });
+      const stream = streamWithNormalizedUpstreamUsage(model, context, {
+        ...streamOptions,
+        signal: watchdog.signal,
+      });
       let accumulatedText = "";
       let streamEventCount = 0;
-      for await (const event of stream) {
+      streamIterator = stream[Symbol.asyncIterator]();
+      while (true) {
+        const next = await watchdog.race(streamIterator.next());
+        if (next.done === true) {
+          break;
+        }
+        const event = next.value;
         streamEventCount += 1;
+        if (isSemanticModelStreamEvent(event)) {
+          watchdog.markSemanticEvent(event.type);
+        }
         switch (event.type) {
           case "text_delta":
             accumulatedText += event.delta;
@@ -158,7 +194,7 @@ export class PiBridge {
         }
       }
 
-      const finalMessage = await stream.result();
+      const finalMessage = await watchdog.race(stream.result());
       const contentSummary = summarizeAssistantContent(finalMessage.content);
       logger.debug("streaming llm turn finished", {
         modelId: input.model.id,
@@ -168,13 +204,19 @@ export class PiBridge {
       });
       return normalizeAssistantResult(finalMessage, "stream");
     } catch (error) {
-      const enrichedError = enrichCodexFetchFailure(error, input.model, "request");
+      if (streamIterator?.return != null) {
+        void streamIterator.return().catch(() => undefined);
+      }
+      const enrichedError =
+        watchdog?.failure ?? enrichCodexFetchFailure(error, input.model, "request");
       logRawLlmFailure("stream", input.model, enrichedError);
       throw normalizeAgentLlmError({
         error: enrichedError,
         provider: input.model.provider.id,
         model: input.model.id,
       });
+    } finally {
+      watchdog?.dispose();
     }
   }
 
@@ -318,6 +360,192 @@ export class PiAgentModelRunner implements AgentModelRunner, CompactionModelRunn
 
   runCompaction(input: CompactionModelRunnerInput): Promise<CompactionModelRunnerResult> {
     return this.bridge.completeText(input);
+  }
+}
+
+type LlmStreamWatchdogTimeoutKind = "first_response" | "stream_idle";
+
+class LlmStreamWatchdog {
+  readonly controller = new AbortController();
+  failure: AgentLlmError | null = null;
+
+  private readonly timeoutPromise: Promise<never>;
+  private rejectTimeoutPromise!: (error: AgentLlmError) => void;
+  private timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+  private sawSemanticEvent = false;
+
+  constructor(
+    private readonly input: {
+      parentSignal: AbortSignal;
+      model: ResolvedModel;
+      firstResponseTimeoutMs: number;
+      streamIdleTimeoutMs: number;
+    },
+  ) {
+    this.timeoutPromise = new Promise<never>((_resolve, reject) => {
+      this.rejectTimeoutPromise = reject;
+    });
+
+    if (input.parentSignal.aborted) {
+      this.failWithAbort();
+      return;
+    }
+
+    input.parentSignal.addEventListener("abort", this.handleParentAbort, { once: true });
+    this.scheduleTimeout("first_response", input.firstResponseTimeoutMs);
+  }
+
+  get signal(): AbortSignal {
+    return this.controller.signal;
+  }
+
+  race<T>(operation: Promise<T>): Promise<T> {
+    if (this.failure != null) {
+      return Promise.reject(this.failure);
+    }
+
+    return Promise.race([operation, this.timeoutPromise]);
+  }
+
+  markSemanticEvent(eventType: AssistantMessageEvent["type"]): void {
+    if (this.disposed || this.failure != null) {
+      return;
+    }
+
+    if (!this.sawSemanticEvent) {
+      this.sawSemanticEvent = true;
+      logger.debug("llm first semantic stream event received", {
+        modelId: this.input.model.id,
+        provider: this.input.model.provider.id,
+        eventType,
+      });
+    }
+
+    this.scheduleTimeout("stream_idle", this.input.streamIdleTimeoutMs);
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.clearTimeout();
+    this.input.parentSignal.removeEventListener("abort", this.handleParentAbort);
+  }
+
+  private readonly handleParentAbort = (): void => {
+    this.failWithAbort();
+  };
+
+  private failWithAbort(): void {
+    if (this.disposed || this.failure != null) {
+      return;
+    }
+
+    this.clearTimeout();
+    this.failure = new AgentLlmError({
+      kind: "aborted",
+      message: "Request was aborted",
+      retryable: false,
+      provider: this.input.model.provider.id,
+      model: this.input.model.id,
+      rawMessage: "Request was aborted",
+    });
+    this.controller.abort(this.input.parentSignal.reason);
+    this.rejectTimeoutPromise(this.failure);
+  }
+
+  private scheduleTimeout(kind: LlmStreamWatchdogTimeoutKind, timeoutMs: number): void {
+    this.clearTimeout();
+    if (timeoutMs <= 0 || this.disposed || this.failure != null) {
+      return;
+    }
+
+    this.timeoutHandle = setTimeout(() => {
+      this.failWithTimeout(kind, timeoutMs);
+    }, timeoutMs);
+    unrefTimer(this.timeoutHandle);
+  }
+
+  private failWithTimeout(kind: LlmStreamWatchdogTimeoutKind, timeoutMs: number): void {
+    if (this.disposed || this.failure != null) {
+      return;
+    }
+
+    if (this.input.parentSignal.aborted) {
+      this.failWithAbort();
+      return;
+    }
+
+    this.clearTimeout();
+    const message =
+      kind === "first_response"
+        ? `LLM first response timed out after ${timeoutMs}ms`
+        : `LLM stream idle timed out after ${timeoutMs}ms`;
+    this.failure = new AgentLlmError({
+      kind: "timeout",
+      message,
+      retryable: true,
+      provider: this.input.model.provider.id,
+      model: this.input.model.id,
+      rawMessage: message,
+    });
+    logger.warn("aborting llm request after stream watchdog timeout", {
+      modelId: this.input.model.id,
+      provider: this.input.model.provider.id,
+      timeoutKind: kind,
+      timeoutMs,
+      sawSemanticEvent: this.sawSemanticEvent,
+    });
+    this.rejectTimeoutPromise(this.failure);
+    this.controller.abort(this.failure);
+  }
+
+  private clearTimeout(): void {
+    if (this.timeoutHandle == null) {
+      return;
+    }
+
+    clearTimeout(this.timeoutHandle);
+    this.timeoutHandle = null;
+  }
+}
+
+function throwIfSignalAborted(signal: AbortSignal, model: ResolvedModel): void {
+  if (!signal.aborted) {
+    return;
+  }
+
+  throw new AgentLlmError({
+    kind: "aborted",
+    message: "Request was aborted",
+    retryable: false,
+    provider: model.provider.id,
+    model: model.id,
+    rawMessage: "Request was aborted",
+  });
+}
+
+function isSemanticModelStreamEvent(event: AssistantMessageEvent): boolean {
+  switch (event.type) {
+    case "text_start":
+    case "text_delta":
+    case "text_end":
+    case "thinking_start":
+    case "thinking_delta":
+    case "thinking_end":
+    case "toolcall_start":
+    case "toolcall_delta":
+    case "toolcall_end":
+      return true;
+    case "start":
+    case "done":
+    case "error":
+      return false;
+  }
+}
+
+function unrefTimer(timer: ReturnType<typeof setTimeout>): void {
+  if (typeof timer === "object" && timer !== null && "unref" in timer) {
+    (timer as { unref: () => void }).unref();
   }
 }
 

--- a/tests/agent/llm/pi-bridge.test.ts
+++ b/tests/agent/llm/pi-bridge.test.ts
@@ -109,6 +109,72 @@ function createAssistantEventStream(events: AssistantMessageEvent[], result: Ass
   };
 }
 
+function createNeverYieldingAssistantEventStream(result: AssistantMessage) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      await new Promise<never>(() => undefined);
+    },
+    async result() {
+      return result;
+    },
+  };
+}
+
+function createAssistantEventStreamThenHang(
+  events: AssistantMessageEvent[],
+  result: AssistantMessage,
+) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const event of events) {
+        yield event;
+      }
+      await new Promise<never>(() => undefined);
+    },
+    async result() {
+      return result;
+    },
+  };
+}
+
+function createTextAssistantMessage(text = "ok"): AssistantMessage {
+  return {
+    role: "assistant" as const,
+    api: "anthropic-messages" as const,
+    provider: "anthropic_main",
+    model: "claude-sonnet-4-5-20250929",
+    stopReason: "stop" as const,
+    content: [{ type: "text" as const, text }],
+    usage: {
+      input: 1,
+      output: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 2,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+    },
+    timestamp: Date.now(),
+  };
+}
+
+async function waitForPromiseResult<T>(
+  promise: Promise<T>,
+  timeoutMs = 200,
+): Promise<T | "still-pending"> {
+  return Promise.race([
+    promise,
+    new Promise<"still-pending">((resolve) => {
+      setTimeout(() => resolve("still-pending"), timeoutMs);
+    }),
+  ]);
+}
+
 describe("pi bridge", () => {
   beforeEach(() => {
     upstreamStreamMock.mockImplementation((model, context, options) =>
@@ -253,6 +319,123 @@ describe("pi bridge", () => {
     expect(options.apiKey).toBe("secret");
     expect(options.sessionId).toBe("anthropic_main/claude-sonnet-4-5");
     expect(options.reasoning).toBe("medium");
+  });
+
+  test("aborts and raises retryable timeout when no first model event arrives", async () => {
+    const finalMessage = createTextAssistantMessage();
+    let requestSignal: AbortSignal | undefined;
+    streamSimpleMock.mockImplementation((_model, _context, options) => {
+      requestSignal = options.signal;
+      return createNeverYieldingAssistantEventStream(finalMessage);
+    });
+
+    const bridge = new PiBridge(undefined, {
+      firstResponseTimeoutMs: 10,
+      streamIdleTimeoutMs: 0,
+    });
+    const resultPromise = bridge
+      .streamTurn({
+        model: createResolvedModel(),
+        compactSummary: null,
+        messages: [createStoredUserMessage()],
+        tools: new ToolRegistry(),
+        signal: new AbortController().signal,
+      })
+      .catch((caught) => caught);
+
+    const result = await waitForPromiseResult(resultPromise);
+
+    expect(result).toBeInstanceOf(AgentLlmError);
+    expect(result).toMatchObject({
+      kind: "timeout",
+      retryable: true,
+      provider: "anthropic_main",
+      model: "anthropic_main/claude-sonnet-4-5",
+    });
+    expect(result).toHaveProperty("message", "LLM first response timed out after 10ms");
+    expect(requestSignal?.aborted).toBe(true);
+  });
+
+  test("does not classify parent cancellation as a first-response timeout", async () => {
+    const finalMessage = createTextAssistantMessage();
+    let requestSignal: AbortSignal | undefined;
+    streamSimpleMock.mockImplementation((_model, _context, options) => {
+      requestSignal = options.signal;
+      return createNeverYieldingAssistantEventStream(finalMessage);
+    });
+
+    const parentController = new AbortController();
+    const bridge = new PiBridge(undefined, {
+      firstResponseTimeoutMs: 100,
+      streamIdleTimeoutMs: 0,
+    });
+    const resultPromise = bridge
+      .streamTurn({
+        model: createResolvedModel(),
+        compactSummary: null,
+        messages: [createStoredUserMessage()],
+        tools: new ToolRegistry(),
+        signal: parentController.signal,
+      })
+      .catch((caught) => caught);
+
+    setTimeout(() => parentController.abort(), 10);
+    const result = await waitForPromiseResult(resultPromise);
+
+    expect(result).toBeInstanceOf(AgentLlmError);
+    expect(result).toMatchObject({
+      kind: "aborted",
+      retryable: false,
+    });
+    expect(requestSignal?.aborted).toBe(true);
+  });
+
+  test("raises stream idle timeout after visible output without masking the streamed delta", async () => {
+    const finalMessage = createTextAssistantMessage("partial answer");
+    let requestSignal: AbortSignal | undefined;
+    streamSimpleMock.mockImplementation((_model, _context, options) => {
+      requestSignal = options.signal;
+      return createAssistantEventStreamThenHang(
+        [
+          {
+            type: "text_delta",
+            contentIndex: 0,
+            delta: "partial answer",
+            partial: finalMessage,
+          },
+        ],
+        finalMessage,
+      );
+    });
+
+    const deltas: Array<{ delta: string; accumulatedText: string }> = [];
+    const bridge = new PiBridge(undefined, {
+      firstResponseTimeoutMs: 100,
+      streamIdleTimeoutMs: 10,
+    });
+    const resultPromise = bridge
+      .streamTurn({
+        model: createResolvedModel(),
+        compactSummary: null,
+        messages: [createStoredUserMessage()],
+        tools: new ToolRegistry(),
+        signal: new AbortController().signal,
+        onTextDelta(event) {
+          deltas.push(event);
+        },
+      })
+      .catch((caught) => caught);
+
+    const result = await waitForPromiseResult(resultPromise);
+
+    expect(deltas).toEqual([{ delta: "partial answer", accumulatedText: "partial answer" }]);
+    expect(result).toBeInstanceOf(AgentLlmError);
+    expect(result).toMatchObject({
+      kind: "timeout",
+      retryable: true,
+    });
+    expect(result).toHaveProperty("message", "LLM stream idle timed out after 10ms");
+    expect(requestSignal?.aborted).toBe(true);
   });
 
   test("passes configured max output tokens into stream options", async () => {

--- a/tests/agent/loop.test.ts
+++ b/tests/agent/loop.test.ts
@@ -4176,6 +4176,106 @@ describe("agent loop", () => {
     });
   });
 
+  test("retries a first-response timeout after a completed tool call", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    seedConversationFixture(handle);
+
+    const sessionsRepo = new SessionsRepo(handle.storage.db);
+    const messagesRepo = new MessagesRepo(handle.storage.db);
+    sessionsRepo.create({
+      id: "sess_1",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      purpose: "chat",
+      createdAt: new Date("2026-03-22T00:00:00.000Z"),
+    });
+    messagesRepo.append({
+      id: "msg_user",
+      sessionId: "sess_1",
+      seq: 1,
+      role: "user",
+      payloadJson: '{"content":"run quick tool, then continue"}',
+      createdAt: new Date("2026-03-22T00:00:01.000Z"),
+    });
+
+    let runTurnCount = 0;
+    const runner: AgentModelRunner = {
+      async runTurn(input) {
+        runTurnCount += 1;
+        if (runTurnCount === 1) {
+          return makeAssistantResult({
+            stopReason: "toolUse",
+            content: [
+              {
+                type: "toolCall",
+                id: "tool_1",
+                name: "quick_check",
+                arguments: {},
+              },
+            ],
+          });
+        }
+
+        const toolMessages = input.messages.filter((message) => message.role === "tool");
+        expect(toolMessages).toHaveLength(1);
+        expect(toolMessages[0]?.payloadJson ?? "").toContain("tool ok");
+
+        if (runTurnCount === 2) {
+          throw new AgentLlmError({
+            kind: "timeout",
+            message: "LLM first response timed out after 10ms",
+            retryable: true,
+            provider: "anthropic_main",
+            model: "anthropic_main/claude-sonnet-4-5",
+          });
+        }
+
+        return makeAssistantResult({
+          content: [{ type: "text", text: "recovered after tool" }],
+        });
+      },
+    };
+
+    const tools = new ToolRegistry([
+      defineTool({
+        name: "quick_check",
+        description: "Returns quickly",
+        inputSchema: NO_ARGS_TOOL_SCHEMA,
+        execute() {
+          return textToolResult("tool ok");
+        },
+      }),
+    ]);
+    const loop = new AgentLoop({
+      sessions: new AgentSessionService(sessionsRepo, messagesRepo),
+      messages: messagesRepo,
+      models: new ProviderRegistry(createModelConfig()),
+      tools,
+      cancel: new SessionRunAbortRegistry(),
+      modelRunner: runner,
+      storage: handle.storage.db,
+      securityConfig: DEFAULT_CONFIG.security,
+      compaction: DEFAULT_CONFIG.compaction,
+    });
+
+    const result = await loop.run({ sessionId: "sess_1", scenario: "chat" });
+
+    expect(runTurnCount).toBe(3);
+    expect(result.events.some((event) => event.type === "run_failed")).toBe(false);
+    expect(
+      result.events.filter((event) => event.type === "assistant_message_started"),
+    ).toHaveLength(3);
+
+    const rows = messagesRepo.listBySession("sess_1");
+    expect(rows).toHaveLength(4);
+    expect(rows[2]?.role).toBe("tool");
+    expect(rows[2]?.payloadJson ?? "").toContain("tool ok");
+    expect(rows[3]?.role).toBe("assistant");
+    expect(JSON.parse(rows[3]?.payloadJson ?? "{}")).toEqual({
+      content: [{ type: "text", text: "recovered after tool" }],
+    });
+  });
+
   test("retries a successful empty assistant output once when nothing visible was streamed", async () => {
     handle = await createTestDatabase(import.meta.url);
     seedConversationFixture(handle);


### PR DESCRIPTION
## Summary
- add a per-attempt LLM stream watchdog with a 10s first-response timeout and a 60s idle timeout
- abort only the current provider request via a child AbortController while preserving parent/user cancel semantics
- surface first-response timeouts as retryable AgentLlmError so AgentLoop can retry before visible output
- cover the post-tool first-response timeout case seen in production

Fixes POK-52

## Verification
- pnpm preflight
- commit hook preflight