### PR TITLE
Fix OpenAI Responses fallback item ids

### DIFF
--- a/src/agent/llm/pi-ai-openai-responses-shared.ts
+++ b/src/agent/llm/pi-ai-openai-responses-shared.ts
@@ -170,6 +170,26 @@ function parseTextSignature(signature?: string): TextSignature | undefined {
   return { id: signature };
 }
 
+function reserveResponseItemId(preferredId: string, usedIds: Set<string>): string {
+  if (!usedIds.has(preferredId)) {
+    usedIds.add(preferredId);
+    return preferredId;
+  }
+
+  for (let attempt = 2; ; attempt += 1) {
+    const suffix = `_${attempt.toString(36)}`;
+    const candidateBase =
+      preferredId.length + suffix.length > 64
+        ? preferredId.slice(0, 64 - suffix.length).replace(/_+$/, "")
+        : preferredId;
+    const candidate = `${candidateBase}${suffix}`;
+    if (!usedIds.has(candidate)) {
+      usedIds.add(candidate);
+      return candidate;
+    }
+  }
+}
+
 function transformMessages(
   messages: Message[],
   model: Model<Api>,
@@ -340,6 +360,7 @@ export function convertResponsesMessages<TApi extends Api>(
     normalizeToolCallId(id),
   );
   const includeSystemPrompt = options?.includeSystemPrompt ?? true;
+  const usedResponseItemIds = new Set<string>();
 
   if (includeSystemPrompt && context.systemPrompt) {
     messages.push({
@@ -387,11 +408,15 @@ export function convertResponsesMessages<TApi extends Api>(
         assistantMsg.provider === model.provider &&
         assistantMsg.api === model.api;
 
-      for (const block of msg.content) {
+      for (const [blockIndex, block] of msg.content.entries()) {
         if (block.type === "thinking") {
           if (block.thinkingSignature) {
             try {
-              output.push(JSON.parse(block.thinkingSignature) as Record<string, unknown>);
+              const item = JSON.parse(block.thinkingSignature) as Record<string, unknown>;
+              if (typeof item.id === "string") {
+                usedResponseItemIds.add(item.id);
+              }
+              output.push(item);
             } catch {
               // thinkingSignature may be a plain string marker (e.g. "reasoning_content"
               // used as a DeepSeek compat marker), not JSON.  Keep the raw value.
@@ -402,10 +427,11 @@ export function convertResponsesMessages<TApi extends Api>(
           const parsedSignature = parseTextSignature(block.textSignature);
           let msgId = parsedSignature?.id;
           if (!msgId) {
-            msgId = `msg_${msgIndex}`;
+            msgId = `msg_${msgIndex}_${blockIndex}`;
           } else if (msgId.length > 64) {
             msgId = `msg_${shortHash(msgId)}`;
           }
+          msgId = reserveResponseItemId(msgId, usedResponseItemIds);
 
           output.push({
             type: "message",
@@ -422,6 +448,9 @@ export function convertResponsesMessages<TApi extends Api>(
           let itemId = itemIdRaw;
           if (isDifferentModel && itemId?.startsWith("fc_")) {
             itemId = undefined;
+          }
+          if (itemId != null) {
+            itemId = reserveResponseItemId(itemId, usedResponseItemIds);
           }
           output.push({
             type: "function_call",

--- a/tests/agent/llm/pi-ai-openai-responses-shared.test.ts
+++ b/tests/agent/llm/pi-ai-openai-responses-shared.test.ts
@@ -36,6 +36,71 @@ function makeStoredMessage(overrides: Partial<Message>): Message {
 }
 
 describe("pi ai openai responses shared", () => {
+  test("generates unique fallback response item ids for multiple unsigned assistant text items", () => {
+    const messages: Message[] = [
+      makeStoredMessage({
+        id: "msg_user",
+        payloadJson: JSON.stringify({ content: "continue" }),
+      }),
+      makeStoredMessage({
+        id: "msg_deepseek_assistant",
+        seq: 2,
+        role: "assistant",
+        provider: "deepseek",
+        model: "deepseek-v4-pro",
+        modelApi: "openai-completions",
+        stopReason: "stop",
+        usageJson: JSON.stringify({
+          input: 10,
+          output: 5,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 15,
+        }),
+        payloadJson: JSON.stringify({
+          content: [
+            {
+              type: "thinking",
+              thinking: "Private reasoning from a non-Responses model.",
+            },
+            {
+              type: "text",
+              text: "Visible answer from the same assistant message.",
+            },
+          ],
+        }),
+      }),
+      makeStoredMessage({
+        id: "msg_user_2",
+        seq: 3,
+        payloadJson: JSON.stringify({ content: "next" }),
+      }),
+    ];
+
+    const responseInput = convertResponsesMessages(
+      {
+        id: "codex-gpt5.5",
+        provider: "openai_codex",
+        api: "openai-codex-responses",
+        input: ["text"],
+        reasoning: true,
+      } as never,
+      {
+        systemPrompt: null,
+        messages: buildPiMessages(messages),
+      } as never,
+      new Set<string>(),
+      { includeSystemPrompt: false },
+    ) as Array<{ type?: string; id?: string }>;
+
+    const assistantItemIds = responseInput
+      .filter((entry) => entry.type === "message")
+      .map((entry) => entry.id);
+
+    expect(assistantItemIds).toHaveLength(2);
+    expect(new Set(assistantItemIds).size).toBe(assistantItemIds.length);
+  });
+
   test("preserves explicit synthetic interruption tool results instead of auto-filling missing outputs", () => {
     const messages: Message[] = [
       makeStoredMessage({


### PR DESCRIPTION
## Summary
- generate unique fallback ids for unsigned OpenAI Responses message items
- reserve item ids across a converted Responses input to avoid collisions
- add regression coverage for cross-model DeepSeek thinking + text history

## Tests
- pnpm preflight