### PR TITLE
fix(lark): split run card after consumed steer

### DIFF
--- a/src/channels/lark/outbound.ts
+++ b/src/channels/lark/outbound.ts
@@ -43,6 +43,7 @@ import {
   type LarkSubagentCreationRequestCardState,
 } from "@/src/channels/lark/render.js";
 import {
+  finalizeLarkRunSegmentForSteer,
   type LarkRunState,
   markLarkRunApprovalResolved,
   markLarkRunAwaitingApproval,
@@ -152,6 +153,7 @@ export function createLarkOutboundRuntime(
   const activeRunSegmentByRunId = new Map<string, string>();
   const latestRunSegmentByRunId = new Map<string, string>();
   const nextRunSegmentIndexByRunId = new Map<string, number>();
+  const pendingSteerBoundaryByRunId = new Set<string>();
   const latestApprovalByRunId = new Map<string, string>();
   const subagentRequestStates = new Map<
     string,
@@ -1806,6 +1808,43 @@ export function createLarkOutboundRuntime(
     }
   };
 
+  const handleSteerConsumedRunSegmentBoundary = (
+    envelope: OrchestratedRuntimeEventEnvelope,
+  ): void => {
+    if (envelope.event.type !== "steer_message_consumed") {
+      return;
+    }
+    const sourceMessageId = envelope.event.channelMessageId;
+    const runId = envelope.run.runId;
+    if (sourceMessageId == null || sourceMessageId.length === 0 || runId == null) {
+      return;
+    }
+
+    ensureRecoveredRunSegmentState(runId);
+    pendingSteerBoundaryByRunId.add(runId);
+
+    const runCardObjectId = activeRunSegmentByRunId.get(runId);
+    if (runCardObjectId == null) {
+      return;
+    }
+    const previous = runStates.get(runCardObjectId);
+    if (previous == null) {
+      activeRunSegmentByRunId.delete(runId);
+      return;
+    }
+
+    const next = finalizeLarkRunSegmentForSteer(previous);
+    runStates.set(runCardObjectId, next);
+    activeRunSegmentByRunId.delete(runId);
+    latestRunSegmentByRunId.set(runId, runCardObjectId);
+    logger.debug("closed lark run card segment after consumed steer message", {
+      runId,
+      runCardObjectId,
+      sourceMessageId,
+    });
+    bumpVersionAndSchedule(`run:${runCardObjectId}`, { immediate: true });
+  };
+
   const handleOutboundAttachmentEvent = async (
     envelope: OrchestratedOutboundAttachmentEventEnvelope,
   ): Promise<void> => {
@@ -2016,6 +2055,7 @@ export function createLarkOutboundRuntime(
         }
 
         if (envelope.event.type === "steer_message_consumed") {
+          handleSteerConsumedRunSegmentBoundary(envelope);
           void handleSteerConsumedReactionUpdate(envelope);
           return;
         }
@@ -2078,8 +2118,11 @@ export function createLarkOutboundRuntime(
           }
         }
 
-        let runCardObjectId = activeRunSegmentByRunId.get(runId) ?? null;
-        if (runCardObjectId == null) {
+        const hasPendingSteerBoundary = pendingSteerBoundaryByRunId.has(runId);
+        let runCardObjectId = hasPendingSteerBoundary
+          ? null
+          : (activeRunSegmentByRunId.get(runId) ?? null);
+        if (runCardObjectId == null && !hasPendingSteerBoundary) {
           runCardObjectId = findResolvedApprovalToolRunCardObjectId(envelope, runId, {
             latestRunSegmentByRunId,
             runStates,
@@ -2091,12 +2134,18 @@ export function createLarkOutboundRuntime(
             envelope.event.type === "run_cancelled" ||
             envelope.event.type === "run_failed";
           if (terminalEvent) {
-            runCardObjectId = latestRunSegmentByRunId.get(runId) ?? null;
+            const shouldCreateSteerTerminalSegment =
+              hasPendingSteerBoundary && envelope.event.type !== "run_completed";
+            runCardObjectId = shouldCreateSteerTerminalSegment
+              ? allocateRunSegmentObjectId(runId)
+              : (latestRunSegmentByRunId.get(runId) ?? null);
+            pendingSteerBoundaryByRunId.delete(runId);
             if (runCardObjectId == null) {
               return;
             }
           } else if (shouldCreateRunSegmentForEvent(envelope)) {
             runCardObjectId = allocateRunSegmentObjectId(runId);
+            pendingSteerBoundaryByRunId.delete(runId);
           } else {
             logger.debug("deferring lark run card creation until visible content arrives", {
               runId,
@@ -2153,6 +2202,7 @@ export function createLarkOutboundRuntime(
       activeRunSegmentByRunId.clear();
       latestRunSegmentByRunId.clear();
       nextRunSegmentIndexByRunId.clear();
+      pendingSteerBoundaryByRunId.clear();
       latestApprovalByRunId.clear();
       sentDocPreviewKeys.clear();
       logger.info("lark outbound runtime shutdown complete");

--- a/src/channels/lark/run-state.ts
+++ b/src/channels/lark/run-state.ts
@@ -620,6 +620,29 @@ export function markLarkRunApprovalResolved(
   };
 }
 
+export function finalizeLarkRunSegmentForSteer(state: LarkRunState): LarkRunState {
+  return {
+    ...state,
+    blocks: finalizeActiveToolSequenceIfNeeded(state.blocks, state.activeToolSequenceBlockId),
+    activeAssistantMessageId: null,
+    activeToolSequenceBlockId: null,
+    footerStatus: null,
+    footerNotice: null,
+    awaitingApprovalTarget: null,
+    reasoning: {
+      ...state.reasoning,
+      active: false,
+      expanded: false,
+    },
+    // LarkRunState represents one rendered segment. The Agent run itself
+    // continues in a new segment after the consumed steer message.
+    terminal: "completed",
+    terminalErrorKind: null,
+    terminalMessage: null,
+    terminalImageAttachments: [],
+  };
+}
+
 export function hasVisibleLarkRunBlocks(state: LarkRunState): boolean {
   return state.blocks.some((block) => {
     if (block.kind === "assistant_text") {

--- a/tests/channels/lark/outbound-pagination.test.ts
+++ b/tests/channels/lark/outbound-pagination.test.ts
@@ -142,6 +142,9 @@ describe("lark outbound pagination", () => {
                 message: {
                   create: createMessage,
                 },
+                messageReaction: {
+                  create: vi.fn(async () => ({ data: { reaction_id: "reaction_ok" } })),
+                },
               },
             },
           }) as never,
@@ -167,6 +170,27 @@ describe("lark outbound pagination", () => {
         usage: null,
       }),
     );
+
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(250);
+    expect(createCard).toHaveBeenCalledOnce();
+
+    bus.publish(
+      makeEnvelope({
+        type: "steer_message_consumed",
+        eventId: "evt_steer",
+        createdAt: "2026-03-28T00:00:00.500Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 2,
+        messageId: "msg_steer",
+        channelMessageId: "om_steer",
+      }),
+    );
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(0);
 
     for (let index = 0; index < 16; index += 1) {
       const longText = buildLongText(`tool-${index}`, 16);
@@ -263,16 +287,17 @@ describe("lark outbound pagination", () => {
     const createdCards = (createCard.mock.calls as unknown[][]).map((call) =>
       parseCardPayload(call[0]),
     );
-    createdCards.slice(0, -1).forEach((card) => {
+    createdCards.slice(1, -1).forEach((card) => {
       expect(JSON.stringify(card)).not.toContain("stop_run");
     });
+    expect(JSON.stringify(createdCards.at(0) ?? {})).toContain("stop_run");
     expect(JSON.stringify(createdCards.at(-1) ?? {})).toContain("stop_run");
 
     expect(
       new LarkObjectBindingsRepo(handle.storage.db).getByInternalObject({
         channelInstallationId: "default",
         internalObjectKind: "run_card",
-        internalObjectId: "run_1:seg:1:page:2",
+        internalObjectId: "run_1:seg:2:page:2",
       }),
     ).not.toBeNull();
 

--- a/tests/channels/lark/outbound.test.ts
+++ b/tests/channels/lark/outbound.test.ts
@@ -2308,6 +2308,244 @@ describe("lark outbound runtime", () => {
     await runtime.shutdown();
   });
 
+  test("starts a new run card segment after a consumed user steer", async () => {
+    vi.useFakeTimers();
+    handle = await createTestDatabase(import.meta.url);
+    handle.storage.sqlite.exec(`
+      INSERT INTO channel_instances (id, provider, account_key, created_at, updated_at)
+      VALUES ('ci_lark_default', 'lark', 'default', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversations (id, channel_instance_id, external_chat_id, kind, created_at, updated_at)
+      VALUES ('conv_1', 'ci_lark_default', 'oc_chat_1', 'dm', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+
+      INSERT INTO conversation_branches (id, conversation_id, kind, branch_key, created_at, updated_at)
+      VALUES ('branch_1', 'conv_1', 'dm_main', 'main', '2026-03-28T00:00:00.000Z', '2026-03-28T00:00:00.000Z');
+    `);
+    new ChannelSurfacesRepo(handle.storage.db).upsert({
+      id: "surface_1",
+      channelType: "lark",
+      channelInstallationId: "default",
+      conversationId: "conv_1",
+      branchId: "branch_1",
+      surfaceKey: "chat:oc_chat_1",
+      surfaceObjectJson: JSON.stringify({ chat_id: "oc_chat_1" }),
+    });
+
+    let nextCardId = 0;
+    let nextMessageId = 0;
+    const createCard = vi.fn(async (_input: unknown) => {
+      nextCardId += 1;
+      return { data: { card_id: `card_${nextCardId}` } };
+    });
+    const createMessage = vi.fn(async () => {
+      nextMessageId += 1;
+      return {
+        data: {
+          message_id: `om_card_${nextMessageId}`,
+          open_message_id: `oom_card_${nextMessageId}`,
+        },
+      };
+    });
+    const updateCard = vi.fn(async () => ({}));
+    const streamContent = vi.fn(async () => ({}));
+    const reactionCreate = vi.fn(async () => ({ data: { reaction_id: "reaction_ok" } }));
+    const bus = new RuntimeEventBus<OrchestratedOutboundEventEnvelope>();
+    const runtime = createLarkOutboundRuntime({
+      storage: handle.storage.db,
+      outboundEventBus: bus,
+      clients: {
+        getOrCreate: () =>
+          ({
+            sdk: {
+              cardkit: {
+                v1: {
+                  card: { create: createCard, update: updateCard },
+                  cardElement: { content: streamContent },
+                },
+              },
+              im: {
+                message: { create: createMessage },
+                messageReaction: { create: reactionCreate },
+              },
+            },
+          }) as never,
+      },
+    });
+    runtime.start();
+
+    bus.publish(
+      makeEnvelope({
+        type: "assistant_message_completed",
+        eventId: "evt_before_steer",
+        createdAt: "2026-03-28T00:00:00.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        messageId: "msg_before_steer",
+        text: "before steer",
+        reasoningText: null,
+        toolCalls: [],
+        usage: null,
+      }),
+    );
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(250);
+    expect(createCard).toHaveBeenCalledOnce();
+
+    for (const [index, messageId] of ["om_steer_1", "om_steer_2"].entries()) {
+      bus.publish(
+        makeEnvelope({
+          type: "steer_message_consumed",
+          eventId: `evt_steer_${index + 1}`,
+          createdAt: `2026-03-28T00:00:0${index + 1}.000Z`,
+          sessionId: "sess_1",
+          conversationId: "conv_1",
+          branchId: "branch_1",
+          runId: "run_1",
+          turn: 2,
+          messageId: `msg_steer_${index + 1}`,
+          channelMessageId: messageId,
+        }),
+      );
+    }
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(createCard).toHaveBeenCalledOnce();
+    expect(
+      new LarkObjectBindingsRepo(handle.storage.db).getByInternalObject({
+        channelInstallationId: "default",
+        internalObjectKind: "run_card",
+        internalObjectId: "run_1:seg:2",
+      }),
+    ).toBeNull();
+    expect(
+      new LarkObjectBindingsRepo(handle.storage.db).getByInternalObject({
+        channelInstallationId: "default",
+        internalObjectKind: "run_card",
+        internalObjectId: "run_1:seg:1",
+      })?.status,
+    ).toBe("finalized");
+
+    bus.publish(
+      makeEnvelope({
+        type: "assistant_message_started",
+        eventId: "evt_after_steer_start",
+        createdAt: "2026-03-28T00:00:03.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 2,
+        messageId: "msg_after_steer",
+      }),
+    );
+    bus.publish(
+      makeEnvelope({
+        type: "assistant_message_delta",
+        eventId: "evt_after_steer_delta",
+        createdAt: "2026-03-28T00:00:04.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 2,
+        messageId: "msg_after_steer",
+        delta: "after user steer",
+        accumulatedText: "after user steer",
+      }),
+    );
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(createCard).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(createCard.mock.calls.at(0)?.[0])).toContain("before steer");
+    expect(JSON.stringify(createCard.mock.calls.at(0)?.[0])).not.toContain("after user steer");
+    expect(JSON.stringify(createCard.mock.calls.at(1)?.[0])).toContain("after user steer");
+
+    bus.publish(
+      makeEnvelope({
+        type: "steer_message_consumed",
+        eventId: "evt_hidden_steer",
+        createdAt: "2026-03-28T00:00:05.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 3,
+        messageId: "msg_hidden_steer",
+        channelMessageId: null,
+      }),
+    );
+    bus.publish(
+      makeEnvelope({
+        type: "assistant_message_completed",
+        eventId: "evt_after_hidden_steer",
+        createdAt: "2026-03-28T00:00:06.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 2,
+        messageId: "msg_after_steer",
+        text: "after hidden steer",
+        reasoningText: null,
+        toolCalls: [],
+        usage: null,
+      }),
+    );
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(250);
+    expect(createCard).toHaveBeenCalledTimes(2);
+
+    bus.publish(
+      makeEnvelope({
+        type: "steer_message_consumed",
+        eventId: "evt_steer_before_failure",
+        createdAt: "2026-03-28T00:00:07.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 3,
+        messageId: "msg_steer_before_failure",
+        channelMessageId: "om_steer_3",
+      }),
+    );
+    bus.publish(
+      makeEnvelope({
+        type: "run_failed",
+        eventId: "evt_failed_after_steer",
+        createdAt: "2026-03-28T00:00:08.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        scenario: "chat",
+        modelId: "model_1",
+        errorKind: "upstream",
+        errorMessage: "failed after steer",
+        retryable: false,
+      }),
+    );
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(createCard).toHaveBeenCalledTimes(3);
+    expect(JSON.stringify(createCard.mock.calls.at(2)?.[0])).toContain("failed after steer");
+    expect(
+      new LarkObjectBindingsRepo(handle.storage.db).getByInternalObject({
+        channelInstallationId: "default",
+        internalObjectKind: "run_card",
+        internalObjectId: "run_1:seg:3",
+      }),
+    ).not.toBeNull();
+
+    await runtime.shutdown();
+  });
+
   test("retries run-card visible message send with the same uuid after local finalize failure", async () => {
     vi.useFakeTimers();
     handle = await createTestDatabase(import.meta.url);

--- a/tests/channels/lark/run-state.test.ts
+++ b/tests/channels/lark/run-state.test.ts
@@ -9,6 +9,7 @@ import {
   renderLarkRunCard,
 } from "@/src/channels/lark/render.js";
 import {
+  finalizeLarkRunSegmentForSteer,
   LARK_ASSISTANT_PLACEHOLDER_TEXT,
   LARK_REASONING_STATE_MAX_CHARS,
   markLarkRunApprovalResolved,
@@ -1151,6 +1152,62 @@ describe("lark run state", () => {
     expect(deniedText).toContain("已拒绝");
     expect(deniedText).toContain("本次执行已停止");
     expect(deniedText).not.toContain("⏹ 停止");
+  });
+
+  test("silently finalizes the current run card when a steer is consumed", () => {
+    const running = reduceLarkRunState(
+      null,
+      makeEnvelope({
+        type: "tool_call_started",
+        eventId: "evt_steer_tool_1",
+        createdAt: "2026-03-28T00:00:00.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        toolCallId: "tool_steer_1",
+        toolName: "bash",
+        args: { command: "pnpm test" },
+      }),
+    );
+
+    const finalized = finalizeLarkRunSegmentForSteer(running);
+    expect(finalized).toMatchObject({
+      terminal: "completed",
+      activeAssistantMessageId: null,
+      activeToolSequenceBlockId: null,
+      footerStatus: null,
+      footerNotice: null,
+    });
+    expect(finalized.blocks).toMatchObject([{ kind: "tool_sequence", finalized: true }]);
+
+    const cardText = JSON.stringify(renderLarkRunCard(finalized));
+    expect(cardText).toContain("pnpm test");
+    expect(cardText).not.toContain("⏹ 停止");
+    expect(cardText).not.toContain("后续回复");
+  });
+
+  test("removes an empty streaming placeholder without adding steer copy", () => {
+    const running = reduceLarkRunState(
+      null,
+      makeEnvelope({
+        type: "assistant_message_started",
+        eventId: "evt_steer_empty_1",
+        createdAt: "2026-03-28T00:00:00.000Z",
+        sessionId: "sess_1",
+        conversationId: "conv_1",
+        branchId: "branch_1",
+        runId: "run_1",
+        turn: 1,
+        messageId: "msg_steer_empty_1",
+      }),
+    );
+
+    const cardText = JSON.stringify(renderLarkRunCard(finalizeLarkRunSegmentForSteer(running)));
+    expect(cardText).not.toContain(LARK_ASSISTANT_PLACEHOLDER_TEXT);
+    expect(cardText).not.toContain("⏹ 停止");
+    expect(cardText).not.toContain("补充指令");
   });
 
   test("renders request_permissions inside the run transcript while awaiting approval", () => {


### PR DESCRIPTION
## Summary
- finalize the current Lark run-card segment when a user steer message is consumed
- lazily open the next segment for subsequent visible output without creating empty cards
- keep hidden steers on the current segment and preserve existing pagination for new segments
- render post-steer failures and cancellations below the steer message

No extra transition copy is added to the old card.

## Testing
- pnpm preflight
- 163 test files passed
- 1111 tests passed