### PR TITLE
Add Codex fast service tier config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -175,6 +175,28 @@ Matching `secrets.toml`:
 appSecret = "paste-your-feishu-or-lark-app-secret-here"
 ```
 
+To create a fast-tier Codex model instance, add a separate catalog entry that points at the
+same upstream model and sets `serviceTier = "fast"`:
+
+```toml
+[[models.catalog]]
+id = "codex-gpt5.5-fast"
+provider = "openai_codex"
+upstreamId = "gpt-5.5"
+contextWindow = 400000
+maxOutputTokens = 16384
+supportsTools = true
+supportsVision = true
+serviceTier = "fast"
+[models.catalog.reasoning]
+enabled = true
+effort = "high"
+```
+
+`serviceTier = "fast"` is sent to the native Codex/OpenAI Responses request as
+`service_tier = "priority"`. It is a model-instance setting, like
+`reasoning.effort`, so scenarios can choose the normal or fast entry explicitly.
+
 ### Template B: OpenRouter via environment variable
 
 Replace `upstreamId` with the OpenRouter model the user actually wants. The structure stays the same.

--- a/src/agent/llm/models.ts
+++ b/src/agent/llm/models.ts
@@ -8,6 +8,7 @@ import type {
   ModelPricingConfig,
   ModelReasoningConfig,
   ModelScenarioConfig,
+  ModelServiceTier,
   ProviderConfig,
 } from "@/src/config/schema.js";
 
@@ -41,6 +42,7 @@ export interface ResolvedModel {
   maxOutputTokens: number;
   supportsTools: boolean;
   supportsVision: boolean;
+  serviceTier?: ModelServiceTier;
   reasoning?: ModelReasoningConfig;
   pricing?: ModelPricingConfig;
   provider: ResolvedProvider;

--- a/src/agent/llm/pi-bridge.ts
+++ b/src/agent/llm/pi-bridge.ts
@@ -54,6 +54,9 @@ const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 120_000;
 const OPENAI_COMPAT_ROLE_OVERRIDE = {
   supportsDeveloperRole: false,
 } as const;
+const OPENAI_SERVICE_TIER_HOSTS = new Set(["api.openai.com", "chatgpt.com"]);
+
+type RequestServiceTier = "auto" | "default" | "flex" | "scale" | "priority";
 
 export interface PiBridgeTextDelta {
   delta: string;
@@ -620,6 +623,11 @@ async function buildPiStreamOptions(
     maxTokens: number;
     apiKey?: string;
     reasoning?: "minimal" | "low" | "medium" | "high" | "xhigh";
+    serviceTier?: RequestServiceTier;
+    onPayload?: (
+      payload: unknown,
+      model: Model<Api>,
+    ) => unknown | undefined | Promise<unknown | undefined>;
   } = {
     signal,
     sessionId: model.id,
@@ -645,7 +653,58 @@ async function buildPiStreamOptions(
     options.reasoning = model.reasoning.effort ?? DEFAULT_REASONING_LEVEL;
   }
 
+  const serviceTier = resolveRequestServiceTier(model.serviceTier);
+  if (serviceTier != null && shouldApplyOpenAIServiceTier(model)) {
+    options.serviceTier = serviceTier;
+    options.onPayload = createServiceTierPayloadPatch(serviceTier);
+  }
+
   return options;
+}
+
+function resolveRequestServiceTier(
+  serviceTier: ResolvedModel["serviceTier"],
+): RequestServiceTier | undefined {
+  if (serviceTier == null) {
+    return undefined;
+  }
+  return serviceTier === "fast" ? "priority" : serviceTier;
+}
+
+function createServiceTierPayloadPatch(serviceTier: RequestServiceTier) {
+  return (payload: unknown): unknown | undefined => {
+    if (!isPlainObjectRecord(payload) || payload.service_tier !== undefined) {
+      return undefined;
+    }
+    payload.service_tier = serviceTier;
+    return undefined;
+  };
+}
+
+function isPlainObjectRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function shouldApplyOpenAIServiceTier(model: ResolvedModel): boolean {
+  const api = resolvePiApi(model);
+  if (api !== "openai-responses" && api !== "openai-codex-responses") {
+    return false;
+  }
+
+  const host = resolveServiceTierBaseUrlHost(model);
+  if (host == null || !OPENAI_SERVICE_TIER_HOSTS.has(host)) {
+    return false;
+  }
+
+  return api === "openai-responses" ? host === "api.openai.com" : host === "chatgpt.com";
+}
+
+function resolveServiceTierBaseUrlHost(model: ResolvedModel): string | null {
+  try {
+    return new URL(resolvePiBaseUrl(model)).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
 }
 
 function toPiModel(model: ResolvedModel): Model<Api> {

--- a/src/agent/llm/pi-bridge.ts
+++ b/src/agent/llm/pi-bridge.ts
@@ -54,7 +54,6 @@ const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 120_000;
 const OPENAI_COMPAT_ROLE_OVERRIDE = {
   supportsDeveloperRole: false,
 } as const;
-const OPENAI_SERVICE_TIER_HOSTS = new Set(["api.openai.com", "chatgpt.com"]);
 
 type RequestServiceTier = "auto" | "default" | "flex" | "scale" | "priority";
 
@@ -672,6 +671,8 @@ function resolveRequestServiceTier(
 }
 
 function createServiceTierPayloadPatch(serviceTier: RequestServiceTier) {
+  // pi-ai calls `onPayload` with the live request payload before JSON serialization.
+  // Mutating in place is intentional here and covered by the final-fetch bridge tests.
   return (payload: unknown): unknown | undefined => {
     if (!isPlainObjectRecord(payload) || payload.service_tier !== undefined) {
       return undefined;
@@ -687,16 +688,14 @@ function isPlainObjectRecord(value: unknown): value is Record<string, unknown> {
 
 function shouldApplyOpenAIServiceTier(model: ResolvedModel): boolean {
   const api = resolvePiApi(model);
-  if (api !== "openai-responses" && api !== "openai-codex-responses") {
-    return false;
-  }
-
   const host = resolveServiceTierBaseUrlHost(model);
-  if (host == null || !OPENAI_SERVICE_TIER_HOSTS.has(host)) {
-    return false;
+  if (api === "openai-responses") {
+    return host === "api.openai.com";
   }
-
-  return api === "openai-responses" ? host === "api.openai.com" : host === "chatgpt.com";
+  if (api === "openai-codex-responses") {
+    return host === "chatgpt.com";
+  }
+  return false;
 }
 
 function resolveServiceTierBaseUrlHost(model: ResolvedModel): string | null {

--- a/src/agent/llm/provider-registry.ts
+++ b/src/agent/llm/provider-registry.ts
@@ -122,6 +122,10 @@ export class ProviderRegistry {
       provider,
     };
 
+    if (entry.serviceTier != null) {
+      resolved.serviceTier = entry.serviceTier;
+    }
+
     if (entry.reasoning != null) {
       resolved.reasoning = { ...entry.reasoning };
     }

--- a/src/channels/lark/render/model-switch-card.ts
+++ b/src/channels/lark/render/model-switch-card.ts
@@ -108,7 +108,7 @@ function buildModelSwitchCardElements(
 function buildOverviewMarkdown(overview: ScenarioModelSwitchOverview): string {
   const modelLines = overview.models.map(
     (model) =>
-      `${model.index}. **${model.modelId}** · provider: \`${model.providerId}\` · upstream: \`${model.upstreamModelId}\` · tools: ${model.supportsTools ? "yes" : "no"} · reasoning: ${model.supportsReasoning ? "yes" : "no"}`,
+      `${model.index}. **${model.modelId}** · provider: \`${model.providerId}\` · upstream: \`${model.upstreamModelId}\` · tools: ${model.supportsTools ? "yes" : "no"} · reasoning: ${model.supportsReasoning ? "yes" : "no"}${model.serviceTier == null ? "" : ` · tier: ${model.serviceTier}`}`,
   );
   const scenarioLines = overview.scenarios.map(
     (scenario) =>
@@ -178,7 +178,7 @@ function buildModelRow(
             content: [
               `**${model.index}. ${model.modelId}**${isCurrent ? " · 当前使用" : ""}`,
               `provider: \`${model.providerId}\` · upstream: \`${model.upstreamModelId}\``,
-              `tools: ${model.supportsTools ? "yes" : "no"} · reasoning: ${model.supportsReasoning ? "yes" : "no"}`,
+              `tools: ${model.supportsTools ? "yes" : "no"} · reasoning: ${model.supportsReasoning ? "yes" : "no"}${model.serviceTier == null ? "" : ` · tier: ${model.serviceTier}`}`,
             ].join("\n"),
           },
         ],

