### PR TITLE
Improve Lark subagent provisioning errors

### DIFF
--- a/docs/feishu-lark-setup.md
+++ b/docs/feishu-lark-setup.md
@@ -106,7 +106,6 @@ In **Permissions**, use **Batch import** and paste this permission set:
       "im:chat.moderation:read",
       "im:chat.tabs:read",
       "im:chat.tabs:write_only",
-      "im:chat.top_notice:write_only",
       "im:chat.widgets:read",
       "im:chat.widgets:write_only",
       "im:chat:create",
@@ -150,6 +149,10 @@ In **Permissions**, use **Batch import** and paste this permission set:
   }
 }
 ```
+
+SubAgent group provisioning uses the bot/app tenant token. Keep chat creation and member-management
+permissions in `tenant` scopes; putting `im:chat.members:write_only` only in `user` scopes is not
+enough for Pokoclaw to add users to a SubAgent group.
 
 If the platform UI or permission names have changed, adapt carefully instead of pretending the old list is exact.
 

--- a/src/channels/lark/subagent-provisioner.ts
+++ b/src/channels/lark/subagent-provisioner.ts
@@ -377,7 +377,7 @@ async function runLarkApiStep<T>(context: string, operation: () => Promise<T>): 
   try {
     return await operation();
   } catch (error: unknown) {
-    throw new LarkApiStepError(context, extractLarkApiErrorDetails(error));
+    throw new LarkApiStepError(context, extractLarkApiErrorDetails(error), { cause: error });
   }
 }
 
@@ -385,8 +385,9 @@ class LarkApiStepError extends Error {
   constructor(
     readonly step: string,
     readonly details: LarkApiErrorDetails,
+    options?: ErrorOptions,
   ) {
-    super(`${step}: ${formatLarkApiErrorDetails(details)}`);
+    super(`${step}: ${formatLarkApiErrorDetails(details)}`, options);
     this.name = "LarkApiStepError";
   }
 }

--- a/src/channels/lark/subagent-provisioner.ts
+++ b/src/channels/lark/subagent-provisioner.ts
@@ -11,6 +11,15 @@ import { ChannelInstancesRepo } from "@/src/storage/repos/channel-instances.repo
 import { ConversationsRepo } from "@/src/storage/repos/conversations.repo.js";
 
 const logger = createSubsystemLogger("channels/lark-subagent-provisioner");
+const LARK_API_RESPONSE_LOG_MAX_CHARS = 4000;
+
+interface LarkApiErrorDetails {
+  message: string;
+  httpStatus?: number;
+  larkCode?: string | number;
+  larkMsg?: string;
+  responseBody?: string;
+}
 
 export interface CreateLarkSubagentConversationSurfaceProvisionerInput {
   storage: StorageDb;
@@ -65,13 +74,16 @@ export function createLarkSubagentConversationSurfaceProvisioner(
       const installationId = channelInstance.accountKey;
       const client = input.clients.getOrCreate(installationId);
       let externalChatId: string | null = null;
+      let memberCount: number | null = null;
 
       try {
-        const createResp = await client.sdk.im.chat.create({
-          data: {
-            name: buildSubagentChatName(params.title),
-          },
-        });
+        const createResp = await runLarkApiStep("create subagent chat", () =>
+          client.sdk.im.chat.create({
+            data: {
+              name: buildSubagentChatName(params.title),
+            },
+          }),
+        );
         assertLarkOk(createResp, "create subagent chat");
 
         externalChatId = createResp?.data?.chat_id ?? "";
@@ -82,21 +94,25 @@ export function createLarkSubagentConversationSurfaceProvisioner(
             retryable: true,
           };
         }
+        const createdExternalChatId = externalChatId;
 
         const memberIds = await listChatMemberIds(client, sourceConversation.externalChatId);
+        memberCount = memberIds.length;
         if (memberIds.length > 0) {
-          const addResp = await client.sdk.im.chatMembers.create({
-            path: { chat_id: externalChatId },
-            params: { member_id_type: "open_id" },
-            data: { id_list: memberIds },
-          });
+          const addResp = await runLarkApiStep("add subagent chat members", () =>
+            client.sdk.im.chatMembers.create({
+              path: { chat_id: createdExternalChatId },
+              params: { member_id_type: "open_id" },
+              data: { id_list: memberIds },
+            }),
+          );
           assertLarkOk(addResp, "add subagent chat members");
         }
 
-        const shareLink = await getChatShareLink(client, externalChatId);
+        const shareLink = await getChatShareLink(client, createdExternalChatId);
         await publishWelcomeNotice({
           client,
-          chatId: externalChatId,
+          chatId: createdExternalChatId,
           title: params.title,
           description: params.description,
           initialTask: params.initialTask,
@@ -108,7 +124,7 @@ export function createLarkSubagentConversationSurfaceProvisioner(
         logger.info("provisioned lark subagent chat surface", {
           title: params.title,
           sourceConversationId: params.sourceConversationId,
-          externalChatId,
+          externalChatId: createdExternalChatId,
           shareLink,
           channelInstallationId: installationId,
           memberCount: memberIds.length,
@@ -116,28 +132,31 @@ export function createLarkSubagentConversationSurfaceProvisioner(
 
         return {
           status: "provisioned",
-          externalChatId,
+          externalChatId: createdExternalChatId,
           shareLink,
           conversationKind: "group",
           channelSurface: {
             channelType: "lark",
             channelInstallationId: installationId,
-            surfaceKey: buildLarkChatSurfaceKey(externalChatId),
+            surfaceKey: buildLarkChatSurfaceKey(createdExternalChatId),
             surfaceObjectJson: JSON.stringify({
-              chat_id: externalChatId,
+              chat_id: createdExternalChatId,
             }),
           },
         };
       } catch (error: unknown) {
         const cleanupError =
           externalChatId == null ? null : await cleanupProvisioningFailure(client, externalChatId);
-        const reason = error instanceof Error ? error.message : String(error);
+        const reason = describeLarkApiError(error);
         logger.error("failed to provision lark subagent chat surface", {
           title: params.title,
           sourceConversationId: params.sourceConversationId,
+          sourceExternalChatId: sourceConversation.externalChatId,
           installationId,
           externalChatId,
+          memberCount,
           cleanupError,
+          ...buildLarkApiErrorLogContext(error),
           error: reason,
         });
         return {
@@ -159,14 +178,16 @@ async function listChatMemberIds(client: LarkSdkClient, chatId: string): Promise
   let hasMore = true;
 
   while (hasMore) {
-    const response = await client.sdk.im.chatMembers.get({
-      path: { chat_id: chatId },
-      params: {
-        member_id_type: "open_id",
-        page_size: 100,
-        ...(pageToken == null ? {} : { page_token: pageToken }),
-      },
-    });
+    const response = await runLarkApiStep(`list chat members for ${chatId}`, () =>
+      client.sdk.im.chatMembers.get({
+        path: { chat_id: chatId },
+        params: {
+          member_id_type: "open_id",
+          page_size: 100,
+          ...(pageToken == null ? {} : { page_token: pageToken }),
+        },
+      }),
+    );
     assertLarkOk(response, `list chat members for ${chatId}`);
 
     for (const item of response.data?.items ?? []) {
@@ -188,26 +209,31 @@ function buildSubagentChatName(title: string): string {
 
 async function getChatShareLink(client: LarkSdkClient, chatId: string): Promise<string | null> {
   try {
-    const response = await client.sdk.im.chat.link({
-      path: { chat_id: chatId },
-      data: { validity_period: "permanently" },
-    });
+    const response = await runLarkApiStep(`get subagent chat share link for ${chatId}`, () =>
+      client.sdk.im.chat.link({
+        path: { chat_id: chatId },
+        data: { validity_period: "permanently" },
+      }),
+    );
     assertLarkOk(response, `get subagent chat share link for ${chatId}`);
     const shareLink = response.data?.share_link ?? "";
     return shareLink.length > 0 ? shareLink : null;
   } catch (error: unknown) {
     logger.warn("failed to get lark subagent chat share link", {
       chatId,
-      error: error instanceof Error ? error.message : String(error),
+      ...buildLarkApiErrorLogContext(error),
+      error: describeLarkApiError(error),
     });
     return null;
   }
 }
 
 async function deleteChat(client: LarkSdkClient, chatId: string): Promise<void> {
-  const response = await client.sdk.im.chat.delete({
-    path: { chat_id: chatId },
-  });
+  const response = await runLarkApiStep(`delete subagent chat ${chatId}`, () =>
+    client.sdk.im.chat.delete({
+      path: { chat_id: chatId },
+    }),
+  );
   assertLarkOk(response, `delete subagent chat ${chatId}`);
 }
 
@@ -219,7 +245,7 @@ async function cleanupProvisioningFailure(
     await deleteChat(client, chatId);
     return null;
   } catch (error: unknown) {
-    return error instanceof Error ? error.message : String(error);
+    return describeLarkApiError(error);
   }
 }
 
@@ -234,35 +260,22 @@ async function publishWelcomeNotice(input: {
   shareLink: string | null;
 }): Promise<void> {
   try {
-    const response = await input.client.sdk.im.message.create({
-      params: { receive_id_type: "chat_id" },
-      data: {
-        receive_id: input.chatId,
-        msg_type: "interactive",
-        content: JSON.stringify(buildSubagentWelcomeCard(input)),
-      },
-    });
+    const response = await runLarkApiStep(`send subagent welcome card to ${input.chatId}`, () =>
+      input.client.sdk.im.message.create({
+        params: { receive_id_type: "chat_id" },
+        data: {
+          receive_id: input.chatId,
+          msg_type: "interactive",
+          content: JSON.stringify(buildSubagentWelcomeCard(input)),
+        },
+      }),
+    );
     assertLarkOk(response, `send subagent welcome card to ${input.chatId}`);
-
-    const messageId = response.data?.message_id ?? "";
-    if (messageId.length === 0) {
-      logger.warn("sent subagent welcome card without message_id", {
-        chatId: input.chatId,
-      });
-      return;
-    }
-
-    const topNoticeResp = await input.client.sdk.im.chatTopNotice.putTopNotice({
-      path: { chat_id: input.chatId },
-      data: {
-        chat_top_notice: [{ action_type: "1", message_id: messageId }],
-      },
-    });
-    assertLarkOk(topNoticeResp, `pin subagent welcome card in ${input.chatId}`);
   } catch (error: unknown) {
     logger.warn("failed to publish lark subagent welcome notice", {
       chatId: input.chatId,
-      error: error instanceof Error ? error.message : String(error),
+      ...buildLarkApiErrorLogContext(error),
+      error: describeLarkApiError(error),
     });
   }
 }
@@ -349,12 +362,150 @@ function buildSubagentWelcomeCard(input: {
 
 function assertLarkOk(
   response: {
-    code?: number | undefined;
+    code?: number | string | undefined;
     msg?: string | undefined;
+    data?: unknown;
   },
   context: string,
 ): void {
-  if (response.code !== undefined && response.code !== 0) {
-    throw new Error(`${context}: ${response.msg ?? `code=${response.code}`}`);
+  if (response.code !== undefined && !isLarkSuccessCode(response.code)) {
+    throw new LarkApiStepError(context, extractLarkApiResponseDetails(response));
   }
+}
+
+async function runLarkApiStep<T>(context: string, operation: () => Promise<T>): Promise<T> {
+  try {
+    return await operation();
+  } catch (error: unknown) {
+    throw new LarkApiStepError(context, extractLarkApiErrorDetails(error));
+  }
+}
+
+class LarkApiStepError extends Error {
+  constructor(
+    readonly step: string,
+    readonly details: LarkApiErrorDetails,
+  ) {
+    super(`${step}: ${formatLarkApiErrorDetails(details)}`);
+    this.name = "LarkApiStepError";
+  }
+}
+
+function describeLarkApiError(error: unknown): string {
+  if (error instanceof LarkApiStepError) {
+    return error.message;
+  }
+
+  return formatLarkApiErrorDetails(extractLarkApiErrorDetails(error));
+}
+
+function buildLarkApiErrorLogContext(error: unknown): Record<string, unknown> {
+  if (error instanceof LarkApiStepError) {
+    return {
+      apiStep: error.step,
+      apiError: error.details,
+    };
+  }
+
+  return {
+    apiError: extractLarkApiErrorDetails(error),
+  };
+}
+
+function extractLarkApiErrorDetails(error: unknown): LarkApiErrorDetails {
+  const message = error instanceof Error ? error.message : String(error);
+  const response = readRecordProperty(error, "response");
+  const responseBody = response == null ? undefined : response.data;
+  const httpStatus = response == null ? undefined : readNumber(response.status);
+  return {
+    message,
+    ...(response == null ? {} : extractLarkApiBodyDetails(responseBody)),
+    ...(httpStatus === undefined ? {} : { httpStatus }),
+    ...(responseBody === undefined ? {} : { responseBody: formatUnknownForLog(responseBody) }),
+  };
+}
+
+function extractLarkApiResponseDetails(response: {
+  code?: number | string | undefined;
+  msg?: string | undefined;
+  data?: unknown;
+}): LarkApiErrorDetails {
+  const responseBody = formatUnknownForLog(response);
+  return {
+    message: response.msg ?? `code=${response.code}`,
+    ...(response.code === undefined ? {} : { larkCode: response.code }),
+    ...(response.msg === undefined ? {} : { larkMsg: response.msg }),
+    responseBody,
+  };
+}
+
+function extractLarkApiBodyDetails(body: unknown): Partial<LarkApiErrorDetails> {
+  if (!isRecord(body)) {
+    return {};
+  }
+
+  const code = readStringOrNumber(body.code);
+  const msg = readString(body.msg) ?? readString(body.message);
+  return {
+    ...(code === undefined ? {} : { larkCode: code }),
+    ...(msg === undefined ? {} : { larkMsg: msg }),
+  };
+}
+
+function isLarkSuccessCode(code: number | string): boolean {
+  return code === 0 || code === "0";
+}
+
+function formatLarkApiErrorDetails(details: LarkApiErrorDetails): string {
+  return [
+    details.message,
+    ...(details.httpStatus === undefined ? [] : [`httpStatus=${details.httpStatus}`]),
+    ...(details.larkCode === undefined ? [] : [`larkCode=${details.larkCode}`]),
+    ...(details.larkMsg === undefined ? [] : [`larkMsg=${details.larkMsg}`]),
+    ...(details.responseBody === undefined ? [] : [`responseBody=${details.responseBody}`]),
+  ].join(" ");
+}
+
+function formatUnknownForLog(value: unknown): string {
+  const text = typeof value === "string" ? value : safeJsonStringify(value);
+  return text.length <= LARK_API_RESPONSE_LOG_MAX_CHARS
+    ? text
+    : `${text.slice(0, LARK_API_RESPONSE_LOG_MAX_CHARS)}...`;
+}
+
+function safeJsonStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function readRecordProperty(value: unknown, property: string): Record<string, unknown> | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const child = value[property];
+  return isRecord(child) ? child : null;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function readStringOrNumber(value: unknown): string | number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  return readString(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }

--- a/tests/channels/lark/subagent-provisioner.test.ts
+++ b/tests/channels/lark/subagent-provisioner.test.ts
@@ -232,6 +232,82 @@ describe("lark subagent provisioner", () => {
     });
   });
 
+  test("surfaces non-zero lark response codes returned over successful HTTP responses", async () => {
+    handle = await createTestDatabase(import.meta.url);
+    handle.storage.sqlite.exec(`
+      INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+      VALUES ('ci_1', 'lark', 'default', '2026-03-29T00:00:00.000Z', '2026-03-29T00:00:00.000Z');
+
+      INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, title, created_at, updated_at)
+      VALUES ('conv_main', 'ci_1', 'chat_main', 'dm', 'Main', '2026-03-29T00:00:00.000Z', '2026-03-29T00:00:00.000Z');
+    `);
+
+    const chatCreate = vi.fn(async () => ({ data: { chat_id: "chat_sub_3" } }));
+    const chatDelete = vi.fn(async () => ({ data: {} }));
+    const chatMembersGet = vi.fn(async () => ({
+      data: {
+        items: [{ member_id: "ou_user_1" }],
+        has_more: false,
+      },
+    }));
+    const chatMembersCreate = vi.fn(async () => ({
+      code: 99991664,
+      msg: "member id type is invalid",
+      data: {
+        member_id_type: "open_id",
+      },
+    }));
+
+    const provisioner = createLarkSubagentConversationSurfaceProvisioner({
+      storage: handle.storage.db,
+      clients: {
+        getOrCreate: () =>
+          ({
+            sdk: {
+              im: {
+                chat: {
+                  create: chatCreate,
+                  delete: chatDelete,
+                  link: vi.fn(async () => ({ data: {} })),
+                },
+                chatMembers: {
+                  get: chatMembersGet,
+                  create: chatMembersCreate,
+                },
+                message: {
+                  create: vi.fn(async () => ({ data: { message_id: "om_welcome_3" } })),
+                },
+              },
+            },
+          }) as never,
+      },
+    });
+
+    const result = await provisioner.provisionSubagentSurface({
+      conversationId: "conv_sub_3",
+      sourceConversationId: "conv_main",
+      channelInstanceId: "ci_1",
+      title: "PR Review",
+      description: "Review pull requests and summarize findings.",
+      initialTask: "Review the current PR and report concrete issues.",
+      workdir: "/Users/example/work/pokoclaw",
+      privateWorkspaceDir: "/Users/example/.pokoclaw/workspace/subagents/abcd1234",
+      preferredSurface: "independent_chat",
+    });
+
+    if (result.status !== "failed") {
+      throw new Error(`expected provisioning to fail, got ${result.status}`);
+    }
+    expect(result.retryable).toBe(true);
+    expect(result.reason).toContain("add subagent chat members: member id type is invalid");
+    expect(result.reason).toContain("larkCode=99991664");
+    expect(result.reason).toContain("larkMsg=member id type is invalid");
+    expect(result.reason).toContain('"member_id_type":"open_id"');
+    expect(chatDelete).toHaveBeenCalledExactlyOnceWith({
+      path: { chat_id: "chat_sub_3" },
+    });
+  });
+
   test("supports explicit cleanup of a provisioned subagent chat", async () => {
     handle = await createTestDatabase(import.meta.url);
     handle.storage.sqlite.exec(`

