### PR TITLE
Add configurable empty-output LLM retries

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -343,6 +343,25 @@ autopilot = true
 
 Restart Pokoclaw after changing this value.
 
+### LLM empty-output retries
+
+Pokoclaw retries a model response when the model times out before producing any
+visible output, or returns an empty assistant message with no tool call. The
+default is five total model attempts, including the first request.
+
+```toml
+[runtime]
+maxEmptyOutputLlmAttempts = 5
+llmFirstResponseTimeoutMs = 45000
+```
+
+Lark run cards show retry progress in the footer, for example:
+`🔁 模型响应超时，正在重试 2/5`.
+
+Use `llmFirstResponseTimeoutMs` to shorten or lengthen the per-attempt wait for
+the first semantic model event. Local testing can set it to `3000` to trigger the
+retry path quickly.
+
 ### If the user prefers file-based secrets
 
 Keep `config.toml` like this:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -356,7 +356,7 @@ llmFirstResponseTimeoutMs = 45000
 ```
 
 Lark run cards show retry progress in the footer, for example:
-`🔁 模型响应超时，正在重试 2/5`.
+`🔁 模型调用出错，正在重试 2/5`.
 
 Use `llmFirstResponseTimeoutMs` to shorten or lengthen the per-attempt wait for
 the first semantic model event. Local testing can set it to `3000` to trigger the

--- a/src/agent/events.ts
+++ b/src/agent/events.ts
@@ -102,6 +102,22 @@ export interface AssistantMessageCompletedEvent extends AgentRuntimeEventBase {
   usage: MessageUsage | null;
 }
 
+export type AssistantResponseRetryReason =
+  | "llm_failure_without_visible_output"
+  | "successful_empty_output";
+
+export interface AssistantResponseRetryingEvent extends AgentRuntimeEventBase {
+  type: "assistant_response_retrying";
+  turn: number;
+  messageId: string;
+  attempt: number;
+  maxAttempts: number;
+  reason: AssistantResponseRetryReason;
+  errorKind?: AgentLlmErrorKind;
+  errorMessage?: string;
+  rawErrorMessage?: string | null;
+}
+
 export interface ToolCallStartedEvent extends AgentRuntimeEventBase {
   type: "tool_call_started";
   turn: number;
@@ -222,6 +238,7 @@ export type AgentRuntimeEvent =
   | AssistantMessageDeltaEvent
   | AssistantReasoningDeltaEvent
   | AssistantMessageCompletedEvent
+  | AssistantResponseRetryingEvent
   | ToolCallStartedEvent
   | ToolCallCompletedEvent
   | ToolCallFailedEvent
@@ -245,6 +262,7 @@ export type AgentRuntimeEventInput =
   | Omit<AssistantMessageDeltaEvent, "eventId" | "createdAt">
   | Omit<AssistantReasoningDeltaEvent, "eventId" | "createdAt">
   | Omit<AssistantMessageCompletedEvent, "eventId" | "createdAt">
+  | Omit<AssistantResponseRetryingEvent, "eventId" | "createdAt">
   | Omit<ToolCallStartedEvent, "eventId" | "createdAt">
   | Omit<ToolCallCompletedEvent, "eventId" | "createdAt">
   | Omit<ToolCallFailedEvent, "eventId" | "createdAt">

--- a/src/agent/llm/empty-output-retry.ts
+++ b/src/agent/llm/empty-output-retry.ts
@@ -1,0 +1,53 @@
+import { type AgentLlmError, isAgentLlmError } from "@/src/agent/llm/errors.js";
+
+export function getEmptyOutputLlmRetryLimit(maxAttempts: number): number {
+  return Math.max(0, maxAttempts - 1);
+}
+
+export function getNextEmptyOutputLlmAttempt(input: { retryCountAfterIncrement: number }): number {
+  return input.retryCountAfterIncrement + 1;
+}
+
+export function shouldRetrySuccessfulEmptyAssistantOutput(input: {
+  assistantText: string;
+  reasoningText: string;
+  toolCallsRequested: number;
+  sawStreamedText: boolean;
+  sawStreamedReasoning: boolean;
+  retryCount: number;
+  maxAttempts: number;
+}): boolean {
+  if (
+    input.retryCount >= getEmptyOutputLlmRetryLimit(input.maxAttempts) ||
+    input.sawStreamedText ||
+    input.sawStreamedReasoning
+  ) {
+    return false;
+  }
+
+  return (
+    input.assistantText.length === 0 &&
+    input.reasoningText.length === 0 &&
+    input.toolCallsRequested === 0
+  );
+}
+
+export function getRetryableLlmFailureWithoutVisibleOutput(input: {
+  error: unknown;
+  sawStreamedText: boolean;
+  sawStreamedReasoning: boolean;
+  retryCount: number;
+  maxAttempts: number;
+}): AgentLlmError | null {
+  if (
+    input.retryCount >= getEmptyOutputLlmRetryLimit(input.maxAttempts) ||
+    !isAgentLlmError(input.error) ||
+    !input.error.retryable ||
+    input.sawStreamedText ||
+    input.sawStreamedReasoning
+  ) {
+    return null;
+  }
+
+  return input.error;
+}

--- a/src/agent/llm/empty-output-retry.ts
+++ b/src/agent/llm/empty-output-retry.ts
@@ -4,8 +4,8 @@ export function getEmptyOutputLlmRetryLimit(maxAttempts: number): number {
   return Math.max(0, maxAttempts - 1);
 }
 
-export function getNextEmptyOutputLlmAttempt(input: { retryCountAfterIncrement: number }): number {
-  return input.retryCountAfterIncrement + 1;
+export function getNextEmptyOutputLlmAttempt(input: { retryCount: number }): number {
+  return input.retryCount + 1;
 }
 
 export function shouldRetrySuccessfulEmptyAssistantOutput(input: {

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -866,7 +866,7 @@ export class AgentLoop {
             if (emptyOutputRetryError != null) {
               emptyOutputRetryCount += 1;
               const retryAttempt = getNextEmptyOutputLlmAttempt({
-                retryCountAfterIncrement: emptyOutputRetryCount,
+                retryCount: emptyOutputRetryCount,
               });
               logger.warn("retrying assistant response after empty-output llm failure", {
                 sessionId: input.sessionId,
@@ -941,7 +941,7 @@ export class AgentLoop {
         if (successfulEmptyOutputRetry) {
           emptyOutputRetryCount += 1;
           const retryAttempt = getNextEmptyOutputLlmAttempt({
-            retryCountAfterIncrement: emptyOutputRetryCount,
+            retryCount: emptyOutputRetryCount,
           });
           logger.warn("retrying assistant response after successful empty output", {
             sessionId: input.sessionId,

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -26,6 +26,11 @@ import type {
   AgentRuntimeEventInput,
   AgentToolCall,
 } from "@/src/agent/events.js";
+import {
+  getNextEmptyOutputLlmAttempt,
+  getRetryableLlmFailureWithoutVisibleOutput,
+  shouldRetrySuccessfulEmptyAssistantOutput,
+} from "@/src/agent/llm/empty-output-retry.js";
 import { isAgentLlmError } from "@/src/agent/llm/errors.js";
 import type {
   AgentAssistantContentBlock,
@@ -63,6 +68,7 @@ import {
   DEFAULT_CONFIG,
   DEFAULT_RUNTIME_APPROVAL_GRANT_TTL_MS,
   DEFAULT_RUNTIME_APPROVAL_TIMEOUT_MS,
+  DEFAULT_RUNTIME_MAX_EMPTY_OUTPUT_LLM_ATTEMPTS,
   DEFAULT_RUNTIME_MAX_TURNS,
 } from "@/src/config/defaults.js";
 import type {
@@ -126,7 +132,6 @@ const ASSISTANT_REASONING_CAPTURE_MAX_CHARS = 100_000;
 const ASSISTANT_REASONING_EVENT_FLUSH_CHARS = 512;
 const ASSISTANT_REASONING_EVENT_FLUSH_MS = 250;
 const ASSISTANT_REASONING_TRUNCATION_PREFIX = "...[earlier reasoning truncated]\n";
-const EMPTY_OUTPUT_LLM_RETRY_LIMIT = 1;
 const UNKNOWN_ASSISTANT_ERROR_USAGE: MessageUsage = {
   input: 0,
   output: 0,
@@ -263,6 +268,7 @@ export class AgentLoop {
   private readonly approvalFlow: SessionApprovalFlowRegistry;
   private readonly steerQueue = new SessionSteerQueueRegistry();
   private readonly defaultMaxTurns: number;
+  private readonly emptyOutputLlmMaxAttempts: number;
   private readonly approvalTimeoutMs: number;
   private readonly approvalGrantTtlMs: number;
 
@@ -281,6 +287,8 @@ export class AgentLoop {
       );
     this.approvalFlow = deps.approvalFlow ?? new SessionApprovalFlowRegistry();
     this.defaultMaxTurns = deps.runtime?.maxTurns ?? DEFAULT_RUNTIME_MAX_TURNS;
+    this.emptyOutputLlmMaxAttempts =
+      deps.runtime?.maxEmptyOutputLlmAttempts ?? DEFAULT_RUNTIME_MAX_EMPTY_OUTPUT_LLM_ATTEMPTS;
     this.approvalTimeoutMs =
       deps.approvalTimeoutMs ??
       deps.runtime?.approvalTimeoutMs ??
@@ -603,6 +611,7 @@ export class AgentLoop {
       contextWindow: model.contextWindow,
       config: this.deps.compaction,
     });
+    let emptyOutputRetryCount = 0;
 
     try {
       this.recordEvent(events, {
@@ -648,7 +657,6 @@ export class AgentLoop {
         let streamedReasoningDeltaCount = 0;
         let streamedReasoningChars = 0;
         let overflowRecovered = false;
-        let emptyOutputRetryCount = 0;
         let response: AgentModelTurnResult;
 
         const flushPendingReasoningDelta = (force = false) => {
@@ -853,9 +861,13 @@ export class AgentLoop {
               sawStreamedText,
               sawStreamedReasoning,
               retryCount: emptyOutputRetryCount,
+              maxAttempts: this.emptyOutputLlmMaxAttempts,
             });
             if (emptyOutputRetryError != null) {
               emptyOutputRetryCount += 1;
+              const retryAttempt = getNextEmptyOutputLlmAttempt({
+                retryCountAfterIncrement: emptyOutputRetryCount,
+              });
               logger.warn("retrying assistant response after empty-output llm failure", {
                 sessionId: input.sessionId,
                 conversationId: context.session.conversationId,
@@ -867,8 +879,23 @@ export class AgentLoop {
                 modelId: model.id,
                 errorKind: emptyOutputRetryError.kind,
                 errorMessage: emptyOutputRetryError.message,
-                retryAttempt: emptyOutputRetryCount,
-                retryLimit: EMPTY_OUTPUT_LLM_RETRY_LIMIT,
+                retryAttempt,
+                maxAttempts: this.emptyOutputLlmMaxAttempts,
+              });
+              this.recordEvent(events, {
+                type: "assistant_response_retrying",
+                turn: turn + 1,
+                messageId: assistantMessageId,
+                attempt: retryAttempt,
+                maxAttempts: this.emptyOutputLlmMaxAttempts,
+                reason: "llm_failure_without_visible_output",
+                errorKind: emptyOutputRetryError.kind,
+                errorMessage: emptyOutputRetryError.message,
+                rawErrorMessage: emptyOutputRetryError.rawMessage ?? null,
+                sessionId: input.sessionId,
+                conversationId: context.session.conversationId,
+                branchId: context.session.branchId,
+                runId,
               });
               continue;
             }
@@ -909,9 +936,13 @@ export class AgentLoop {
           sawStreamedText,
           sawStreamedReasoning,
           retryCount: emptyOutputRetryCount,
+          maxAttempts: this.emptyOutputLlmMaxAttempts,
         });
         if (successfulEmptyOutputRetry) {
           emptyOutputRetryCount += 1;
+          const retryAttempt = getNextEmptyOutputLlmAttempt({
+            retryCountAfterIncrement: emptyOutputRetryCount,
+          });
           logger.warn("retrying assistant response after successful empty output", {
             sessionId: input.sessionId,
             conversationId: context.session.conversationId,
@@ -921,11 +952,24 @@ export class AgentLoop {
             runId,
             assistantMessageId,
             modelId: model.id,
-            retryAttempt: emptyOutputRetryCount,
-            retryLimit: EMPTY_OUTPUT_LLM_RETRY_LIMIT,
+            retryAttempt,
+            maxAttempts: this.emptyOutputLlmMaxAttempts,
+          });
+          this.recordEvent(events, {
+            type: "assistant_response_retrying",
+            turn: turn + 1,
+            messageId: assistantMessageId,
+            attempt: retryAttempt,
+            maxAttempts: this.emptyOutputLlmMaxAttempts,
+            reason: "successful_empty_output",
+            sessionId: input.sessionId,
+            conversationId: context.session.conversationId,
+            branchId: context.session.branchId,
+            runId,
           });
           continue;
         }
+        emptyOutputRetryCount = 0;
         // Some runners will stream deltas incrementally, others may only return
         // the final assistant payload. We keep one event shape and only fall back
         // to a single full-text delta if nothing was streamed.
@@ -2129,48 +2173,6 @@ function appendMessageAndHydrate(input: {
     usageJson: input.usage == null ? null : JSON.stringify(input.usage),
     createdAt: input.createdAt.toISOString(),
   };
-}
-
-function shouldRetrySuccessfulEmptyAssistantOutput(input: {
-  assistantText: string;
-  reasoningText: string;
-  toolCallsRequested: number;
-  sawStreamedText: boolean;
-  sawStreamedReasoning: boolean;
-  retryCount: number;
-}): boolean {
-  if (
-    input.retryCount >= EMPTY_OUTPUT_LLM_RETRY_LIMIT ||
-    input.sawStreamedText ||
-    input.sawStreamedReasoning
-  ) {
-    return false;
-  }
-
-  return (
-    input.assistantText.length === 0 &&
-    input.reasoningText.length === 0 &&
-    input.toolCallsRequested === 0
-  );
-}
-
-function getRetryableLlmFailureWithoutVisibleOutput(input: {
-  error: unknown;
-  sawStreamedText: boolean;
-  sawStreamedReasoning: boolean;
-  retryCount: number;
-}): import("@/src/agent/llm/errors.js").AgentLlmError | null {
-  if (
-    input.retryCount >= EMPTY_OUTPUT_LLM_RETRY_LIMIT ||
-    !isAgentLlmError(input.error) ||
-    !input.error.retryable ||
-    input.sawStreamedText ||
-    input.sawStreamedReasoning
-  ) {
-    return null;
-  }
-
-  return input.error;
 }
 
 function appendPartialStreamedAssistantMessageOnFailure(input: {

--- a/src/channels/lark/outbound.ts
+++ b/src/channels/lark/outbound.ts
@@ -509,6 +509,7 @@ export function createLarkOutboundRuntime(
       activeToolSequenceBlockId: state.activeToolSequenceBlockId,
       blockCount: state.blocks.length,
       footerStatus: state.footerStatus,
+      footerNotice: state.footerNotice,
     });
 
     const deliveryTargets = listLarkDeliveryTargets(input.storage, {
@@ -2079,6 +2080,7 @@ export function createLarkOutboundRuntime(
           activeToolSequenceBlockId: next.activeToolSequenceBlockId,
           blockCount: next.blocks.length,
           footerStatus: next.footerStatus,
+          footerNotice: next.footerNotice,
           terminal: next.terminal,
         });
         bumpVersionAndSchedule(`run:${runCardObjectId}`, {
@@ -2649,6 +2651,7 @@ function shouldCreateRunSegmentForEvent(envelope: OrchestratedRuntimeEventEnvelo
     case "assistant_message_started":
     case "assistant_message_delta":
     case "assistant_message_completed":
+    case "assistant_response_retrying":
     case "tool_call_started":
     case "tool_call_completed":
     case "tool_call_failed":

--- a/src/channels/lark/render/run-card.ts
+++ b/src/channels/lark/render/run-card.ts
@@ -7,6 +7,11 @@ import {
 } from "@/src/channels/lark/render/task-card.js";
 import { renderToolSequenceSlice } from "@/src/channels/lark/render/tool-calls.js";
 import {
+  type LarkRetryFooterNotice,
+  renderLarkRetryFooterNotice,
+  summarizeLarkRetryFooterNotice,
+} from "@/src/channels/lark/retry-footer.js";
+import {
   buildLarkAssistantElementId,
   LARK_ASSISTANT_PLACEHOLDER_TEXT,
   type LarkAssistantTextBlock,
@@ -462,7 +467,12 @@ function buildRunCardPage(
   }
 
   if (includeFooter && options.pageIndex === options.pageCount) {
-    const footerElements = renderFooter(state.footerStatus, state.terminal, state.runId);
+    const footerElements = renderFooter(
+      state.footerStatus,
+      state.footerNotice,
+      state.terminal,
+      state.runId,
+    );
     if (footerElements.length > 0) {
       elements.push({ tag: "hr" }, ...footerElements);
     }
@@ -719,25 +729,32 @@ function renderVisibleTerminalSummary(
 
 function renderFooter(
   status: LarkFooterStatus,
+  notice: LarkRetryFooterNotice | null,
   terminal: LarkRunState["terminal"],
   runId: string | null,
 ): Array<Record<string, unknown>> {
   const elements: Array<Record<string, unknown>> = [];
-  if (status === "thinking") {
+  if (notice != null) {
+    elements.push({
+      tag: "markdown",
+      content: renderLarkRetryFooterNotice(notice),
+      text_size: "notation",
+    });
+  } else if (status === "thinking") {
     elements.push({
       tag: "markdown",
       content: "🧠 正在思考",
       text_size: "notation",
     });
   }
-  if (status === "tool_running") {
+  if (notice == null && status === "tool_running") {
     elements.push({
       tag: "markdown",
       content: "🧰 正在调用工具",
       text_size: "notation",
     });
   }
-  if (status === "waiting_approval") {
+  if (notice == null && status === "waiting_approval") {
     elements.push({
       tag: "markdown",
       content: "🔐 等待批复",
@@ -780,6 +797,9 @@ function summarizeRunState(state: LarkRunState): string {
     if (state.terminal === "denied") {
       return `${taskKind}已拒绝`;
     }
+    if (state.footerNotice != null) {
+      return summarizeLarkRetryFooterNotice(state.footerNotice);
+    }
     if (state.footerStatus === "waiting_approval") {
       return `${taskKind}等待批复`;
     }
@@ -815,6 +835,9 @@ function summarizeRunState(state: LarkRunState): string {
   }
   if (state.terminal === "denied") {
     return "已拒绝";
+  }
+  if (state.footerNotice != null) {
+    return summarizeLarkRetryFooterNotice(state.footerNotice);
   }
   if (state.footerStatus === "waiting_approval") {
     return "等待批复";

--- a/src/channels/lark/retry-footer.ts
+++ b/src/channels/lark/retry-footer.ts
@@ -17,7 +17,7 @@ export function createLarkRetryFooterNotice(
 }
 
 export function renderLarkRetryFooterNotice(notice: LarkRetryFooterNotice): string {
-  return `🔁 模型响应超时，正在重试 ${notice.attempt}/${notice.maxAttempts}`;
+  return `🔁 模型调用出错，正在重试 ${notice.attempt}/${notice.maxAttempts}`;
 }
 
 export function summarizeLarkRetryFooterNotice(notice: LarkRetryFooterNotice): string {

--- a/src/channels/lark/retry-footer.ts
+++ b/src/channels/lark/retry-footer.ts
@@ -1,0 +1,25 @@
+import type { AssistantResponseRetryingEvent } from "@/src/agent/events.js";
+
+export interface LarkRetryFooterNotice {
+  kind: "assistant_response_retrying";
+  attempt: number;
+  maxAttempts: number;
+}
+
+export function createLarkRetryFooterNotice(
+  event: AssistantResponseRetryingEvent,
+): LarkRetryFooterNotice {
+  return {
+    kind: "assistant_response_retrying",
+    attempt: event.attempt,
+    maxAttempts: event.maxAttempts,
+  };
+}
+
+export function renderLarkRetryFooterNotice(notice: LarkRetryFooterNotice): string {
+  return `🔁 模型响应超时，正在重试 ${notice.attempt}/${notice.maxAttempts}`;
+}
+
+export function summarizeLarkRetryFooterNotice(notice: LarkRetryFooterNotice): string {
+  return renderLarkRetryFooterNotice(notice);
+}

--- a/src/channels/lark/run-state.ts
+++ b/src/channels/lark/run-state.ts
@@ -228,6 +228,8 @@ function onAssistantMessageStarted(
     ...state,
     activeAssistantMessageId: event.messageId,
     footerStatus: "thinking",
+    // Preserve retry progress after AgentLoop starts the next attempt; clear it
+    // when the model emits real progress such as reasoning, text, or tool calls.
     awaitingApprovalTarget: null,
     reasoning: {
       ...state.reasoning,

--- a/src/channels/lark/run-state.ts
+++ b/src/channels/lark/run-state.ts
@@ -10,10 +10,15 @@ import type {
   AssistantMessageDeltaEvent,
   AssistantMessageStartedEvent,
   AssistantReasoningDeltaEvent,
+  AssistantResponseRetryingEvent,
   ToolCallCompletedEvent,
   ToolCallFailedEvent,
   ToolCallStartedEvent,
 } from "@/src/agent/events.js";
+import {
+  createLarkRetryFooterNotice,
+  type LarkRetryFooterNotice,
+} from "@/src/channels/lark/retry-footer.js";
 import type {
   OrchestratedRuntimeEventEnvelope,
   OrchestratedTaskRunEventEnvelope,
@@ -78,6 +83,7 @@ export interface LarkRunState {
   activeAssistantMessageId: string | null;
   activeToolSequenceBlockId: string | null;
   footerStatus: LarkFooterStatus;
+  footerNotice: LarkRetryFooterNotice | null;
   awaitingApprovalTarget: "user" | "main_agent" | null;
   reasoning: LarkReasoningState;
   terminal: LarkRunTerminal;
@@ -148,6 +154,8 @@ export function reduceLarkRunState(
       return onAssistantReasoningDelta(hydratedState, envelope.event);
     case "assistant_message_completed":
       return onAssistantMessageCompleted(hydratedState, envelope.event);
+    case "assistant_response_retrying":
+      return onAssistantResponseRetrying(hydratedState, envelope.event);
     case "tool_call_started":
       return onToolCallStarted(hydratedState, envelope.event);
     case "tool_call_completed":
@@ -184,6 +192,7 @@ function createInitialRunState(input: {
     activeAssistantMessageId: null,
     activeToolSequenceBlockId: null,
     footerStatus: null,
+    footerNotice: null,
     awaitingApprovalTarget: null,
     reasoning: {
       content: "",
@@ -265,6 +274,7 @@ function onAssistantMessageDelta(
         ? null
         : state.activeToolSequenceBlockId,
     footerStatus: null,
+    footerNotice: null,
     awaitingApprovalTarget: null,
     reasoning: {
       ...state.reasoning,
@@ -283,6 +293,7 @@ function onAssistantReasoningDelta(
   return {
     ...state,
     footerStatus: "thinking",
+    footerNotice: null,
     awaitingApprovalTarget: null,
     reasoning: {
       content:
@@ -321,6 +332,7 @@ function onAssistantMessageCompleted(
     activeToolSequenceBlockId:
       existingBlock == null && hasVisibleText ? null : state.activeToolSequenceBlockId,
     footerStatus: null,
+    footerNotice: null,
     awaitingApprovalTarget: null,
     reasoning: {
       content:
@@ -330,6 +342,27 @@ function onAssistantMessageCompleted(
       active: false,
       expanded: false,
     },
+  };
+}
+
+function onAssistantResponseRetrying(
+  state: LarkRunState,
+  event: AssistantResponseRetryingEvent,
+): LarkRunState {
+  return {
+    ...state,
+    activeAssistantMessageId: event.messageId,
+    footerStatus: "thinking",
+    footerNotice: createLarkRetryFooterNotice(event),
+    awaitingApprovalTarget: null,
+    reasoning: {
+      ...state.reasoning,
+      active: false,
+      expanded: false,
+    },
+    terminal: "running",
+    terminalErrorKind: null,
+    terminalMessage: null,
   };
 }
 
@@ -372,6 +405,7 @@ function onToolCallStarted(state: LarkRunState, event: ToolCallStartedEvent): La
     ),
     activeToolSequenceBlockId,
     footerStatus: "tool_running",
+    footerNotice: null,
     awaitingApprovalTarget: null,
     reasoning: {
       ...state.reasoning,
@@ -397,6 +431,7 @@ function onToolCallCompleted(state: LarkRunState, event: ToolCallCompletedEvent)
         : block,
     ),
     footerStatus: hasRunningTool(state.blocks, event.toolCallId) ? "tool_running" : null,
+    footerNotice: null,
     awaitingApprovalTarget: null,
   };
 }
@@ -421,6 +456,7 @@ function onToolCallFailed(state: LarkRunState, event: ToolCallFailedEvent): Lark
         : block,
     ),
     footerStatus: hasRunningTool(state.blocks, event.toolCallId) ? "tool_running" : null,
+    footerNotice: null,
     awaitingApprovalTarget: null,
   };
 }
@@ -461,6 +497,7 @@ function finalizeRun(
     activeAssistantMessageId: null,
     activeToolSequenceBlockId: null,
     footerStatus: null,
+    footerNotice: null,
     awaitingApprovalTarget: null,
     reasoning: {
       ...state.reasoning,
@@ -490,6 +527,7 @@ function finalizeTaskRun(
     activeAssistantMessageId: null,
     activeToolSequenceBlockId: null,
     footerStatus: null,
+    footerNotice: null,
     awaitingApprovalTarget: null,
     reasoning: {
       ...state.reasoning,
@@ -514,6 +552,7 @@ export function markLarkRunAwaitingApproval(
     activeAssistantMessageId: null,
     activeToolSequenceBlockId: null,
     footerStatus: input.approvalTarget === "main_agent" ? "waiting_approval" : null,
+    footerNotice: null,
     awaitingApprovalTarget: input.approvalTarget,
     reasoning: {
       ...state.reasoning,
@@ -539,6 +578,7 @@ export function markLarkRunApprovalResolved(
     activeAssistantMessageId: null,
     activeToolSequenceBlockId: null,
     footerStatus: null,
+    footerNotice: null,
     awaitingApprovalTarget: null,
     reasoning: {
       ...state.reasoning,
@@ -676,6 +716,7 @@ export function shouldHandleLarkRuntimeEvent(envelope: OrchestratedRuntimeEventE
     envelope.event.type === "assistant_message_delta" ||
     envelope.event.type === "assistant_reasoning_delta" ||
     envelope.event.type === "assistant_message_completed" ||
+    envelope.event.type === "assistant_response_retrying" ||
     envelope.event.type === "tool_call_started" ||
     envelope.event.type === "tool_call_completed" ||
     envelope.event.type === "tool_call_failed" ||

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,6 +1,8 @@
 import type { RawConfig } from "@/src/config/schema.js";
 
 export const DEFAULT_RUNTIME_MAX_TURNS = 100;
+export const DEFAULT_RUNTIME_MAX_EMPTY_OUTPUT_LLM_ATTEMPTS = 5;
+export const DEFAULT_RUNTIME_LLM_FIRST_RESPONSE_TIMEOUT_MS = 45_000;
 export const DEFAULT_RUNTIME_APPROVAL_TIMEOUT_MS = 3 * 60 * 1000;
 export const DEFAULT_RUNTIME_APPROVAL_GRANT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 export const DEFAULT_PROJECT_CONTEXT_MAX_BYTES = 8192;
@@ -30,6 +32,8 @@ export const DEFAULT_CONFIG: RawConfig = {
   },
   runtime: {
     maxTurns: DEFAULT_RUNTIME_MAX_TURNS,
+    maxEmptyOutputLlmAttempts: DEFAULT_RUNTIME_MAX_EMPTY_OUTPUT_LLM_ATTEMPTS,
+    llmFirstResponseTimeoutMs: DEFAULT_RUNTIME_LLM_FIRST_RESPONSE_TIMEOUT_MS,
     approvalTimeoutMs: DEFAULT_RUNTIME_APPROVAL_TIMEOUT_MS,
     approvalGrantTtlMs: DEFAULT_RUNTIME_APPROVAL_GRANT_TTL_MS,
     autopilot: false,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -65,6 +65,8 @@ export interface CompactionConfig {
 
 export interface RuntimeConfig {
   maxTurns: number;
+  maxEmptyOutputLlmAttempts: number;
+  llmFirstResponseTimeoutMs: number;
   approvalTimeoutMs: number;
   approvalGrantTtlMs: number;
   autopilot: boolean;
@@ -260,6 +262,8 @@ interface CompactionConfigInput {
 
 interface RuntimeConfigInput {
   maxTurns?: unknown;
+  maxEmptyOutputLlmAttempts?: unknown;
+  llmFirstResponseTimeoutMs?: unknown;
   approvalTimeoutMs?: unknown;
   approvalGrantTtlMs?: unknown;
   autopilot?: unknown;
@@ -922,7 +926,14 @@ function validateRuntimeConfig(input: unknown, defaults: RuntimeConfig): Runtime
   const config = input as RuntimeConfigInput;
   assertAllowedKeys(
     config,
-    new Set(["maxTurns", "approvalTimeoutMs", "approvalGrantTtlMs", "autopilot"]),
+    new Set([
+      "maxTurns",
+      "maxEmptyOutputLlmAttempts",
+      "llmFirstResponseTimeoutMs",
+      "approvalTimeoutMs",
+      "approvalGrantTtlMs",
+      "autopilot",
+    ]),
     "config.toml runtime",
   );
 
@@ -930,6 +941,14 @@ function validateRuntimeConfig(input: unknown, defaults: RuntimeConfig): Runtime
     maxTurns: validatePositiveInteger(
       config.maxTurns ?? defaults.maxTurns,
       "config.toml runtime.maxTurns",
+    ),
+    maxEmptyOutputLlmAttempts: validatePositiveInteger(
+      config.maxEmptyOutputLlmAttempts ?? defaults.maxEmptyOutputLlmAttempts,
+      "config.toml runtime.maxEmptyOutputLlmAttempts",
+    ),
+    llmFirstResponseTimeoutMs: validatePositiveInteger(
+      config.llmFirstResponseTimeoutMs ?? defaults.llmFirstResponseTimeoutMs,
+      "config.toml runtime.llmFirstResponseTimeoutMs",
     ),
     approvalTimeoutMs: validatePositiveInteger(
       config.approvalTimeoutMs ?? defaults.approvalTimeoutMs,

--- a/src/orchestration/outbound-events.ts
+++ b/src/orchestration/outbound-events.ts
@@ -367,6 +367,7 @@ function extractRuntimeObjectAnchors(event: AgentRuntimeEvent): OutboundEventCon
     case "assistant_message_delta":
     case "assistant_reasoning_delta":
     case "assistant_message_completed":
+    case "assistant_response_retrying":
     case "steer_message_consumed":
       return {
         messageId: event.messageId,

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -130,7 +130,9 @@ export function createRuntimeBootstrap(input: CreateRuntimeBootstrapInput): Runt
     autopilotEnabled: input.config.runtime.autopilot,
   });
   const providerApiKeyResolver = new CodexProviderApiKeyResolver();
-  const llmBridge = new PiBridge(providerApiKeyResolver);
+  const llmBridge = new PiBridge(providerApiKeyResolver, {
+    firstResponseTimeoutMs: input.config.runtime.llmFirstResponseTimeoutMs,
+  });
   const status = new RuntimeStatusService({
     storage: input.storage,
     control,

--- a/tests/agent/empty-output-retry.test.ts
+++ b/tests/agent/empty-output-retry.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, describe, expect, test } from "vitest";
+import type { AgentRuntimeEvent } from "@/src/agent/events.js";
+import { AgentLlmError } from "@/src/agent/llm/errors.js";
+import type { AgentAssistantContentBlock } from "@/src/agent/llm/messages.js";
+import { ProviderRegistry } from "@/src/agent/llm/provider-registry.js";
+import { AgentLoop, type AgentModelRunner } from "@/src/agent/loop.js";
+import { AgentSessionService } from "@/src/agent/session.js";
+import { DEFAULT_CONFIG } from "@/src/config/defaults.js";
+import type { AppConfig } from "@/src/config/schema.js";
+import { SessionRunAbortRegistry } from "@/src/runtime/cancel.js";
+import { MessagesRepo } from "@/src/storage/repos/messages.repo.js";
+import { SessionsRepo } from "@/src/storage/repos/sessions.repo.js";
+import { ToolRegistry } from "@/src/tools/core/registry.js";
+import {
+  createTestDatabase,
+  destroyTestDatabase,
+  type TestDatabaseHandle,
+} from "@/tests/storage/helpers/test-db.js";
+
+function createModelConfig(): Pick<AppConfig, "providers" | "models"> {
+  return {
+    providers: {
+      anthropic_main: {
+        api: "anthropic-messages",
+      },
+    },
+    models: {
+      catalog: [
+        {
+          id: "anthropic_main/claude-sonnet-4-5",
+          provider: "anthropic_main",
+          upstreamId: "claude-sonnet-4-5-20250929",
+          contextWindow: 200_000,
+          maxOutputTokens: 16_384,
+          supportsTools: true,
+          supportsVision: true,
+          reasoning: { enabled: true },
+        },
+      ],
+      scenarios: {
+        chat: ["anthropic_main/claude-sonnet-4-5"],
+        compaction: ["anthropic_main/claude-sonnet-4-5"],
+        task: ["anthropic_main/claude-sonnet-4-5"],
+        meditationBucket: [],
+        meditationConsolidation: [],
+      },
+    },
+  };
+}
+
+function makeAssistantResult(content: AgentAssistantContentBlock[]) {
+  return {
+    provider: "anthropic_main",
+    model: "claude-sonnet-4-5",
+    modelApi: "anthropic-messages",
+    stopReason: "stop" as const,
+    content,
+    usage: {
+      input: 10,
+      output: 5,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 15,
+    },
+  };
+}
+
+function seedConversationFixture(handle: TestDatabaseHandle): void {
+  handle.storage.sqlite.exec(`
+    INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+    VALUES ('ci_1', 'lark', 'acct_a', '2026-03-22T00:00:00.000Z', '2026-03-22T00:00:00.000Z');
+
+    INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+    VALUES ('conv_1', 'ci_1', 'chat_1', 'dm', '2026-03-22T00:00:00.000Z', '2026-03-22T00:00:00.000Z');
+
+    INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+    VALUES ('branch_1', 'conv_1', 'dm_main', 'main', '2026-03-22T00:00:00.000Z', '2026-03-22T00:00:00.000Z');
+  `);
+}
+
+function seedChatSession(handle: TestDatabaseHandle): {
+  sessionsRepo: SessionsRepo;
+  messagesRepo: MessagesRepo;
+} {
+  seedConversationFixture(handle);
+  const sessionsRepo = new SessionsRepo(handle.storage.db);
+  const messagesRepo = new MessagesRepo(handle.storage.db);
+  sessionsRepo.create({
+    id: "sess_1",
+    conversationId: "conv_1",
+    branchId: "branch_1",
+    purpose: "chat",
+    createdAt: new Date("2026-03-22T00:00:00.000Z"),
+  });
+  messagesRepo.append({
+    id: "msg_user",
+    sessionId: "sess_1",
+    seq: 1,
+    role: "user",
+    payloadJson: '{"content":"hello"}',
+    createdAt: new Date("2026-03-22T00:00:01.000Z"),
+  });
+  return { sessionsRepo, messagesRepo };
+}
+
+function createLoop(input: {
+  handle: TestDatabaseHandle;
+  sessionsRepo: SessionsRepo;
+  messagesRepo: MessagesRepo;
+  runner: AgentModelRunner;
+  emittedEvents: AgentRuntimeEvent[];
+  maxEmptyOutputLlmAttempts?: number;
+}): AgentLoop {
+  return new AgentLoop({
+    sessions: new AgentSessionService(input.sessionsRepo, input.messagesRepo),
+    messages: input.messagesRepo,
+    models: new ProviderRegistry(createModelConfig()),
+    tools: new ToolRegistry(),
+    cancel: new SessionRunAbortRegistry(),
+    modelRunner: input.runner,
+    storage: input.handle.storage.db,
+    securityConfig: DEFAULT_CONFIG.security,
+    compaction: DEFAULT_CONFIG.compaction,
+    ...(input.maxEmptyOutputLlmAttempts == null
+      ? {}
+      : {
+          runtime: {
+            ...DEFAULT_CONFIG.runtime,
+            maxEmptyOutputLlmAttempts: input.maxEmptyOutputLlmAttempts,
+          },
+        }),
+    emitEvent(event) {
+      input.emittedEvents.push(event);
+    },
+  });
+}
+
+describe("AgentLoop empty-output LLM retry", () => {
+  let handle: TestDatabaseHandle | null = null;
+
+  afterEach(async () => {
+    if (handle != null) {
+      await destroyTestDatabase(handle);
+      handle = null;
+    }
+  });
+
+  test("defaults to five total attempts and emits retry progress", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    const { sessionsRepo, messagesRepo } = seedChatSession(handle);
+
+    let runTurnCount = 0;
+    const emittedEvents: AgentRuntimeEvent[] = [];
+    const runner: AgentModelRunner = {
+      async runTurn() {
+        runTurnCount += 1;
+        if (runTurnCount < 5) {
+          throw new AgentLlmError({
+            kind: "timeout",
+            message: "LLM first response timed out after 45000ms",
+            retryable: true,
+            provider: "anthropic_main",
+            model: "anthropic_main/claude-sonnet-4-5",
+          });
+        }
+
+        return makeAssistantResult([{ type: "text", text: "recovered on fifth attempt" }]);
+      },
+    };
+
+    const loop = createLoop({
+      handle,
+      sessionsRepo,
+      messagesRepo,
+      runner,
+      emittedEvents,
+    });
+
+    const result = await loop.run({ sessionId: "sess_1", scenario: "chat" });
+
+    expect(runTurnCount).toBe(5);
+    expect(result.events.some((event) => event.type === "run_failed")).toBe(false);
+    expect(
+      emittedEvents
+        .filter((event) => event.type === "assistant_response_retrying")
+        .map((event) => ({
+          attempt: event.attempt,
+          maxAttempts: event.maxAttempts,
+          reason: event.reason,
+          errorKind: event.errorKind,
+        })),
+    ).toEqual([
+      {
+        attempt: 2,
+        maxAttempts: 5,
+        reason: "llm_failure_without_visible_output",
+        errorKind: "timeout",
+      },
+      {
+        attempt: 3,
+        maxAttempts: 5,
+        reason: "llm_failure_without_visible_output",
+        errorKind: "timeout",
+      },
+      {
+        attempt: 4,
+        maxAttempts: 5,
+        reason: "llm_failure_without_visible_output",
+        errorKind: "timeout",
+      },
+      {
+        attempt: 5,
+        maxAttempts: 5,
+        reason: "llm_failure_without_visible_output",
+        errorKind: "timeout",
+      },
+    ]);
+  });
+
+  test("respects configured max attempts", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    const { sessionsRepo, messagesRepo } = seedChatSession(handle);
+
+    let runTurnCount = 0;
+    const emittedEvents: AgentRuntimeEvent[] = [];
+    const runner: AgentModelRunner = {
+      async runTurn() {
+        runTurnCount += 1;
+        throw new AgentLlmError({
+          kind: "timeout",
+          message: "LLM first response timed out after 45000ms",
+          retryable: true,
+          provider: "anthropic_main",
+          model: "anthropic_main/claude-sonnet-4-5",
+        });
+      },
+    };
+
+    const loop = createLoop({
+      handle,
+      sessionsRepo,
+      messagesRepo,
+      runner,
+      emittedEvents,
+      maxEmptyOutputLlmAttempts: 2,
+    });
+
+    await expect(loop.run({ sessionId: "sess_1", scenario: "chat" })).rejects.toThrow(
+      "LLM first response timed out",
+    );
+
+    expect(runTurnCount).toBe(2);
+    expect(
+      emittedEvents
+        .filter((event) => event.type === "assistant_response_retrying")
+        .map((event) => ({
+          attempt: event.attempt,
+          maxAttempts: event.maxAttempts,
+        })),
+    ).toEqual([{ attempt: 2, maxAttempts: 2 }]);
+  });
+
+  test("applies the same attempt budget to successful empty assistant outputs", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    const { sessionsRepo, messagesRepo } = seedChatSession(handle);
+
+    let runTurnCount = 0;
+    const emittedEvents: AgentRuntimeEvent[] = [];
+    const runner: AgentModelRunner = {
+      async runTurn() {
+        runTurnCount += 1;
+        if (runTurnCount < 3) {
+          return makeAssistantResult([]);
+        }
+        return makeAssistantResult([{ type: "text", text: "recovered after empty outputs" }]);
+      },
+    };
+
+    const loop = createLoop({
+      handle,
+      sessionsRepo,
+      messagesRepo,
+      runner,
+      emittedEvents,
+      maxEmptyOutputLlmAttempts: 3,
+    });
+
+    const result = await loop.run({ sessionId: "sess_1", scenario: "chat" });
+
+    expect(runTurnCount).toBe(3);
+    expect(result.events.some((event) => event.type === "run_failed")).toBe(false);
+    expect(
+      emittedEvents
+        .filter((event) => event.type === "assistant_response_retrying")
+        .map((event) => ({
+          attempt: event.attempt,
+          maxAttempts: event.maxAttempts,
+          reason: event.reason,
+        })),
+    ).toEqual([
+      {
+        attempt: 2,
+        maxAttempts: 3,
+        reason: "successful_empty_output",
+      },
+      {
+        attempt: 3,
+        maxAttempts: 3,
+        reason: "successful_empty_output",
+      },
+    ]);
+  });
+});

--- a/tests/agent/loop.test.ts
+++ b/tests/agent/loop.test.ts
@@ -4332,6 +4332,14 @@ describe("agent loop", () => {
     expect(
       result.events.filter((event) => event.type === "assistant_message_started"),
     ).toHaveLength(2);
+    expect(
+      result.events.find((event) => event.type === "assistant_response_retrying"),
+    ).toMatchObject({
+      type: "assistant_response_retrying",
+      attempt: 2,
+      maxAttempts: 5,
+      reason: "successful_empty_output",
+    });
     const rows = messagesRepo.listBySession("sess_1");
     expect(rows).toHaveLength(2);
     expect(JSON.parse(rows[1]?.payloadJson ?? "{}")).toEqual({

--- a/tests/channels/lark/retry-footer.test.ts
+++ b/tests/channels/lark/retry-footer.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "vitest";
+import { buildLarkRenderedRunCard } from "@/src/channels/lark/render.js";
+import { reduceLarkRunState } from "@/src/channels/lark/run-state.js";
+import type { OrchestratedRuntimeEventEnvelope } from "@/src/orchestration/outbound-events.js";
+
+function makeEnvelope(
+  event: OrchestratedRuntimeEventEnvelope["event"],
+): OrchestratedRuntimeEventEnvelope {
+  return {
+    kind: "runtime_event",
+    target: {
+      conversationId: "conv_1",
+      branchId: "branch_1",
+    },
+    session: {
+      sessionId: "sess_1",
+      purpose: "chat",
+    },
+    agent: {
+      ownerAgentId: "agent_1",
+      ownerRole: "main",
+      mainAgentId: "agent_1",
+    },
+    taskRun: {
+      taskRunId: null,
+      runType: null,
+      status: null,
+      executionSessionId: null,
+    },
+    run: {
+      runId: "run_1",
+    },
+    object: {
+      messageId: null,
+      toolCallId: null,
+      toolName: null,
+      approvalId: null,
+    },
+    event,
+  };
+}
+
+function getCardBodyElements(card: Record<string, unknown>): Record<string, unknown>[] {
+  const body = isRecord(card.body) ? card.body : null;
+  const elements = Array.isArray(body?.elements) ? body.elements : [];
+  return elements.filter(isRecord);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != null && !Array.isArray(value);
+}
+
+describe("lark retry footer", () => {
+  test("renders assistant response retry progress until visible model progress resumes", () => {
+    let state = reduceLarkRunState(
+      null,
+      makeEnvelope({
+        type: "assistant_message_started",
+        eventId: "evt_started",
+        createdAt: "2026-03-28T00:00:01.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        messageId: "msg_1",
+      }),
+    );
+    state = reduceLarkRunState(
+      state,
+      makeEnvelope({
+        type: "assistant_response_retrying",
+        eventId: "evt_retry",
+        createdAt: "2026-03-28T00:00:46.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        messageId: "msg_1",
+        attempt: 2,
+        maxAttempts: 5,
+        reason: "llm_failure_without_visible_output",
+        errorKind: "timeout",
+        errorMessage: "LLM first response timed out",
+        rawErrorMessage: null,
+      }),
+    );
+
+    let rendered = buildLarkRenderedRunCard(state);
+    expect(rendered.card).toMatchObject({
+      config: {
+        summary: {
+          content: "🔁 模型响应超时，正在重试 2/5",
+        },
+      },
+    });
+    expect(getCardBodyElements(rendered.card)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          tag: "markdown",
+          content: "🔁 模型响应超时，正在重试 2/5",
+          text_size: "notation",
+        }),
+      ]),
+    );
+
+    state = reduceLarkRunState(
+      state,
+      makeEnvelope({
+        type: "assistant_message_started",
+        eventId: "evt_retry_started",
+        createdAt: "2026-03-28T00:00:47.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        messageId: "msg_1",
+      }),
+    );
+    rendered = buildLarkRenderedRunCard(state);
+    expect(getCardBodyElements(rendered.card)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          content: "🔁 模型响应超时，正在重试 2/5",
+        }),
+      ]),
+    );
+
+    state = reduceLarkRunState(
+      state,
+      makeEnvelope({
+        type: "assistant_reasoning_delta",
+        eventId: "evt_reasoning",
+        createdAt: "2026-03-28T00:00:48.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        messageId: "msg_1",
+        delta: "Now thinking.",
+      }),
+    );
+    rendered = buildLarkRenderedRunCard(state);
+    const bodyJson = JSON.stringify((rendered.card as { body?: unknown }).body ?? {});
+    expect(bodyJson).not.toContain("正在重试");
+    expect(bodyJson).toContain("🧠 正在思考");
+  });
+});

--- a/tests/channels/lark/retry-footer.test.ts
+++ b/tests/channels/lark/retry-footer.test.ts
@@ -91,7 +91,7 @@ describe("lark retry footer", () => {
     expect(rendered.card).toMatchObject({
       config: {
         summary: {
-          content: "🔁 模型响应超时，正在重试 2/5",
+          content: "🔁 模型调用出错，正在重试 2/5",
         },
       },
     });
@@ -99,7 +99,7 @@ describe("lark retry footer", () => {
       expect.arrayContaining([
         expect.objectContaining({
           tag: "markdown",
-          content: "🔁 模型响应超时，正在重试 2/5",
+          content: "🔁 模型调用出错，正在重试 2/5",
           text_size: "notation",
         }),
       ]),
@@ -123,7 +123,7 @@ describe("lark retry footer", () => {
     expect(getCardBodyElements(rendered.card)).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          content: "🔁 模型响应超时，正在重试 2/5",
+          content: "🔁 模型调用出错，正在重试 2/5",
         }),
       ]),
     );

--- a/tests/config/load.test.ts
+++ b/tests/config/load.test.ts
@@ -188,6 +188,8 @@ describe("config loader", () => {
     });
     expect(config.runtime).toEqual({
       maxTurns: 100,
+      maxEmptyOutputLlmAttempts: 5,
+      llmFirstResponseTimeoutMs: 45_000,
       approvalTimeoutMs: 180_000,
       approvalGrantTtlMs: 604_800_000,
       autopilot: false,
@@ -708,6 +710,8 @@ describe("config loader", () => {
       [
         "[runtime]",
         "maxTurns = 24",
+        "maxEmptyOutputLlmAttempts = 3",
+        "llmFirstResponseTimeoutMs = 3000",
         "approvalTimeoutMs = 240000",
         "approvalGrantTtlMs = 172800000",
         "autopilot = true",
@@ -720,6 +724,8 @@ describe("config loader", () => {
 
     expect(config.runtime).toEqual({
       maxTurns: 24,
+      maxEmptyOutputLlmAttempts: 3,
+      llmFirstResponseTimeoutMs: 3_000,
       approvalTimeoutMs: 240_000,
       approvalGrantTtlMs: 172_800_000,
       autopilot: true,

--- a/tests/runtime/bootstrap.test.ts
+++ b/tests/runtime/bootstrap.test.ts
@@ -35,6 +35,8 @@ function createConfig(): AppConfig {
     },
     runtime: {
       maxTurns: 100,
+      maxEmptyOutputLlmAttempts: 5,
+      llmFirstResponseTimeoutMs: 45_000,
       approvalTimeoutMs: 180_000,
       approvalGrantTtlMs: 604_800_000,
       autopilot: false,

--- a/tests/runtime/status.test.ts
+++ b/tests/runtime/status.test.ts
@@ -78,6 +78,8 @@ function createConfig(): AppConfig {
     },
     runtime: {
       maxTurns: 100,
+      maxEmptyOutputLlmAttempts: 5,
+      llmFirstResponseTimeoutMs: 45_000,
       approvalTimeoutMs: 180_000,
       approvalGrantTtlMs: 604_800_000,
       autopilot: false,


### PR DESCRIPTION
## What

Implements configurable retry handling for LLM attempts that produce no effective user-visible output.

- Adds `runtime.maxEmptyOutputLlmAttempts` with a default of 5 total attempts.
- Adds `runtime.llmFirstResponseTimeoutMs` with a default of 45000ms and wires it into `PiBridge`.
- Emits a channel-neutral `assistant_response_retrying` runtime event before each semantic retry.
- Renders retry progress in the Lark run card footer as `🔁 模型响应超时，正在重试 2/5`.

## Why

The previous empty-output retry behavior was a hard-coded single retry, which was too brittle for slow or occasionally empty model responses. Increasing retries without UI feedback would make users think the run was stuck, so the retry state is surfaced in the existing run card status area instead of using message reactions.

## How

- Moves empty-output retry budget checks into `src/agent/llm/empty-output-retry.ts`.
- Keeps `AgentLoop` channel-agnostic by emitting a structured runtime event.
- Adds a small Lark footer helper in `src/channels/lark/retry-footer.ts`.
- Updates Lark run state/rendering to keep the retry footer visible until real model progress resumes.
- Documents the new runtime settings in `docs/configuration.md`.

## Tests

- `pnpm preflight`

Linear: POK-54