--- a/src/config/scenario-model-switch.ts
+++ b/src/config/scenario-model-switch.ts
@@ -15,6 +15,7 @@ export interface ScenarioModelCatalogSummary {
   supportsTools: boolean;
   supportsVision: boolean;
   supportsReasoning: boolean;
+  serviceTier?: string | null;
 }
 
 export interface ScenarioModelStateSummary {
@@ -136,6 +137,7 @@ function summarizeCatalogModel(
     supportsTools: model.supportsTools,
     supportsVision: model.supportsVision,
     supportsReasoning: model.reasoning?.enabled === true,
+    serviceTier: model.serviceTier ?? null,
   };
 }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -9,6 +9,7 @@ export interface LoggingConfig {
 
 export type ProviderAuthSource = "config" | "codex-local";
 export type ReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh";
+export type ModelServiceTier = "auto" | "default" | "flex" | "scale" | "priority" | "fast";
 
 export interface ProviderConfig {
   api: string;
@@ -37,6 +38,7 @@ export interface ModelCatalogEntry {
   maxOutputTokens: number;
   supportsTools: boolean;
   supportsVision: boolean;
+  serviceTier?: ModelServiceTier;
   reasoning?: ModelReasoningConfig;
   pricing?: ModelPricingConfig;
 }
@@ -231,6 +233,7 @@ interface ModelCatalogEntryInput {
   maxOutputTokens?: unknown;
   supportsTools?: unknown;
   supportsVision?: unknown;
+  serviceTier?: unknown;
   reasoning?: unknown;
   pricing?: unknown;
 }
@@ -378,6 +381,14 @@ const MODEL_SCENARIOS = [
 const LARK_CONNECTION_MODES: readonly LarkConnectionMode[] = ["websocket", "webhook"];
 const PROVIDER_AUTH_SOURCES: readonly ProviderAuthSource[] = ["config", "codex-local"];
 const REASONING_EFFORTS: readonly ReasoningEffort[] = ["minimal", "low", "medium", "high", "xhigh"];
+const MODEL_SERVICE_TIERS: readonly ModelServiceTier[] = [
+  "auto",
+  "default",
+  "flex",
+  "scale",
+  "priority",
+  "fast",
+];
 const MCP_TRANSPORTS: readonly McpTransport[] = ["stdio", "streamable_http"];
 const MCP_TOOL_POLICIES: readonly McpToolPolicy[] = ["auto", "ask", "always_allow"];
 const MCP_SERVER_NAME_PATTERN = /^[A-Za-z0-9_-]+$/;
@@ -688,6 +699,7 @@ function validateModelCatalog(
         "maxOutputTokens",
         "supportsTools",
         "supportsVision",
+        "serviceTier",
         "reasoning",
         "pricing",
       ]),
@@ -734,6 +746,14 @@ function validateModelCatalog(
         `config.toml models.catalog[${index}].supportsVision`,
       ),
     };
+
+    const serviceTier = validateOptionalModelServiceTier(
+      entry.serviceTier,
+      `config.toml models.catalog[${index}].serviceTier`,
+    );
+    if (serviceTier != null) {
+      normalizedEntry.serviceTier = serviceTier;
+    }
 
     const reasoning = validateReasoningConfig(
       entry.reasoning,
@@ -1719,6 +1739,10 @@ function cloneModelCatalogEntry(entry: ModelCatalogEntry): ModelCatalogEntry {
     cloned.reasoning = { ...entry.reasoning };
   }
 
+  if (entry.serviceTier != null) {
+    cloned.serviceTier = entry.serviceTier;
+  }
+
   if (entry.pricing != null) {
     cloned.pricing = { ...entry.pricing };
   }
@@ -1770,6 +1794,19 @@ function validateOptionalReasoningEffort(
     throw new Error(`${path} must be one of: minimal, low, medium, high, xhigh`);
   }
   return value as ReasoningEffort;
+}
+
+function validateOptionalModelServiceTier(
+  value: unknown,
+  path: string,
+): ModelServiceTier | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  if (typeof value !== "string" || !MODEL_SERVICE_TIERS.includes(value as ModelServiceTier)) {
+    throw new Error(`${path} must be one of: auto, default, flex, scale, priority, fast`);
+  }
+  return value as ModelServiceTier;
 }
 
 function validateNonEmptyString(value: unknown, path: string): string {

--- a/src/runtime/status.ts
+++ b/src/runtime/status.ts
@@ -48,6 +48,7 @@ export interface StatusModelSnapshot {
   upstreamModelId: string | null;
   modelApi: string | null;
   supportsReasoning: boolean | null;
+  serviceTier?: string | null;
   source: "latest_assistant" | "agent_default" | "scenario_default" | "unknown";
 }
 
@@ -214,6 +215,9 @@ export function formatConversationStatusText(snapshot: ConversationStatusSnapsho
   if (snapshot.model.supportsReasoning != null) {
     lines.push(`Reasoning: ${snapshot.model.supportsReasoning ? "支持" : "不支持"}`);
   }
+  if (snapshot.model.serviceTier != null) {
+    lines.push(`Service tier: ${snapshot.model.serviceTier}`);
+  }
   lines.push(`运行模式：${formatRuntimeModeLine(snapshot.runtimeMode)}`);
   if (snapshot.mcp != null) {
     lines.push(...formatMcpTextLines(snapshot.mcp));
@@ -314,6 +318,9 @@ export function buildConversationStatusPresentation(
         ...(snapshot.model.supportsReasoning == null
           ? []
           : [`**Reasoning**: ${snapshot.model.supportsReasoning ? "支持" : "不支持"}`]),
+        ...(snapshot.model.serviceTier == null
+          ? []
+          : [`**Service tier**: ${snapshot.model.serviceTier}`]),
         `**运行模式**：${formatRuntimeModeLine(snapshot.runtimeMode)}`,
         ...(snapshot.mcp == null ? [] : formatMcpMarkdownLines(snapshot.mcp)),
       ].join("\n"),
@@ -405,6 +412,7 @@ function resolveStatusModel(input: {
       upstreamModelId: input.latestAssistant.model ?? null,
       modelApi: input.latestAssistant.modelApi ?? null,
       supportsReasoning: latestAssistantModel?.reasoning?.enabled === true,
+      serviceTier: latestAssistantModel?.serviceTier ?? null,
       source: "latest_assistant",
     };
   }
@@ -431,6 +439,7 @@ function resolveStatusModel(input: {
     upstreamModelId: null,
     modelApi: null,
     supportsReasoning: null,
+    serviceTier: null,
     source: "unknown",
   };
 }
@@ -464,6 +473,7 @@ function modelToStatusSnapshot(
     upstreamModelId: model.upstreamId,
     modelApi: model.provider.api,
     supportsReasoning: model.reasoning?.enabled === true,
+    serviceTier: model.serviceTier ?? null,
     source,
   };
 }
@@ -612,6 +622,7 @@ function formatModelLine(model: StatusModelSnapshot): string {
     model.upstreamModelId,
     model.providerId,
     model.modelApi,
+    model.serviceTier == null ? null : `tier:${model.serviceTier}`,
   ].filter((value): value is string => value != null && value.length > 0);
   return parts.length > 0 ? parts.join(" / ") : "未知";
 }

--- a/tests/agent/llm/pi-bridge.codex-service-tier.test.ts
+++ b/tests/agent/llm/pi-bridge.codex-service-tier.test.ts
@@ -114,7 +114,10 @@ describe("pi bridge Codex service tier", () => {
     vi.unstubAllGlobals();
   });
 
-  test("sends configured fast service tier in the final streaming Codex HTTP request body", async () => {
+  test.each([
+    ["fast", "priority"],
+    ["flex", "flex"],
+  ] as const)("sends configured %s service tier as %s in the final streaming Codex HTTP request body", async (configuredTier, requestTier) => {
     const requests: Array<{ url: string; body: unknown }> = [];
     vi.stubGlobal(
       "fetch",
@@ -129,7 +132,7 @@ describe("pi bridge Codex service tier", () => {
 
     const bridge = new PiBridge();
     const result = await bridge.streamTurn({
-      model: createCodexModel({ serviceTier: "fast" }),
+      model: createCodexModel({ serviceTier: configuredTier }),
       systemPrompt: "You are concise.",
       compactSummary: null,
       messages: [createStoredUserMessage()],
@@ -142,7 +145,7 @@ describe("pi bridge Codex service tier", () => {
     expect(requests[0]?.url).toBe("https://chatgpt.com/backend-api/codex/responses");
     expect(requests[0]?.body).toMatchObject({
       model: "gpt-5.5",
-      service_tier: "priority",
+      service_tier: requestTier,
     });
   });
 });

--- a/tests/agent/llm/pi-bridge.codex-service-tier.test.ts
+++ b/tests/agent/llm/pi-bridge.codex-service-tier.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { ResolvedModel } from "@/src/agent/llm/models.js";
+import { PiBridge } from "@/src/agent/llm/pi-bridge.js";
+import type { Message } from "@/src/storage/schema/types.js";
+import { ToolRegistry } from "@/src/tools/core/registry.js";
+
+function createCodexAccessToken(): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url");
+  const payload = Buffer.from(
+    JSON.stringify({
+      "https://api.openai.com/auth": {
+        chatgpt_account_id: "acct_test",
+      },
+    }),
+  ).toString("base64url");
+  return `${header}.${payload}.signature`;
+}
+
+function createCodexModel(overrides?: Partial<ResolvedModel>): ResolvedModel {
+  return {
+    id: "codex-gpt5.5-fast",
+    providerId: "openai_codex",
+    upstreamId: "gpt-5.5",
+    contextWindow: 400_000,
+    maxOutputTokens: 16_384,
+    supportsTools: true,
+    supportsVision: true,
+    reasoning: { enabled: true, effort: "high" },
+    provider: {
+      id: "openai_codex",
+      api: "openai-codex-responses",
+      apiKey: createCodexAccessToken(),
+    },
+    ...overrides,
+  };
+}
+
+function createStoredUserMessage(): Message {
+  return {
+    id: "msg_user",
+    sessionId: "sess_1",
+    seq: 1,
+    role: "user",
+    messageType: "text",
+    visibility: "user_visible",
+    channelMessageId: null,
+    channelParentMessageId: null,
+    channelThreadId: null,
+    provider: null,
+    model: null,
+    modelApi: null,
+    stopReason: null,
+    errorMessage: null,
+    payloadJson: JSON.stringify({ content: "Say ok." }),
+    tokenInput: null,
+    tokenOutput: null,
+    tokenCacheRead: null,
+    tokenCacheWrite: null,
+    tokenTotal: null,
+    usageJson: null,
+    createdAt: "2026-03-22T00:00:01.000Z",
+  };
+}
+
+function createSseResponse(): Response {
+  const messageItem = {
+    type: "message",
+    id: "msg_test",
+    role: "assistant",
+    status: "completed",
+    content: [{ type: "output_text", text: "ok", annotations: [] }],
+  };
+  const events = [
+    {
+      type: "response.output_item.added",
+      item: { ...messageItem, content: [] },
+    },
+    {
+      type: "response.content_part.added",
+      part: { type: "output_text", text: "", annotations: [] },
+    },
+    {
+      type: "response.output_text.delta",
+      delta: "ok",
+    },
+    {
+      type: "response.output_item.done",
+      item: messageItem,
+    },
+    {
+      type: "response.completed",
+      response: {
+        id: "resp_test",
+        status: "completed",
+        usage: {
+          input_tokens: 1,
+          output_tokens: 1,
+          total_tokens: 2,
+          input_tokens_details: { cached_tokens: 0 },
+        },
+        service_tier: "priority",
+      },
+    },
+  ];
+
+  return new Response(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""), {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+describe("pi bridge Codex service tier", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("sends configured fast service tier in the final streaming Codex HTTP request body", async () => {
+    const requests: Array<{ url: string; body: unknown }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        requests.push({
+          url: String(input),
+          body: typeof init?.body === "string" ? JSON.parse(init.body) : init?.body,
+        });
+        return createSseResponse();
+      }),
+    );
+
+    const bridge = new PiBridge();
+    const result = await bridge.streamTurn({
+      model: createCodexModel({ serviceTier: "fast" }),
+      systemPrompt: "You are concise.",
+      compactSummary: null,
+      messages: [createStoredUserMessage()],
+      tools: new ToolRegistry(),
+      signal: new AbortController().signal,
+    });
+
+    expect(result.content).toMatchObject([{ type: "text", text: "ok" }]);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe("https://chatgpt.com/backend-api/codex/responses");
+    expect(requests[0]?.body).toMatchObject({
+      model: "gpt-5.5",
+      service_tier: "priority",
+    });
+  });
+});

--- a/tests/agent/llm/provider-registry.test.ts
+++ b/tests/agent/llm/provider-registry.test.ts
@@ -75,6 +75,19 @@ describe("provider registry", () => {
     expect(model.provider.apiKey).toBe("anthropic-secret");
   });
 
+  test("preserves per-model service tier configuration", () => {
+    const config = createConfig();
+    const model = config.models.catalog[1];
+    if (model == null) {
+      throw new Error("expected seeded model catalog entry");
+    }
+    model.serviceTier = "fast";
+
+    const registry = new ProviderRegistry(config);
+
+    expect(registry.getRequiredModel("openai_main/gpt-5-mini").serviceTier).toBe("fast");
+  });
+
   test("returns null for missing scenario selection when the list is empty", () => {
     const config = createConfig();
     config.models.scenarios.task = [];

--- a/tests/config/load.test.ts
+++ b/tests/config/load.test.ts
@@ -375,6 +375,7 @@ describe("config loader", () => {
         "maxOutputTokens = 16384",
         "supportsTools = true",
         "supportsVision = true",
+        'serviceTier = "fast"',
         "[models.catalog.reasoning]",
         "enabled = true",
         "[models.catalog.pricing]",
@@ -452,6 +453,7 @@ describe("config loader", () => {
       },
     });
     expect(config.models.catalog).toHaveLength(2);
+    expect(config.models.catalog[0]?.serviceTier).toBe("fast");
     expect(config.models.scenarios.chat).toEqual([
       "anthropic_main/claude-sonnet-4-5",
       "openai_main/gpt-5-mini",
@@ -931,6 +933,33 @@ describe("config loader", () => {
 
     await expect(loadConfig({ configTomlPath: configPath })).rejects.toThrow(
       "config.toml models.scenarios contains unknown key: subagent",
+    );
+  });
+
+  test("rejects invalid model service tier values", async () => {
+    const configPath = path.join(tempDir, "config.toml");
+    await writeFile(
+      configPath,
+      [
+        "[providers.main]",
+        'api = "openai-responses"',
+        "",
+        "[[models.catalog]]",
+        'id = "gpt5"',
+        'provider = "main"',
+        'upstreamId = "openai/gpt-5"',
+        "contextWindow = 200000",
+        "maxOutputTokens = 16384",
+        "supportsTools = true",
+        "supportsVision = true",
+        'serviceTier = "turbo"',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await expect(loadConfig({ configTomlPath: configPath })).rejects.toThrow(
+      "config.toml models.catalog[0].serviceTier must be one of: auto, default, flex, scale, priority, fast",
     );
   });
 


### PR DESCRIPTION
## What

Add per-model `serviceTier` configuration so Codex/OpenAI Responses model instances can opt into Fast mode.

This lets a model catalog entry such as `codex-gpt5.5` declare:

```toml
serviceTier = "fast"
```

and have the final OpenAI/Codex request carry the service tier required for Fast mode.

## Why

Codex Fast mode is a service tier choice, not a separate reasoning setting. It belongs next to other model-instance configuration like reasoning effort, because users may want one GPT-5.5 entry to use normal priority and another GPT-5.5 entry to use Fast mode.

The `pi-agent` layer exposes provider-specific `serviceTier` types, but the simple stream path used here does not currently preserve that option all the way to the final request. To avoid losing the parameter in the deeper call chain, this PR verifies and patches the final HTTP payload that is sent to OpenAI/Codex.

## How

- Extend the model catalog schema with `serviceTier`, including validation for known OpenAI service tier values.
- Propagate `serviceTier` through `ResolvedModel` and provider resolution.
- Map the user-facing `fast` value to the OpenAI request value `priority`.
- Inject `service_tier` only for native OpenAI/Codex Responses endpoints, so downgraded/non-OpenAI routes do not receive unsupported fields.
- Show the configured tier in model summaries/status output so users can confirm the selected model instance is configured for Fast mode.
- Document the new config in `docs/configuration.md`.

## Tests

- Added config validation coverage for valid and invalid `serviceTier` values.
- Added provider-registry coverage to ensure resolved models preserve `serviceTier`.
- Added an end-to-end `PiBridge.streamTurn()` test that does not mock the bridge/provider layer; it stubs the final `fetch` call and asserts the actual request body sent to the Codex endpoint includes:

```json
{
  "model": "gpt-5.5",
  "service_tier": "priority"
}
```

Validation run:

```bash
pnpm preflight
```