--- a/tests/channels/lark/subagent-provisioner.test.ts
+++ b/tests/channels/lark/subagent-provisioner.test.ts
@@ -40,7 +40,6 @@ describe("lark subagent provisioner", () => {
     }));
     const chatMembersCreate = vi.fn(async () => ({ data: { invalid_id_list: [] } }));
     const messageCreate = vi.fn(async () => ({ data: { message_id: "om_welcome_1" } }));
-    const putTopNotice = vi.fn(async () => ({ data: {} }));
 
     const provisioner = createLarkSubagentConversationSurfaceProvisioner({
       storage: handle.storage.db,
@@ -60,9 +59,6 @@ describe("lark subagent provisioner", () => {
                 },
                 message: {
                   create: messageCreate,
-                },
-                chatTopNotice: {
-                  putTopNotice,
                 },
               },
             },
@@ -153,12 +149,6 @@ describe("lark subagent provisioner", () => {
     expect(initialTaskPanel).toBeDefined();
     expect(initialTaskPanel?.expanded).toBe(false);
     expect(initialTaskPanel?.header?.title?.content).toContain("初始任务");
-    expect(putTopNotice).toHaveBeenCalledExactlyOnceWith({
-      path: { chat_id: "chat_sub_1" },
-      data: {
-        chat_top_notice: [{ action_type: "1", message_id: "om_welcome_1" }],
-      },
-    });
   });
 
   test("cleans up the created chat when provisioning fails after chat.create", async () => {
@@ -180,7 +170,13 @@ describe("lark subagent provisioner", () => {
       },
     }));
     const chatMembersCreate = vi.fn(async () => {
-      throw new Error("member add failed");
+      throw makeLarkHttpError(400, {
+        code: 99991663,
+        msg: "missing tenant permission",
+        details: {
+          missing_scope: "im:chat.members:write_only",
+        },
+      });
     });
 
     const provisioner = createLarkSubagentConversationSurfaceProvisioner({
@@ -202,9 +198,6 @@ describe("lark subagent provisioner", () => {
                 message: {
                   create: vi.fn(async () => ({ data: { message_id: "om_welcome_2" } })),
                 },
-                chatTopNotice: {
-                  putTopNotice: vi.fn(async () => ({ data: {} })),
-                },
               },
             },
           }) as never,
@@ -223,11 +216,17 @@ describe("lark subagent provisioner", () => {
       preferredSurface: "independent_chat",
     });
 
-    expect(result).toMatchObject({
-      status: "failed",
-      reason: "member add failed",
-      retryable: true,
-    });
+    if (result.status !== "failed") {
+      throw new Error(`expected provisioning to fail, got ${result.status}`);
+    }
+    expect(result.retryable).toBe(true);
+    expect(result.reason).toContain(
+      "add subagent chat members: Request failed with status code 400",
+    );
+    expect(result.reason).toContain("httpStatus=400");
+    expect(result.reason).toContain("larkCode=99991663");
+    expect(result.reason).toContain("larkMsg=missing tenant permission");
+    expect(result.reason).toContain('"missing_scope":"im:chat.members:write_only"');
     expect(chatDelete).toHaveBeenCalledExactlyOnceWith({
       path: { chat_id: "chat_sub_2" },
     });
@@ -267,3 +266,17 @@ describe("lark subagent provisioner", () => {
     });
   });
 });
+
+function makeLarkHttpError(
+  status: number,
+  data: Record<string, unknown>,
+): Error & { response: { status: number; data: Record<string, unknown> } } {
+  const error = new Error(`Request failed with status code ${status}`) as Error & {
+    response: { status: number; data: Record<string, unknown> };
+  };
+  error.response = {
+    status,
+    data,
+  };
+  return error;
+}


### PR DESCRIPTION
## Summary
- remove SubAgent welcome-card top notice publishing and drop the corresponding onboarding scope
- log Lark API step, HTTP status, Lark code/msg, and response body for SubAgent provisioning failures
- add regression coverage for Lark 400 responses during member add

## Tests
- pnpm preflight